### PR TITLE
feat(editor): auto-format code before opening editor

### DIFF
--- a/src/components/CodeEditor.tsx
+++ b/src/components/CodeEditor.tsx
@@ -29,6 +29,7 @@ import ts from "typescript"
 import CodeEditorHeader from "./CodeEditorHeader"
 // import { copilotPlugin, Language } from "@valtown/codemirror-codeium"
 import { useCodeCompletionApi } from "@/hooks/use-code-completion-ai-api"
+import { formatCode } from "@/lib/utils/formatCurrentFile"
 const defaultImports = `
 import React from "@types/react/jsx-runtime"
 import { Circuit, createUseComponent } from "@tscircuit/core"
@@ -60,7 +61,14 @@ export const CodeEditor = ({
   const codeCompletionApi = useCodeCompletionApi()
 
   const [cursorPosition, setCursorPosition] = useState<number | null>(null)
-  const [code, setCode] = useState(initialCode)
+  const formattedInitialCode = useMemo(() => {
+    return (
+      formatCode({ currentFile: "index.tsx", currentContent: initialCode }) ||
+      initialCode
+    )
+  }, [initialCode])
+
+  const [code, setCode] = useState(formattedInitialCode)
 
   const files = useMemo(
     () => ({
@@ -72,25 +80,19 @@ export const CodeEditor = ({
   const [currentFile, setCurrentFile] =
     useState<keyof typeof files>("index.tsx")
 
-  const isInitialCodeLoaded = Boolean(initialCode)
-
+  // When `initialCode` changes significantly, reformat and update state
   useEffect(() => {
-    if (initialCode !== code) {
-      setCode(initialCode)
-      if (currentFile === "index.tsx") {
-        updateCurrentEditorContent(initialCode)
-      }
+    if (currentFile === "index.tsx" && code !== formattedInitialCode) {
+      updateCurrentEditorContent(formattedInitialCode)
     }
-  }, [isInitialCodeLoaded])
+  }, [formattedInitialCode])
 
   // Whenever streaming completes, reset the code to the initial code
   useEffect(() => {
-    if (!isStreaming && code !== initialCode && initialCode) {
-      setCode(initialCode)
-
-      // HACK: Timeout because we need to wait for the editor to mount again
+    if (!isStreaming && code !== formattedInitialCode && initialCode) {
+      setCode(formattedInitialCode)
       setTimeout(() => {
-        updateCurrentEditorContent(initialCode)
+        updateCurrentEditorContent(formattedInitialCode)
       }, 200)
     }
   }, [isStreaming])

--- a/src/components/CodeEditor.tsx
+++ b/src/components/CodeEditor.tsx
@@ -29,7 +29,7 @@ import ts from "typescript"
 import CodeEditorHeader from "./CodeEditorHeader"
 // import { copilotPlugin, Language } from "@valtown/codemirror-codeium"
 import { useCodeCompletionApi } from "@/hooks/use-code-completion-ai-api"
-import { formatCode } from "@/lib/utils/formatCurrentFile"
+import { formatCode } from "@/lib/utils/formatCode"
 const defaultImports = `
 import React from "@types/react/jsx-runtime"
 import { Circuit, createUseComponent } from "@tscircuit/core"

