### PR TITLE
fix: Get Started button out of bounds in mobiles

### DIFF
--- a/src/components/Header2.tsx
+++ b/src/components/Header2.tsx
@@ -116,7 +116,7 @@ export const Header2 = () => {
               Contact
             </a>
           </nav>
-          <div className="flex items-center gap-4">
+          <div className="flex items-center md:gap-4">
             <SearchButtonComponent />
             {isLoggedIn && (
               <div className="hidden sm:block">

--- a/src/components/HeaderLogin.tsx
+++ b/src/components/HeaderLogin.tsx
@@ -41,7 +41,7 @@ export const HeaderLogin: React.FC<HeaderLoginProps> = () => {
       }
     }
     return (
-      <div className="flex items-center space-x-2 justify-end">
+      <div className="flex items-center md:space-x-2 justify-end">
         <Button onClick={() => signIn()} variant="ghost">
           Log in
         </Button>


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/54c9d8e1-9d0e-441e-a4d0-cb006b6da1b8)

/claim #549
Closes #549