### PR TITLE
Fix page title: Add document.title update for dashboard page

### DIFF
--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react"
+import React, { useState, useEffect } from "react"
 import { useQuery } from "react-query"
 import { useAxios } from "@/hooks/use-axios"
 import Header from "@/components/Header"
@@ -18,6 +18,10 @@ export const DashboardPage = () => {
   const currentUser = useGlobalStore((s) => s.session?.github_username)
   const [showAllTrending, setShowAllTrending] = useState(false)
   const [showAllNewest, setShowAllNewest] = useState(false)
+
+  useEffect(() => {
+    document.title = "Dashboard - TSCircuit";
+  }, []);
 
   const {
     data: mySnippets,


### PR DESCRIPTION
# Fix Page Title Issue

## Changes
- Added useEffect hook to update document.title on the Dashboard page
- Sets page title to "Dashboard - TSCircuit" when the user navigates to the dashboard

## Testing
- Verified that page title updates properly when navigating to the dashboard page
- Ensured the title appears correctly in browser tabs

/claim #797 

