### PR TITLE
Fake for order-quote (WIP)

### DIFF
--- a/fake-snippets-api/lib/db/db-client.ts
+++ b/fake-snippets-api/lib/db/db-client.ts
@@ -11,6 +11,7 @@ import {
   type LoginPage,
   type Order,
   type OrderFile,
+  OrderQuote,
   type Package,
   type PackageFile,
   type PackageRelease,
@@ -120,6 +121,23 @@ const initializer = combine(databaseSchema.parse({}), (set, get) => ({
       }
     })
     return newOrderFile
+  },
+  addOrderQuote: (orderQuote: Omit<OrderQuote, "order_quote_id">): OrderQuote => {
+    const newOrderQuote = {
+      order_quote_id: `order_quote_${get().idCounter + 1}`,
+      ...orderQuote,
+    }
+    set((state) => {
+      return {
+        orderQuotes: [...state.orderQuotes, newOrderQuote],
+        idCounter: state.idCounter + 1,
+      }
+    })
+    return newOrderQuote
+  },
+  getOrderQuoteById: (orderQuoteId: string): OrderQuote | undefined => {
+    const state = get()
+    return state.orderQuotes.find((quote) => quote.order_quote_id === orderQuoteId)
   },
   getOrderFileById: (orderFileId: string): OrderFile | undefined => {
     const state = get()

--- a/fake-snippets-api/lib/db/schema.ts
+++ b/fake-snippets-api/lib/db/schema.ts
@@ -101,14 +101,11 @@ export const orderFileSchema = z.object({
 export type OrderFile = z.infer<typeof orderFileSchema>
 
 export const orderQuoteComponentSchema = z.object({
-  component_id: z.string(),
-  name: z.string(),
   manufacturer_part_number: z.string().nullable(),
-  jlcpcb_part_number: z.string().nullable(),
-  quantity: z.number(),
-  unit_price: z.number(),
-  total_price: z.number(),
-  type: z.string(), // e.g., "resistor", "capacitor", etc.
+  supplier_part_number: z.string().nullable(),
+  quantity: z.number().default(0),
+  unit_price: z.number().default(0),
+  total_price: z.number().default(0),
   available: z.boolean().default(true),
 })
 export type OrderQuoteComponent = z.infer<typeof orderQuoteComponentSchema>
@@ -124,10 +121,9 @@ export const orderQuoteSchema = z.object({
   created_at: z.string(),
   updated_at: z.string(),
   completed_at: z.string().nullable(),
-  bom_rows: z.string(),
-  components: z.array(orderQuoteComponentSchema).default([]),
+  quoted_components: z.array(orderQuoteComponentSchema).default([]),
   pcb_price: z.number().default(0),
-  components_price: z.number().default(0),
+  total_components_price: z.number().default(0),
   shipping_price: z.number().default(0),
   total_price: z.number().default(0),
 })

--- a/fake-snippets-api/lib/db/schema.ts
+++ b/fake-snippets-api/lib/db/schema.ts
@@ -100,6 +100,39 @@ export const orderFileSchema = z.object({
 })
 export type OrderFile = z.infer<typeof orderFileSchema>
 
+export const orderQuoteComponentSchema = z.object({
+  component_id: z.string(),
+  name: z.string(),
+  manufacturer_part_number: z.string().nullable(),
+  jlcpcb_part_number: z.string().nullable(),
+  quantity: z.number(),
+  unit_price: z.number(),
+  total_price: z.number(),
+  type: z.string(), // e.g., "resistor", "capacitor", etc.
+  available: z.boolean().default(true),
+})
+export type OrderQuoteComponent = z.infer<typeof orderQuoteComponentSchema>
+
+export const orderQuoteSchema = z.object({
+  order_quote_id: z.string(),
+  account_id: z.string().nullable(),
+  package_release_id: z.string().nullable(),
+  is_completed: z.boolean().default(false),
+  is_processing: z.boolean().default(true),
+  error: errorSchema.nullable(),
+  has_error: z.boolean().default(false),
+  created_at: z.string(),
+  updated_at: z.string(),
+  completed_at: z.string().nullable(),
+  bom_rows: z.string(),
+  components: z.array(orderQuoteComponentSchema).default([]),
+  pcb_price: z.number().default(0),
+  components_price: z.number().default(0),
+  shipping_price: z.number().default(0),
+  total_price: z.number().default(0),
+})
+export type OrderQuote = z.infer<typeof orderQuoteSchema>
+
 // TODO: Remove this schema after migration to accountPackages is complete
 export const accountSnippetSchema = z.object({
   account_id: z.string(),
@@ -223,5 +256,6 @@ export const databaseSchema = z.object({
   accountPackages: z.array(accountPackageSchema).default([]),
   jlcpcbOrderState: z.array(jlcpcbOrderStateSchema).default([]),
   jlcpcbOrderStepRuns: z.array(jlcpcbOrderStepRunSchema).default([]),
+  orderQuotes: z.array(orderQuoteSchema).default([]),
 })
 export type DatabaseSchema = z.infer<typeof databaseSchema>

--- a/fake-snippets-api/routes/api/order_quote/create.ts
+++ b/fake-snippets-api/routes/api/order_quote/create.ts
@@ -1,0 +1,49 @@
+import {
+    orderQuoteSchema,
+} from "fake-snippets-api/lib/db/schema"
+import { withRouteSpec } from "fake-snippets-api/lib/middleware/with-winter-spec"
+import { z } from "zod"
+import { convertCircuitJsonToBomRows } from "circuit-json-to-bom-csv"
+
+export default withRouteSpec({
+    methods: ["POST"],
+    auth: "session",
+    jsonBody: z
+        .object({
+            package_release_id: z.string().optional(),
+            circuit_json: z.array(z.record(z.any())),
+        })
+        .refine((data) => data.package_release_id || data.circuit_json, {
+            message: "Either package_release_id or circuit_json must be provided",
+        }),
+    jsonResponse: z.object({
+        order_quote: orderQuoteSchema,
+    }),
+})(async (req, ctx) => {
+    const { circuit_json, package_release_id } = req.jsonBody
+
+
+    const bomRows = await convertCircuitJsonToBomRows({ circuitJson: circuit_json as any })
+
+    const orderQuote = ctx.db.addOrderQuote({
+        account_id: ctx.auth.account_id,
+        package_release_id: package_release_id ?? null,
+        is_completed: false,
+        is_processing: true,
+        error: null,
+        has_error: false,
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+        completed_at: null,
+        bom_rows: bomRows.toString(),
+        components: [],
+        pcb_price: 0,
+        components_price: 0,
+        shipping_price: 0,
+        total_price: 0,
+    })
+
+    return ctx.json({
+        order_quote: orderQuote,
+    })
+})

--- a/fake-snippets-api/routes/api/order_quote/get.ts
+++ b/fake-snippets-api/routes/api/order_quote/get.ts
@@ -1,0 +1,29 @@
+import { withRouteSpec } from "fake-snippets-api/lib/middleware/with-winter-spec"
+import { z } from "zod"
+import { orderQuoteSchema } from "fake-snippets-api/lib/db/schema"
+
+export default withRouteSpec({
+    methods: ["POST"],
+    auth: "session",
+    jsonBody: z.object({
+        order_quote_id: z.string(),
+    }),
+    jsonResponse: z.object({
+        order_quote: orderQuoteSchema.optional(),
+        error: z.string().optional(),
+    }),
+})(async (req, ctx) => {
+    const { order_quote_id } = req.jsonBody
+
+    const orderQuote = ctx.db.getOrderQuoteById(order_quote_id)
+
+    if (!orderQuote) {
+        return ctx.json({
+            error: "Order quote not found",
+        }, { status: 404 })
+    }
+
+    return ctx.json({
+        order_quote: orderQuote,
+    })
+})

--- a/fake-snippets-api/routes/api/order_quote/get_latest_quote.ts
+++ b/fake-snippets-api/routes/api/order_quote/get_latest_quote.ts
@@ -1,0 +1,37 @@
+import { withRouteSpec } from "fake-snippets-api/lib/middleware/with-winter-spec"
+import { z } from "zod"
+import { orderQuoteSchema } from "fake-snippets-api/lib/db/schema"
+
+export default withRouteSpec({
+    methods: ["GET"],
+    auth: "session",
+    queryParams: z.object({
+        package_release_id: z.string().optional(),
+    }),
+    jsonResponse: z.object({
+        order_quote: orderQuoteSchema.optional(),
+        error: z.string().optional(),
+    }),
+})(async (req, ctx) => {
+    const { package_release_id } = req.query
+
+    let orderQuote
+    if (package_release_id) {
+        orderQuote = ctx.db.orderQuotes
+            .filter((quote) => quote.package_release_id === package_release_id)
+            .sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime())[0]
+    } else {
+        orderQuote = ctx.db.orderQuotes
+            .sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime())[0]
+    }
+
+    if (!orderQuote) {
+        return ctx.json({
+            error: "Order quote not found",
+        }, { status: 404 })
+    }
+
+    return ctx.json({
+        order_quote: orderQuote,
+    })
+})


### PR DESCRIPTION
@seveibar We can convert the circuit_json to bom inside the create endpoint and then that will be picked up by the job to get the price of that parts and then update the orderQuote. Or we don't store the bom in the orderQuotes and just the components (part numbers) whic h is good enough for the job to do the calculation and update the orderQuote?