### PR TITLE
Ensure latest PCB Viewer in RunFrame

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -46,7 +46,6 @@
         "@tscircuit/layout": "^0.0.29",
         "@tscircuit/math-utils": "^0.0.10",
         "@tscircuit/mm": "^0.0.8",
-        "@tscircuit/pcb-viewer": "^1.11.12",
         "@tscircuit/props": "^0.0.143",
         "@tscircuit/schematic-viewer": "^1.4.3",
         "@types/file-saver": "^2.0.7",
@@ -720,7 +719,7 @@
 
     "@tscircuit/mm": ["@tscircuit/mm@0.0.8", "", { "peerDependencies": { "typescript": "^5.0.0" } }, "sha512-nl7nxE7AhARbKuobflI0LUzoir7+wJyvwfPw6bzA/O0Q3YTcH3vBkU/Of+V/fp6ht+AofiCXj7YAH9E446138Q=="],
 
-    "@tscircuit/pcb-viewer": ["@tscircuit/pcb-viewer@1.11.12", "", { "dependencies": { "@emotion/css": "^11.11.2", "@tscircuit/math-utils": "^0.0.7", "circuit-json-to-connectivity-map": "^0.0.18", "circuit-to-svg": "^0.0.36", "color": "^4.2.3", "react-supergrid": "^1.0.10", "react-toastify": "^10.0.5", "transformation-matrix": "^2.13.0", "zustand": "^4.5.2" }, "peerDependencies": { "@tscircuit/core": "*", "react": "*" } }, "sha512-rJb/Xw79tTOjYg/SUq+uuuEifYZJFcnWF+wGA+s4OeBE1qs0IpIhyQXnXpXI6QZr5r/sBI17c8I1HqL2yqwJRw=="],
+    "@tscircuit/pcb-viewer": ["@tscircuit/pcb-viewer@1.11.58", "", { "dependencies": { "@emotion/css": "^11.11.2", "@tscircuit/math-utils": "^0.0.10", "circuit-json-to-connectivity-map": "^0.0.19", "circuit-to-svg": "^0.0.36", "color": "^4.2.3", "graphics-debug": "^0.0.24", "react-supergrid": "^1.0.10", "react-toastify": "^10.0.5", "transformation-matrix": "^2.13.0", "zustand": "^4.5.2" }, "peerDependencies": { "@tscircuit/core": "*", "react": "*" } }, "sha512-lkmKM5XmTRjoQBONHX+og+KdyXiat/QbvoS58WrKMR3qP1XwqDsh/LpXjdzwopLQWWVlmKJTaMJUi0+z2A6dkA=="],
 
     "@tscircuit/prompt-benchmarks": ["@tscircuit/prompt-benchmarks@0.0.28", "", { "dependencies": { "@babel/standalone": "^7.25.7", "@tscircuit/featured-snippets": "^0.0.1", "@tscircuit/footprinter": "^0.0.102", "debug": "^4.3.7", "dotenv": "^16.4.7", "evalite": "^0.8.2", "extract-codefence": "^0.0.4", "toml": "^3.0.0" }, "peerDependencies": { "typescript": "^5.0.0" } }, "sha512-SOhKWAWp3bSvUvbGbtl1ygyyDhF42IbezS965fyUz5cUMJVFyGOoRD0kJak78NVqmHHDMRRPf1R8c5UUaIdBnw=="],
 
@@ -2586,11 +2585,7 @@
 
     "@tscircuit/layout/@tscircuit/soup-util": ["@tscircuit/soup-util@0.0.38", "", { "dependencies": { "parsel-js": "^1.1.2" }, "peerDependencies": { "circuit-json": "*", "transformation-matrix": "*", "zod": "*" } }, "sha512-GdcuFxk+qnJZv+eI7ZoJ1MJEseFgRyaztMtQ/OXA2SUnxyPEH0UTy9vkhKTm+8GTePryEgdXcc65TgUyrr44ww=="],
 
-    "@tscircuit/pcb-viewer/@tscircuit/core": ["@tscircuit/core@file:.yalc/@tscircuit/core", { "dependencies": { "@lume/kiwi": "^0.4.3", "@tscircuit/footprinter": "^0.0.97", "@tscircuit/infgrid-ijump-astar": "^0.0.33", "@tscircuit/math-utils": "^0.0.9", "@tscircuit/props": "^0.0.142", "@tscircuit/schematic-autolayout": "^0.0.6", "@tscircuit/soup-util": "^0.0.41", "circuit-json": "^0.0.136", "circuit-json-to-connectivity-map": "^0.0.17", "format-si-unit": "^0.0.3", "nanoid": "^5.0.7", "performance-now": "^2.1.0", "react-reconciler": "^0.31.0", "react-reconciler-18": "npm:react-reconciler@0.29.2", "schematic-symbols": "^0.0.113", "transformation-matrix": "^2.16.1", "zod": "^3.23.8" }, "peerDependencies": { "typescript": "^5.0.0" } }],
-
-    "@tscircuit/pcb-viewer/@tscircuit/math-utils": ["@tscircuit/math-utils@0.0.7", "", { "peerDependencies": { "typescript": "^5.0.0" } }, "sha512-x8V008uGW3yfQFMsPn4f6TO0dBCangUafsMwLZnbWkKFBrKOIKxVjDZ42A6QuvpqECaf4yJOGDOZgkMC5UdJZw=="],
-
-    "@tscircuit/pcb-viewer/circuit-json-to-connectivity-map": ["circuit-json-to-connectivity-map@0.0.18", "", { "dependencies": { "@tscircuit/math-utils": "^0.0.9" }, "peerDependencies": { "typescript": "^5.0.0" } }, "sha512-0NH8nlYAxzGsVRtAho4FjI3JocXSDVp93t5rveJG21p0ckxCR7iIeEZOKcb0nndxhJ3fxctXWv7eJpyFIrAlPw=="],
+    "@tscircuit/pcb-viewer/circuit-json-to-connectivity-map": ["circuit-json-to-connectivity-map@0.0.19", "", { "dependencies": { "@tscircuit/math-utils": "^0.0.9" }, "peerDependencies": { "typescript": "^5.0.0" } }, "sha512-EJgeuBjCCvlKC+CjnR+yKppSi+/027x3uvXr0PR77iofR629BnVDgWv/0wKLJU7YlklcbpyUvOPyPCE1k2+WQQ=="],
 
     "@tscircuit/pcb-viewer/circuit-to-svg": ["circuit-to-svg@0.0.36", "", { "dependencies": { "@tscircuit/footprinter": "^0.0.57", "@tscircuit/routing": "^1.3.5", "@tscircuit/soup": "*", "@tscircuit/soup-util": "^0.0.28", "@types/node": "^22.5.5", "schematic-symbols": "^0.0.17", "svgson": "^5.3.1", "transformation-matrix": "^2.16.1" } }, "sha512-TGsi4htATqGIJULmUn1NZlN/6ORmZYxiXzBex4fSjzDjPmeMnbSPVefR1SZfxBCE/ucIwCdffRw8v9/ydIu6Wg=="],
 
