### PR TITLE
refactor(DownloadButtonAndMenu): wrap disabled button in div &use asChild for DropdownMenuTrigger

### DIFF
--- a/src/components/DownloadButtonAndMenu.tsx
+++ b/src/components/DownloadButtonAndMenu.tsx
@@ -34,23 +34,25 @@ export function DownloadButtonAndMenu({
 
   if (!circuitJson) {
     return (
-      <Button
-        disabled
-        variant="ghost"
-        size="sm"
-        className="h-9 border-gray-300 dark:border-[#30363d] bg-gray-100 hover:bg-gray-200 dark:bg-[#21262d] dark:hover:bg-[#30363d] text-gray-700 dark:text-[#c9d1d9]"
-      >
-        <Download className="h-4 w-4 mr-1.5" />
-        Export
-        <ChevronDown className="h-4 w-4 ml-0.5" />
-      </Button>
+      <div>
+        <Button
+          disabled
+          var="ghost"
+          size="sm"
+          className="h-9 border-gray-300 dark:border-[#30363d] bg-gray-100 hover:bg-gray-200 dark:bg-[#21262d] dark:hover:bg-[#30363d] text-gray-700 dark:text-[#c9d1d9]"
+        >
+          <Download className="h-4 w-4 mr-1.5" />
+          Export
+          <ChevronDown className="h-4 w-4 ml-0.5" />
+        </Button>
+      </div>
     )
   }
 
   return (
     <div className={className}>
       <DropdownMenu>
-        <DropdownMenuTrigger>
+        <DropdownMenuTrigger asChild>
           <Button
             variant="outline"
             size="sm"

--- a/src/components/DownloadButtonAndMenu.tsx
+++ b/src/components/DownloadButtonAndMenu.tsx
@@ -37,7 +37,7 @@ export function DownloadButtonAndMenu({
       <div>
         <Button
           disabled
-          var="ghost"
+          variant="ghost"
           size="sm"
           className="h-9 border-gray-300 dark:border-[#30363d] bg-gray-100 hover:bg-gray-200 dark:bg-[#21262d] dark:hover:bg-[#30363d] text-gray-700 dark:text-[#c9d1d9]"
         >


### PR DESCRIPTION
# Prevents this err

![image](https://github.com/user-attachments/assets/d2e11b11-9a3a-47be-a6a1-434bb0ec0401)


Wrap the disabled button in a div to improve structure and use `asChild` for DropdownMenuTrigger to ensure proper component composition