--- a/src/components/CodeEditorHeader.tsx
+++ b/src/components/CodeEditorHeader.tsx
@@ -19,6 +19,7 @@ import {
 import { AlertTriangle } from "lucide-react"
 import { checkIfManualEditsImported } from "@/lib/utils/checkIfManualEditsImported"
 import { handleManualEditsImport } from "@/lib/handleManualEditsImport"
+import { formatCode } from "@/lib/utils/formatCurrentFile"
 
 export type FileName = "index.tsx" | "manual-edits.json"
 
@@ -43,37 +44,17 @@ export const CodeEditorHeader = ({
   const { toast } = useToast()
 
   const formatCurrentFile = () => {
-    if (!window.prettier || !window.prettierPlugins) return
-
-    try {
-      const currentContent = files[currentFile]
-
-      if (currentFile.endsWith(".json")) {
-        try {
-          const jsonObj = JSON.parse(currentContent)
-          const formattedJson = JSON.stringify(jsonObj, null, 2)
-          updateFileContent(currentFile, formattedJson)
-        } catch (jsonError) {
-          throw new Error("Invalid JSON content")
-        }
-        return
-      }
-
-      const formattedCode = window.prettier.format(currentContent, {
-        semi: false,
-        parser: "typescript",
-        plugins: window.prettierPlugins,
-      })
-
-      updateFileContent(currentFile, formattedCode)
-    } catch (error) {
-      console.error("Formatting error:", error)
+    const formattedContent = formatCode({
+      currentFile,
+      currentContent: files[currentFile],
+    })
+    if (formattedContent) {
+      updateFileContent(currentFile, formattedContent)
+    } else {
       toast({
         title: "Formatting error",
         description:
-          error instanceof Error
-            ? error.message
-            : "Failed to format the code. Please check for syntax errors.",
+          "Failed to format the code. Please check for syntax errors.",
         variant: "destructive",
       })
     }

--- a/src/components/CodeEditorHeader.tsx
+++ b/src/components/CodeEditorHeader.tsx
@@ -19,7 +19,7 @@ import {
 import { AlertTriangle } from "lucide-react"
 import { checkIfManualEditsImported } from "@/lib/utils/checkIfManualEditsImported"
 import { handleManualEditsImport } from "@/lib/handleManualEditsImport"
-import { formatCode } from "@/lib/utils/formatCurrentFile"
+import { formatCode } from "@/lib/utils/formatCode"
 
 export type FileName = "index.tsx" | "manual-edits.json"
 

--- a/src/lib/utils/formatCode.ts
+++ b/src/lib/utils/formatCode.ts
@@ -12,18 +12,26 @@ export const formatCode = ({
   if (!window.prettier || !window.prettierPlugins || !currentContent)
     return null
 
-  try {
-    if (currentFile.endsWith(".json")) {
+  if (currentFile.endsWith(".json")) {
+    try {
       return JSON.stringify(JSON.parse(currentContent), null, 2)
+    } catch (error) {
+      console.error("JSON Formatting Error: Invalid JSON format", error)
+      return null
     }
+  }
 
+  try {
     return window.prettier.format(currentContent, {
       semi: false,
       parser: "typescript",
       plugins: window.prettierPlugins,
     })
   } catch (error) {
-    console.error("Formatting error:", error)
+    console.error(
+      "TypeScript Formatting Error: Prettier failed to format",
+      error,
+    )
     return null
   }
 }

--- a/src/lib/utils/formatCode.ts
+++ b/src/lib/utils/formatCode.ts
@@ -1,6 +1,6 @@
 import { FileName } from "../../components/CodeEditorHeader"
 
-interface FormatCurrentFileProps {
+interface FormatCodeProps {
   currentFile: FileName
   currentContent: string
 }
@@ -8,7 +8,7 @@ interface FormatCurrentFileProps {
 export const formatCode = ({
   currentFile,
   currentContent,
-}: FormatCurrentFileProps) => {
+}: FormatCodeProps) => {
   if (!window.prettier || !window.prettierPlugins || !currentContent)
     return null
 

--- a/src/lib/utils/formatCurrentFile.ts
+++ b/src/lib/utils/formatCurrentFile.ts
@@ -1,0 +1,29 @@
+import { FileName } from "../../components/CodeEditorHeader"
+
+interface FormatCurrentFileProps {
+  currentFile: FileName
+  currentContent: string
+}
+
+export const formatCode = ({
+  currentFile,
+  currentContent,
+}: FormatCurrentFileProps) => {
+  if (!window.prettier || !window.prettierPlugins || !currentContent)
+    return null
+
+  try {
+    if (currentFile.endsWith(".json")) {
+      return JSON.stringify(JSON.parse(currentContent), null, 2)
+    }
+
+    return window.prettier.format(currentContent, {
+      semi: false,
+      parser: "typescript",
+      plugins: window.prettierPlugins,
+    })
+  } catch (error) {
+    console.error("Formatting error:", error)
+    return null
+  }
+}


### PR DESCRIPTION
##Fix: #678 

- Refactored the code formatting logic into a reusable utility function.
- Now, the code is auto-formatted before opening the editor.
- Added auto-formatting when importing from JLCPCB.


[Screencast from 2025-02-23 19-51-24.webm](https://github.com/user-attachments/assets/517672d3-365b-4023-a4cc-e677cf52e399)



Let me know if any changes are needed! 