@@ -2609,8 +2604,6 @@
     "@tscircuit/runframe/@tscircuit/3d-viewer": ["@tscircuit/3d-viewer@0.0.161", "", { "dependencies": { "@jscad/regl-renderer": "^2.6.12", "@jscad/stl-serializer": "^2.1.20", "@react-three/drei": "^9.121.4", "@react-three/fiber": "^8.17.14", "@tscircuit/core": "^0.0.340", "@tscircuit/props": "^0.0.159", "@tscircuit/soup-util": "^0.0.41", "jscad-electronics": "^0.0.27", "jscad-fiber": "^0.0.77", "jscad-planner": "^0.0.12", "react": "^18.3.1", "react-dom": "^18.3.1", "react-use-gesture": "^9.1.3" }, "peerDependencies": { "three": "*" } }, "sha512-zRvNJI68QhrHQddKkCfthl/HiFLq1Rk7wjxKWqj9ZXDhX6Imz8fONoSj2vG6VoJLRFGbwNSx9+xxpFQIMVNDsg=="],
 
     "@tscircuit/runframe/@tscircuit/core": ["@tscircuit/core@0.0.340", "", { "dependencies": { "@lume/kiwi": "^0.4.3", "@tscircuit/capacity-autorouter": "^0.0.13", "@tscircuit/infgrid-ijump-astar": "^0.0.33", "@tscircuit/math-utils": "^0.0.9", "@tscircuit/props": "^0.0.159", "@tscircuit/schematic-autolayout": "^0.0.6", "@tscircuit/soup-util": "^0.0.41", "circuit-json": "^0.0.151", "circuit-json-to-connectivity-map": "^0.0.17", "format-si-unit": "^0.0.3", "nanoid": "^5.0.7", "performance-now": "^2.1.0", "react-reconciler": "^0.31.0", "react-reconciler-18": "npm:react-reconciler@0.29.2", "schematic-symbols": "^0.0.121", "transformation-matrix": "^2.16.1", "zod": "^3.23.8" }, "peerDependencies": { "@tscircuit/footprinter": "*", "typescript": "^5.0.0" } }, "sha512-9FLK4Lj3VoOXCSaEuYOJpYHSsvD5/0hNEnW8to/2n9BiR/3Zxgrkv+2LJ1Ijg7JeaiMWq8gn4vKS7YdU8S78Wg=="],
-
-    "@tscircuit/runframe/@tscircuit/pcb-viewer": ["@tscircuit/pcb-viewer@1.11.58", "", { "dependencies": { "@emotion/css": "^11.11.2", "@tscircuit/math-utils": "^0.0.10", "circuit-json-to-connectivity-map": "^0.0.19", "circuit-to-svg": "^0.0.36", "color": "^4.2.3", "graphics-debug": "^0.0.24", "react-supergrid": "^1.0.10", "react-toastify": "^10.0.5", "transformation-matrix": "^2.13.0", "zustand": "^4.5.2" }, "peerDependencies": { "@tscircuit/core": "*", "react": "*" } }, "sha512-lkmKM5XmTRjoQBONHX+og+KdyXiat/QbvoS58WrKMR3qP1XwqDsh/LpXjdzwopLQWWVlmKJTaMJUi0+z2A6dkA=="],
 
     "@tscircuit/runframe/@tscircuit/props": ["@tscircuit/props@0.0.159", "", { "peerDependencies": { "@tscircuit/layout": "*", "circuit-json": "*", "react": "*", "zod": "*" } }, "sha512-AI3V0uHd4rCu5MgP3oerYjYxJtyAi8XHYzT7E+AEyR9F2KBtrOjy+PRipDO3QoSF0gOf+rjZgLnodNNK00QGKw=="],
 
@@ -3092,16 +3085,6 @@
 
     "@tscircuit/file-server/winterspec/kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
 
