### PR TITLE
feat: prevent spaces in snippet name and show error message

### DIFF
--- a/src/components/dialogs/rename-snippet-dialog.tsx
+++ b/src/components/dialogs/rename-snippet-dialog.tsx
@@ -6,6 +6,7 @@ import { useMutation, useQueryClient } from "react-query"
 import { createUseDialog } from "./create-use-dialog"
 import { useAxios } from "@/hooks/use-axios"
 import { useToast } from "@/hooks/use-toast"
+import { useIsUsingFakeApi } from "@/hooks/use-is-using-fake-api"
 
 export const RenameSnippetDialog = ({
   open,
@@ -55,6 +56,19 @@ export const RenameSnippetDialog = ({
     },
   })
 
+  const handleRename = () => {
+    if (!useIsUsingFakeApi && newName.includes(" ")) {
+      toast({
+        title: "Invalid Name",
+        description:
+          "Snippet name cannot contain spaces. Please use underscores (_) or hyphens (-) instead.",
+        variant: "destructive",
+      })
+      return
+    }
+    renameSnippetMutation.mutate()
+  }
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent>
@@ -69,7 +83,7 @@ export const RenameSnippetDialog = ({
         />
         <Button
           disabled={renameSnippetMutation.isLoading}
-          onClick={() => renameSnippetMutation.mutate()}
+          onClick={handleRename}
         >
           {renameSnippetMutation.isLoading ? "Renaming..." : "Rename"}
         </Button>


### PR DESCRIPTION
## Fix: #725

- Added validation to prevent spaces in snippet names and avoid unnecessary API calls.  
- Displayed an error message when a user tries to enter a name with spaces.  

[Screencast from 2025-03-21 18-31-21.webm](https://github.com/user-attachments/assets/1c1db63b-8771-4469-9d30-e0e97859b9f1)  

Please let me know if any changes are required.  