-    "@tscircuit/pcb-viewer/@tscircuit/core/@tscircuit/footprinter": ["@tscircuit/footprinter@0.0.97", "", { "dependencies": { "@tscircuit/mm": "^0.0.8", "zod": "^3.23.8" }, "peerDependencies": { "circuit-json": "*" } }, "sha512-LeqjpXqPwR++kcshlfe0E3IOsv0Y9BVRjIllDaHFA2OM+gJ91z/SS3CdweXB+qtF4t9G+8MLKf4nU5L1HDGjmg=="],
-
-    "@tscircuit/pcb-viewer/@tscircuit/core/@tscircuit/math-utils": ["@tscircuit/math-utils@0.0.9", "", { "peerDependencies": { "typescript": "^5.0.0" } }, "sha512-sPzfXndijet8z29X6f5vnSZddiso2tRg7m6rB+268bVj60mxnxUMD14rKuMlLn6n84fMOpD/X7pRTZUfi6M+Tg=="],
-
-    "@tscircuit/pcb-viewer/@tscircuit/core/@tscircuit/props": ["@tscircuit/props@0.0.142", "", { "peerDependencies": { "@tscircuit/layout": "*", "circuit-json": "*", "react": "*", "zod": "*" } }, "sha512-bjyBBePePOvzlFRDjsiDXSFUnYkwoFS+JntFRRqCnzhE1x/Gy0xAZt++70lKtrw6jQb0V3ftu4sVVi8BOqEBPA=="],
-
-    "@tscircuit/pcb-viewer/@tscircuit/core/circuit-json-to-connectivity-map": ["circuit-json-to-connectivity-map@0.0.17", "", { "dependencies": { "@tscircuit/math-utils": "^0.0.4" }, "peerDependencies": { "typescript": "^5.0.0" } }, "sha512-0IlFTwGWFXzlrYSvXQocXi6pYriF/JKnfihfvnVZ4p60kMC+1QvtJdivW9C4I0VNXEe922xak70v3YZNJrjI1g=="],
-
-    "@tscircuit/pcb-viewer/@tscircuit/core/schematic-symbols": ["schematic-symbols@0.0.113", "", { "peerDependencies": { "typescript": "^5.5.4" } }, "sha512-3fVsjAgn9ukmCfNn3q8iii4yFxvmeF0mpRuCplDYwwP4Yo6T6ElzsrkTj+QurljspDF7zTvxxlT+uZQQuVmvYg=="],
-
     "@tscircuit/pcb-viewer/circuit-json-to-connectivity-map/@tscircuit/math-utils": ["@tscircuit/math-utils@0.0.9", "", { "peerDependencies": { "typescript": "^5.0.0" } }, "sha512-sPzfXndijet8z29X6f5vnSZddiso2tRg7m6rB+268bVj60mxnxUMD14rKuMlLn6n84fMOpD/X7pRTZUfi6M+Tg=="],
 
     "@tscircuit/pcb-viewer/circuit-to-svg/@tscircuit/footprinter": ["@tscircuit/footprinter@0.0.57", "", { "dependencies": { "@tscircuit/mm": "^0.0.7", "zod": "^3.23.8" }, "peerDependencies": { "@tscircuit/soup": "*" } }, "sha512-aLUuh3LqeDusjTzp6nyOqss6Et4adTVeCGJpvvq3dosuyfdk5L79l64jdNFK0Bf5fps1SJAHISpPC4nDSJEVfw=="],
@@ -3153,10 +3136,6 @@
     "@tscircuit/runframe/@tscircuit/core/circuit-json": ["circuit-json@0.0.151", "", { "dependencies": { "nanoid": "^5.0.7", "zod": "^3.23.6" } }, "sha512-N6+saL1EwK8OfiPhrjS+oSjdyiZrM/avBZh8wyd4GK6tFNa07CtZduiFrX7oS3vQgKTl1uCk7bKbh/TR9+kHUA=="],
 
     "@tscircuit/runframe/@tscircuit/core/schematic-symbols": ["schematic-symbols@0.0.121", "", { "peerDependencies": { "typescript": "^5.5.4" } }, "sha512-xqWY43VC10wIVL+Kf8PlHj27Ojr7JdFeFHTRoSvmc6zvHirPQiXlnb3l70BerZQy6S/EOH+Q9yGRADYU0m8T1w=="],
-
-    "@tscircuit/runframe/@tscircuit/pcb-viewer/circuit-json-to-connectivity-map": ["circuit-json-to-connectivity-map@0.0.19", "", { "dependencies": { "@tscircuit/math-utils": "^0.0.9" }, "peerDependencies": { "typescript": "^5.0.0" } }, "sha512-EJgeuBjCCvlKC+CjnR+yKppSi+/027x3uvXr0PR77iofR629BnVDgWv/0wKLJU7YlklcbpyUvOPyPCE1k2+WQQ=="],
-
-    "@tscircuit/runframe/@tscircuit/pcb-viewer/circuit-to-svg": ["circuit-to-svg@0.0.36", "", { "dependencies": { "@tscircuit/footprinter": "^0.0.57", "@tscircuit/routing": "^1.3.5", "@tscircuit/soup": "*", "@tscircuit/soup-util": "^0.0.28", "@types/node": "^22.5.5", "schematic-symbols": "^0.0.17", "svgson": "^5.3.1", "transformation-matrix": "^2.16.1" } }, "sha512-TGsi4htATqGIJULmUn1NZlN/6ORmZYxiXzBex4fSjzDjPmeMnbSPVefR1SZfxBCE/ucIwCdffRw8v9/ydIu6Wg=="],
 
     "@tscircuit/runframe/circuit-to-svg/@tscircuit/footprinter": ["@tscircuit/footprinter@0.0.91", "", { "dependencies": { "@tscircuit/mm": "^0.0.8", "zod": "^3.23.8" }, "peerDependencies": { "@tscircuit/soup": "*", "circuit-json": "*" } }, "sha512-6H3CYXNPJlIcT9BLpeC8I18RdsmolkEWAt2ih4RgT3MwTEjNxmJOr6alppXvGUXdw0zu/QOwAOF/NxAUqlxBFQ=="],
 
@@ -3532,8 +3511,6 @@
 
     "@tscircuit/file-server/winterspec/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.19.12", "", { "os": "win32", "cpu": "x64" }, "sha512-T1QyPSDCyMXaO3pzBkF96E8xMkiRYbUEZADd29SyPGabqxMViNoii+NcK7eWJAEoU6RZyEm5lVSIjTmcdoB9HA=="],
 
-    "@tscircuit/pcb-viewer/@tscircuit/core/circuit-json-to-connectivity-map/@tscircuit/math-utils": ["@tscircuit/math-utils@0.0.4", "", { "peerDependencies": { "typescript": "^5.0.0" } }, "sha512-8Bu/C+go95Zk9AXb4Pe37OgObGhOd5F7UIzXV+u1PKuhpJpGjr+X/WHBzSI7xHrBSvwsf39/Luooe4b3djuzgQ=="],
-
     "@tscircuit/pcb-viewer/circuit-to-svg/@tscircuit/footprinter/@tscircuit/mm": ["@tscircuit/mm@0.0.7", "", { "dependencies": { "convert-units": "^2.3.4" }, "peerDependencies": { "typescript": "^5.0.0" } }, "sha512-5lZjeOsrkQDnMd4OEuXQYC8k+zuWCbX9Ruq69JhcvLu18FUen3pPjBxmFyF2DGZYxaTrKUpUdZvoTr49TISN2g=="],
 
     "@tscircuit/pcb-viewer/circuit-to-svg/@types/node/undici-types": ["undici-types@6.19.8", "", {}, "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="],
@@ -3583,18 +3560,6 @@
     "@tscircuit/runframe/@tscircuit/3d-viewer/jscad-electronics/@tscircuit/footprinter": ["@tscircuit/footprinter@0.0.132", "", { "dependencies": { "@tscircuit/mm": "^0.0.8", "zod": "^3.23.8" }, "peerDependencies": { "circuit-json": "*" } }, "sha512-pXSl6VXHbx5w0QNwUs2v3bO7xVaaCbuLZ9q4jZZru78JHmzc/PTvaNZQYsm7OGskh8BkfaOrkRJPI3H2L0x88A=="],
 
     "@tscircuit/runframe/@tscircuit/3d-viewer/jscad-electronics/circuit-json": ["circuit-json@0.0.92", "", { "dependencies": { "nanoid": "^5.0.7", "zod": "^3.23.6" } }, "sha512-cEqFxLadAxS+tm7y5/llS4FtqN3QbzjBNubely7vFo8w05sZnGRCcLzZwKL7rC7He1CqqyFynD4MdeL+F/PjBQ=="],
-
-    "@tscircuit/runframe/@tscircuit/pcb-viewer/circuit-json-to-connectivity-map/@tscircuit/math-utils": ["@tscircuit/math-utils@0.0.9", "", { "peerDependencies": { "typescript": "^5.0.0" } }, "sha512-sPzfXndijet8z29X6f5vnSZddiso2tRg7m6rB+268bVj60mxnxUMD14rKuMlLn6n84fMOpD/X7pRTZUfi6M+Tg=="],
-
-    "@tscircuit/runframe/@tscircuit/pcb-viewer/circuit-to-svg/@tscircuit/footprinter": ["@tscircuit/footprinter@0.0.57", "", { "dependencies": { "@tscircuit/mm": "^0.0.7", "zod": "^3.23.8" }, "peerDependencies": { "@tscircuit/soup": "*" } }, "sha512-aLUuh3LqeDusjTzp6nyOqss6Et4adTVeCGJpvvq3dosuyfdk5L79l64jdNFK0Bf5fps1SJAHISpPC4nDSJEVfw=="],
-
-    "@tscircuit/runframe/@tscircuit/pcb-viewer/circuit-to-svg/@tscircuit/soup": ["@tscircuit/soup@0.0.73", "", { "dependencies": { "convert-units": "^2.3.4", "nanoid": "^5.0.7", "zod": "^3.23.6" } }, "sha512-Q+0gSFunYKagabLUIqtAeuIy14+/z5YRlv0C/ESbAW7miN6gTSlHDV5TD8J3v40DsxiJQF6NRSHbmcBL+C31ng=="],
-
-    "@tscircuit/runframe/@tscircuit/pcb-viewer/circuit-to-svg/@tscircuit/soup-util": ["@tscircuit/soup-util@0.0.28", "", { "dependencies": { "parsel-js": "^1.1.2" }, "peerDependencies": { "@tscircuit/soup": "*", "transformation-matrix": "*", "zod": "*" } }, "sha512-AEImLyTmx/lPQCH6sFj6QOQk++Oyz3Dbtz0gIo1rdgpK6M4jJmoQjeUfMi93KsrSCrryAXt7D0oezTlC6u+c6w=="],
-
-    "@tscircuit/runframe/@tscircuit/pcb-viewer/circuit-to-svg/@types/node": ["@types/node@22.7.0", "", { "dependencies": { "undici-types": "~6.19.2" } }, "sha512-MOdOibwBs6KW1vfqz2uKMlxq5xAfAZ98SZjO8e3XnAbFnTJtAspqhWk7hrdSAs9/Y14ZWMiy7/MxMUzAOadYEw=="],
-
-    "@tscircuit/runframe/@tscircuit/pcb-viewer/circuit-to-svg/schematic-symbols": ["schematic-symbols@0.0.17", "", { "peerDependencies": { "typescript": "^5.5.4" } }, "sha512-xs/A1MNFZphcYRpTQVWm1OUA4bvWhw9LViKSTxEe0nQEbbfZgMS7hCt+DF6SYDgT8cec9hD4JAQMHh5Cz4om1Q=="],
 
     "@tscircuit/runframe/circuit-to-svg/bun-types/@types/node": ["@types/node@20.12.14", "", { "dependencies": { "undici-types": "~5.26.4" } }, "sha512-scnD59RpYD91xngrQQLGkE+6UrHUPzeKZWhhjBSa3HSkwjbQc38+q3RoIVEwxQGRw3M+j5hpNAM+lgV3cVormg=="],
 
@@ -3653,10 +3618,6 @@
     "@tscircuit/runframe/@radix-ui/react-tabs/@radix-ui/react-primitive/@radix-ui/react-slot/@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.1.1", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Y9VzoRDSJtgFMUCoiZBDVo084VQ5hfpXxVE+NgkdNsjiDBByiImMZKKhxMwCbdHvhlENG6a833CbFkOQvTricw=="],
 
     "@tscircuit/runframe/@radix-ui/react-tabs/@radix-ui/react-roving-focus/@radix-ui/react-collection/@radix-ui/react-slot": ["@radix-ui/react-slot@1.1.1", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-RApLLOcINYJA+dMVbOju7MYv1Mb2EBp2nH4HdDzXTSyaR5optlm6Otrz1euW3HbdOR8UmmFK06TD+A9frYWv+g=="],
-
-    "@tscircuit/runframe/@tscircuit/pcb-viewer/circuit-to-svg/@tscircuit/footprinter/@tscircuit/mm": ["@tscircuit/mm@0.0.7", "", { "dependencies": { "convert-units": "^2.3.4" }, "peerDependencies": { "typescript": "^5.0.0" } }, "sha512-5lZjeOsrkQDnMd4OEuXQYC8k+zuWCbX9Ruq69JhcvLu18FUen3pPjBxmFyF2DGZYxaTrKUpUdZvoTr49TISN2g=="],
-
-    "@tscircuit/runframe/@tscircuit/pcb-viewer/circuit-to-svg/@types/node/undici-types": ["undici-types@6.19.8", "", {}, "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="],
 
     "@tscircuit/runframe/circuit-to-svg/bun-types/@types/node/undici-types": ["undici-types@5.26.5", "", {}, "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="],
 

--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "@tscircuit/layout": "^0.0.29",
     "@tscircuit/math-utils": "^0.0.10",
     "@tscircuit/mm": "^0.0.8",
-    "@tscircuit/pcb-viewer": "^1.11.12",
     "@tscircuit/props": "^0.0.143",
     "@tscircuit/schematic-viewer": "^1.4.3",
     "@types/file-saver": "^2.0.7",


### PR DESCRIPTION
- **wip landing page**
- **initial footer**
- **add links to footer**
- **lots of bootstrapping for various pages**
- **add list_newest endpoint**
- **create newest page**
- **fix view snippet page**
- **wip dashboard**
- **wip dashboard**
- **implement /snippets/list**
- **implement dashboard edit recent**
- **save button**
- **implement hasUnsavedChanges**
- **move save button next to snippet**
- **wip**
- **better behaved header buttons**
- **starting view snippet page**
- **progress on view snippets page**
- **wip improve view snippet page**
- **wip start-editor page**
- **wip**
- **wip**
- **add templates and kicad import buttons**
- **load templates properly**
- **errors page**
- **add support for errors tab on codeandpreview**
- **add support for updated_at**
- **add no errors render state**
- **add type_description to snippets**
- **add type badges**
- **add snippet.type**
- **snippet type-related refactors**
- **improvements to running snippet code based on type**
- **wip improving running packages based on type**
- **3d model support**
- **checkpoint ai chat page**
- **checkpoint, ai communication working**
- **wip with streaming hack**
- **wip artifacts moving to preview window**
- **wip error message correction, version numbers**
- **refactor error tab content**
- **fix auto-trimming**
- **save snippet button, minor improvements**
- **chore: update favicon**
- **chore: remove package lock**
- **header login**
- **add README and contributing guidelines**
- **refactor ai chat interface**
- **artifact blocks implemented**
- **add links**
- **3d models rendering on boards**
- **feat: add new dropdown**
- **responsiveness improvements**
- **better small screen header menu with hamburger icon**
- **improve responsiveness in header**
- **lots of responsive improvements**
- **making cross button work**
- **add support for snippets api url to alter backend**
- **refactor to useAxios**
- **add github icon to header, introduce use global store**
- **update snippet definition to match registry**
- **wip refactor to registry-compat snippets api**
- **fix tests and add pseudo-auth temporarily**
- **typefix in test**
- **fixes for editor page with api**
- **login page and session definitions for fake**
- **wip**
- **remove sessions endpoints for now**
- **add create_without_auth for session creation**
- **api redirects**
- **login working, fix code editor not taking up full space**
- **support for creating ai queries from other pages**
- **add ToS and privacy policy**
- **typefixes**
- **add some workflows**
- **format repo**
- **lint command should not run lint checks**
- **rewrite everything to root**
- **fix base url issue for local dev**
- **show account balance, empty state for ai chat interface**
- **format ai hook**
- **wip**
- **many fixes and enhancements for ai chat**
- **format fixes**
- **stricting camelCase**
- **fixes**
- **Update biome.json**
- **Update biome.json**
- **Update biome.json**
- **add jlcpcb import dialog**
- **api endpoint**
- **easyeda import initial**
- **new button hover changes**
- **updated changes**
- **Revert "new button hover changes"**
- **fake api switch**
- **authorize typefix**
- **allow direct use of ai requests**
- **home page made responsive**
- **checkpoint codemirror-ts**
- **checkpoint loading imports**
- **import ata**
- **import react**
- **wip**
- **add user profile page**
- **implement get account balance**
- **import types from "@tscircuit/core"**
- **fix formatting**
- **add database seeding, fix view snippets page**
- **implement seeding for dts**
- **wip download endpoint for snippets**
- **fixed download tests**
- **download with file browsing paths from jsdeliver**
- **fix seed add dts to snippets**
- **minor typefix**
- **better logging**
- **support for sending compiled js**
- **format**
- **save dts**
- **fix seed data and dashboard page to load correct user**
- **fix issues with ai streaming, prepare import system**
- **Create CODEOWNERS**
- **minor typefix**
- **import runner part 1**
- **stricter check for fake api**
- **handle vercel builds**
- **fix a bunch of 401s**
- **header styling and vercel build fix**
- **refactor previewcontent**
- **refactor ai page to use preview content**
- **much clearer error and empty states, basic error tab switching**
- **intelligent run button updates, importing working**
- **improvements to seed data, code runner**
- **minor typefix**
- **persist onboarding tips visibility (#43)**
- **fix code editor scrolling (#51)**
- **Implemented a download function for the circuitJson download button. (#49)**
- **Anon User Editing, other code editor/ai page improvements for empty states, fix code editor not being scrollable (#52)**
- **Add core to runtime, add format button, 404 snippet page, minor fixes (#53)**
- **fix vite dev build error**
- **Import Snippet Dialog (#54)**
- **allow anon mutations for logged in users, generally don't create snippet unless save button is pressed, various fixes, refactor for reuse, playwright snapshot testing, loading/404 pages (#56)**
- **add rename functionality (#57)**
- **minor refactor improvement for rename**
- **Initial ordering API + UI (#46)**
- **fix ai page early hook return issue (#58)**
- **Delete Snippets (#61)**
- **Recursive Importing (#62)**
- **easyeda update (#63)**
- **footprinter fixes (#65)**
- **core update to fix bun dep issue (#66)**
- **Fix Importing Modules on First Run (#67)**
- **Introduce `/orders/{order_id}` page (#69)**
- **Download Fabrication Files (#73)**
- **download fixes for fabrication files (#74)**
- **Add Submit Order Button and Dialog (#78)**
- **Header search bar (#77)**
- **Test ordering API (#68)**
- **fix jlcpcb imports with arc issues, update for shared pin label support, fix errors in local dev to show jlcpcb import errors (#80)**
- **fix tab indent (#84)**
- **Allow editing shipping information in profile settings (#82)**
- **fixed:Search box doesn't render well in small views and dashboard responsiveness (#85)**
- **Update page title to snippet name. (#86)**
- **works for windows (#96)**
- **Added:Playwright test for md,lg and sm (#97)**
- **fixed:quickstart page responsiveness (#95)**
- **order My Snippets by last created time (#108)**
- **update circuit json to gerber**
- **add favicon (#110)**
- **Add files dialog to inspect build files (#114)**
- **update recent snippets view in dashboard to be more condensed**
- **fix dashboard formatting**
- **introduce cmd+click to open snippets (#115)**
- **Make country and state a dropdown in shipping info section (#88)**
- **Add order preview (#89)**
- **added cmd k palette (#117)**
- **minor fixes (#118)**
- **create add star endpoint (#122)**
- **Fix SearchableSelect options width (#124)**
- **Update Dependencies for Pill Holes (#126)**
- **Implemented Fork on ViewSnippetHeader (#125)**
- **Add Download Schematic SVG in download dropdown menu (#127)**
- **feat: Integrate schematic viewer (#131)**
- **feat: manual-edits.json file added to dropdown (#134)**
- **Snippets Page Load Fix, test for editor page load (#138)**
- **fix: current file change update code (#141)**
- **adds snippet type to the url for copy url (#137)**
- **feat: Position update on movement in manual-edits (#143)**
- **fix(ui): fix ui for profile page header and footer "My profile" link (#144)**
- **Update easyeda to fix esp32 import, smaller file header, Schematic Viewer Height Improvement, Sticky Preview (#147)**
- **fix toast position, sticky preview, improve code editor header filename select box color (#149)**
- **Move Toast to Bottom Right, Fix Sticky Preview, Improve Dropdown Color for CodeEditor files, Add FS Map from CDN to fix some type issues (#150)**
- **Fixes Command palette search (#121)**
- **Fix clicking "go to definition" removing dashes (#154)**
- **Disable Automatic Closing Bracket Insertion (#155)**
- **update core**
- **update core and pcb viewer**
- **fix: remove button in view page (#159)**
- **update core**
- **Manual Edits File Editting, Minor one-way dataflow refactor (#162)**
- **feature: warn user (#163)**
- **Fix/overflow view page (#164)**
- **fixed #166: cmd+click tooltip appears on all tsci imports (#167)**
- **update deps (core and circuit-to-svg), swap schematic viewer to circuit to svg with mouse controls (#169)**
- **Change snippet type (#170)**
- **update-deps (#173)**
- **update circuit-to-svg**
- **update core and circuit-to-svg to get latest schematic trace improvements (overlap handling)**
- **deps update**
- **fix #175: zoom effect for schematic view (#178)**
- **Cmdk UI improvements (#176)**
- **updated dependencies (#183)**
- **fix(#180): Added copy to clipboard functionality (#184)**
- **Make Snippets tscircuit.com (#185)**
- **Initial Parts Engine Integration (#186)**
- **Update core, add automatic package update system via renovate config (#188)**
- **BOM View, dropdown in preview content (#192)**
- **chore(deps): update dependency @tscircuit/core to ^0.0.171 (#189)**
- **Support async circuit rendering, open bom links in new tab (#196)**
- **chore(deps): update dependency @tscircuit/prompt-benchmarks to ^0.0.15 (#190)**
- **fix(deps): update dependency @tscircuit/3d-viewer to ^0.0.36 (#193)**
- **fix(deps): update dependency @tscircuit/footprinter to ^0.0.86 (#194)**
- **refactor: search text (#182)**
- **chore(deps): update dependency @tscircuit/core to ^0.0.172 (#199)**
- **chore(deps): update dependency circuit-to-svg to ^0.0.73 (#201)**
- **fix(deps): update dependency @tscircuit/props to ^0.0.96 (#203)**
- **Added circuit_json to snippet schema (#206)**
- **chore(deps): update dependency circuit-to-svg to ^0.0.75 (#205)**
- **chore(deps): update dependency @tscircuit/core to ^0.0.177 (#204)**
- **feat: Download the dsn file (#208)**
- **chore(deps): update dependency circuit-to-svg to ^0.0.76 (#209)**
- **fix(deps): update dependency @tscircuit/footprinter to ^0.0.87 (#210)**
- **improve pcbview reloading (#213)**
- **update core and circuit-to-svg for capacitor rotation fixes (#220)**
- **run tests against main branch**
- **Update renovate.json**
- **fix format**
- **chore(deps): update dependency circuit-to-svg to ^0.0.78 (#223)**
- **chore(deps): update dependency @tscircuit/core to ^0.0.180 (#219)**
- **fix(deps): update dependency jscad-electronics to ^0.0.20 (#226)**
- **fix(deps): update dependency @tscircuit/3d-viewer to ^0.0.38 (#224)**
- **/preview route (#179)**
- **chore(deps): update dependency circuit-to-svg to ^0.0.79 (#229)**
- **chore(deps): update dependency @tscircuit/core to ^0.0.181 (#232)**
- **fix: 3d view issue (#235)**
- **fix(deps): update dependency jscad-electronics to ^0.0.21 (#230)**
- **feat: react typescript syntax error message (#218)**
- **Fix: hovering over traces should change the colour (#233)**
- **chore(deps): update dependency @tscircuit/core to ^0.0.182 (#239)**
- **Update renovate settings to include circuit json, group updates together (#240)**
- **chore(deps): update dependency updates (#241)**
- **fixed 3d capacitor color don't change when using cap footprints (#247)**
- **feature: insert chip (#246)**
- **feat: snippet images (#237)**
- **chore(deps): update dependency updates (#244)**
- **fix(deps): update dependency circuit-json to ^0.0.105 (#249)**
- **fix: cursor-pos (#250)**
- **Revert "fix: cursor-pos (#250)" (#252)**
- **fix(deps): update dependency updates (#251)**
- **insert footprint feature qol improvements (#257)**
- **Update embed link with /preview (#236)**
- **add github link to landing page (#254)**
- **skips parts engine test (#258)**
- **make playground go to the editor (#242)**
- **Manual Edits to `snippets.manual_edits_json` and can be viewed in the files view (#248)**
- **update core (#263)**
- **better keying for circuit json (#264)**
- **spinner on run button when running (#267)**
- **fix: load manual_json (#268)**
- **chore(deps): update dependency updates (#260)**
- **chore(deps): update dependency circuit-to-svg to ^0.0.83 (#272)**
- **chore(deps): update dependency circuit-to-svg to ^0.0.84 (#273)**
- **fix: cursor-pos (#270)**
- **feat: unstar snippets (#202)**
- **chore(deps): update dependency @tscircuit/core to ^0.0.196 (#275)**
- **Implement Capacitor BOM Search (#280)**
- **3d-error-display (#277)**
- **chore(deps): update dependency updates (#281)**
- **implemented pin header BOM (#282)**
- **fix: template-url (#245)**
- **Fixed responsiveness issue in EditorNav component (#287)**
- **fix(deps): update dependency @tscircuit/props to ^0.0.106 (#283)**
- **bundle-analysis (#291)**
- **chore(deps): update dependency updates (#292)**
- **fix(deps): update dependency updates (#296)**
- **feat: expand-preview (#285)**
- **fix: auth generate fails when not using `localhost` (#298)**
- **bundle analysis diff with main (#294)**
- **fix:regex to import names with dash properly (#302)**
- **feat: add the dev login page (#303)**
- **chore(deps): update dependency @tscircuit/core to ^0.0.206 (#299)**
- **cleaned up extra workflow (#304)**
- **updated 3d-viewer dependency (#306)**
- **updating core to fix components not rendering when `pcbRotation="90"` (#309)**
- **bundle-size-analysis only runs on dependency change (#311)**
- **chore(deps): update dependency @tscircuit/core to ^0.0.209 (#308)**
- **fix: Cmd Click is broken for clicking on snippets (#317)**
- **fix(deps): update dependency @tscircuit/props to ^0.0.107 (#316)**
- **test for underlined and clickable imports (#318)**
- **update core, fix expand button (#325)**
- **fix(deps): update dependency updates (#322)**
- **chore(deps): update dependency @tscircuit/core to ^0.0.212 (#329)**
- **fix(deps): update dependency updates (#333)**
- **fixed test falkiness (#332)**
- **fix(deps): update dependency @tscircuit/props to ^0.0.108 (#336)**
- **added static skeleton page with fixed data (#330)**
- **increased playwright timeout (#341)**
- **fix: rename timeout (#297)**
- **refactor: search-links (#307)**
- **fix multiple cursors when ctrl+click is triggered (#338)**
- **fix(deps): update dependency updates (#344)**
- **feat: expand-to-full (#327)**
- **chore(deps): update dependency circuit-to-svg to ^0.0.86 (#347)**
- **add retries for flaky test (#350)**
- **fix: Regex to support underscore as well (#351)**
- **chore(deps): update dependency updates (#353)**
- **auto-run code (#339)**
- **update snapshots (#357)**
- **fixed react 19 types (#356)**
- **create view ts files dialog (#355)**
- **chore(deps): update dependency updates (#354)**
- **update dsn-converter and add to autoupdate list (#358)**
- **chore(deps): update dependency circuit-to-svg to ^0.0.89 (#360)**
- **chore(deps): update dependency updates (#361)**
- **fix: add manual_json validation and playwright-test (#269)**
- **chore: update version (#369)**
- **chore: update core (#372)**
- **Revert "chore: update core (#372)" (#373)**
- **fix(deps): update dependency updates (#366)**
- **chore: update core (#375)**
- **Improve Playwright Test runtime, fix manual edits test (#363)**
- **split: footprint-dialog.spec.ts into multiple files (#365)**
- **fix(deps): update dependency updates (#374)**
- **fix(deps): update dependency updates (#376)**
- **fix(deps): update dependency dsn-converter to ^0.0.44 (#378)**
- **fix(deps): update dependency updates (#379)**
- **fix(deps): update dependency updates (#382)**
- **update 3d viewer (#385)**
- **updated 3d-viewer for silkscreen text (#387)**
- **Delete playwright-tests/error-fallback.spec.ts (#390)**
- **chore: add stalebot configuration for automated issue and PR management (#389)**
- **fix(deps): update dependency updates (#384)**
- **chore: update pcb-viewer (#393)**
- **add blinking led board template (#343)**
- **fix(deps): update dependency @tscircuit/footprinter to ^0.0.94 (#396)**
- **Show error when manualEdits isn't loaded (#386)**
- **feat: add USB-C LED Flashlight template (#398)**
- **fix(deps): update dependency updates (#397)**
- **update blinking led circuit (#407)**
- **fix(deps): update dependency updates (#401)**
- **feat: edit description (#406)**
- **Update playwright-test.yml**
- **fix(deps): update dependency updates (#408)**
- **fix: Use the template at initialization (#413)**
- **Revert "fix: Use the template at initialization (#413)" (#416)**
- **fix(deps): update dependency updates (#412)**
- **skip the view snippet test**
- **added snippet example Arduino Nano Servo Breakout Board (#419)**
- **import snippets from registry to development server (#423)**
- **add waitforLoadState to view-snippet.spec.ts test (#422)**
- **fix(deps): update dependency updates (#424)**
- **fix: import manual edits (#417)**
- **add circuit name for better logs on autorouting server (#430)**
- **fix(deps): update dependency updates (#429)**
- **fix: playwright-tests failing (#431)**
- **add comments (#434)**
- **Fixed reponsiveness issue in EditorNav component (#425)**
- **Add download for readable netlist (#438)**
- **improve seo (#442)**
- **Update renovate.json**
- **chore: switch chat icon to Discord (#439)**
- **New Landing Page (#446)**
- **update snapshots of homePage test (#448)**
- **Landing Page Improvements (#451)**
- **feat: Display number of stars for each snippet on profile page (#452)**
- **slower animation, show PCB view in trending snippets carousel (#454)**
- **fix: playwright tests (#458)**
- **fix for unsaved changes never going away, add tracking (#463)**
- **improve landing feature bullet points on mobile (#468)**
- **fix(deps): update dependency updates (#436)**
- **add algora bounty badge (#472)**
- **fix: search component (#460)**
- **add download Assembly svg button (#475)**
- **feat: show new button on landing page (#465)**
- **Add kicad pcb download option (#482)**
- **fix discord link (#483)**
- **fic card misalignment (#478)**
- **Revert "fic card misalignment (#478)" (#487)**
- **snippet type fix (#488)**
- **feat: CodeEditor AI driven auto completion (#484)**
- **fix: all the test and skip manual edits for now (#490)**
- **fix (#492)**
- **fix(deps): update dependency updates (#474)**
- **improve search component (#493)**
- **fix(deps): update dependency updates (#495)**
- **fix landing page card allignment (#489)**
- **chore(deps): update dependency @tscircuit/core to ^0.0.254 (#499)**
- **footprint dialog enhancements (#498)**
- **Add type declaration for manual-edits.json in ATA (#500)**
- **add support for downloading gltf (#502)**
- **re-request to non-vercel url for large payloads (#503)**
- **fix(deps): update dependency updates (#501)**
- **fix retry with alternate registry server (#505)**
- **update pcb viewer, fix alternate registry handling (again- with special CORS handling) (#506)**
- **chore(deps): update dependency @tscircuit/core to ^0.0.256 (#507)**
- **add kicad-pro file to kicad project (#514)**
- **fix env var order (#512)**
- **add math utils as a presupplied import (#515)**
- **fix(deps): update dependency updates (#516)**
- **fix(deps): update dependency updates (#517)**
- **fix(deps): update dependency updates (#519)**
- **fix star button working (#518)**
- **chore(deps): update dependency @tscircuit/core to ^0.0.259 (#521)**
- **fix: if somebody edits, then hits fork, we drop all their changes to the base snippet (#528)**
- **fix(deps): update dependency updates (#527)**
- **fix(deps): update dependency updates (#529)**
- **improve site performance (#531)**
- **fix(deps): update dependency updates (#532)**
- **fix base url (#542)**
- **image optimization (#536)**
- **chore(deps): update dependency @tscircuit/core to ^0.0.265 (#541)**
- **fix: timing issues in playwright (#545)**
- **fix text box  (#538)**
- **improve seo by adding robot file and generating sitemap for crawlers (#543)**
- **fix: home page images (#548)**
- **fix(deps): update dependency @tscircuit/3d-viewer to ^0.0.94 (#546)**
- **git ignore sitemap.xml (#553)**
- **prefetch pages as their link appears in the viewport (#554)**
- **some accessibility fields and eliminated layout shift on landing page (#556)**
- **add useMychip hook (#557)**
- **download simple route json (#560)**
- **settings -> responsive (#565)**
- **fix(deps): update dependency @tscircuit/3d-viewer to ^0.0.95 (#561)**
- **Revert "fix(deps): update dependency @tscircuit/3d-viewer to ^0.0.95 (#561)" (#571)**
- **Stale out PRs faster**
- **fix(deps): update dependency updates (#572)**
- **set up fake api releases (#578)**
- **Improve error message for 3D model download when 3D viewer is not open (#574)**
- **fix fork errors not showing (#552)**
- **v0.0.2**
- **Update CODEOWNERS**
- **fix: gltf downloader (#575)**
- **fix(deps): update dependency updates (#579)**
- **feat: assembly image for snippets (#583)**
- **v0.0.3**
- **used getFootprintNamesByType() (#585)**
- **fix(deps): update dependency updates (#581)**
- **chore(deps): update dependency @tscircuit/core to ^0.0.273 (#587)**
- **Integrate RunFrame (Use Webworker Beta) (#586)**
- **remove binary lock file**
- **disable terser temporarily**
- **testing terser (#590)**
- **fix: Editor and cmd-click snippet playwright-tests (#597)**
- **fix(deps): update dependency updates (#588)**
- **fix(deps): update dependency updates (#600)**
- **fix: preview page using runframe (#604)**
- **allow importing "tscircuit" inside synchronous snippets (#605)**
- **add latest version of core to enable using "sel"add latest version of core to enable using "sel"add latest version of core to enable using "sel"add latest version of core to enable using "sel"add latest version of core to enable using "sel"add latest version of core to enable using "sel"add latest version of core to enable using "sel"add latest version of core to enable using "sel"add latest version of core to enable using "sel" (#611)**
- **fix(deps): update dependency updates (#601)**
- **chore: update netlist library (#615)**
- **feat: debounce the searched snippet query (#618)**
- **prefetch fix (#619)**
- **fix(deps): update dependency updates (#613)**
- **chore: update core (#621)**
- **fix: encode the search params (#622)**
- **fix(deps): update dependency updates (#620)**
- **chore(deps): update dependency @tscircuit/prompt-benchmarks to ^0.0.28 (#623)**
- **ci(bundle-size-analysis): updated external actions (#624)**
- **fix(deps): update dependency updates (#626)**
- **add fake-api for the packages (#627)**
- **v0.0.4**
- **feat: import circuit json (#599)**
- **feat: add the package_release fake for registry (#633)**
- **v0.0.5**
- **add skeleton loader for landing page (#631)**
- **change snippet background color to previous (#635)**
- **feat(fake-snippets-api): missing package_release/get logic (#636)**
- **v0.0.6**
- **chore: update packages (#637)**
- **Revert "chore: update packages (#637)" (#640)**
- **fix: generate_bundle_stats.js (#642)**
- **chore: 3d-viewer (#643)**
- **chore: package update (#644)**
- **add get started link to go to docs (#651)**
- **add posthog proxy**
- **Fix: Update editor.tsx to handle screen overflow (#654)**
- **give space from right in get-start button (#655)**
- **feat: delete icon in profile snippet grid (#647)**
- **fix github badge responsiveness (#658)**
- **better tracking on landing page hero**
- **update core (#660)**
- **update core to support subcircuit_id in output for autorouting caching (#661)**
- **Remove console.logs, allow viewing core version, update props (#663)**
- **add google-analytics tag (#664)**
- **update core (#665)**
- **chore: dsn-converter (#667)**
- **fix: schematic bug (old packages) (#687)**
- **feat: Add show more/less btn in dashboard (#672)**
- **feat: show warning if the snippet is not saved (#681)**
- **change ai chat link to chat.tscircuit.com (#688)**
- **fix(quickstart): adjust cards and badge for small screens (#685)**
- **fix: blinking led board template (#696)**
- **add fake `package_files/` endpoint (#699)**
- **v0.0.7**
- **update the snippet create fake (#700)**
- **v0.0.8**
- **Remove legacy tsx runner, replace with RunFrame, everything uses WebWorkers (#702)**
- **update runframe for schematic viewer debugging (#704)**
- **update runframe and remove pcb-viewer as direct dep**
