### PR TITLE
feat(routing): add 404 page and handle not found states

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -125,6 +125,7 @@ function App() {
               path="/snippets/:author/:snippetName"
               component={ViewSnippetPage}
             />
+            <Route component={lazyImport(() => import("@/pages/404"))} />
           </Switch>
         </Suspense>
         <Toaster />

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -3,7 +3,6 @@ import { Helmet } from "react-helmet"
 import { Header2 } from "@/components/Header2"
 import Footer from "@/components/Footer"
 import { Button } from "@/components/ui/button"
-import { CircuitBoard } from "lucide-react"
 import { PrefetchPageLink } from "@/components/PrefetchPageLink"
 
 export function NotFoundPage() {

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -5,11 +5,13 @@ import Footer from "@/components/Footer"
 import { Button } from "@/components/ui/button"
 import { PrefetchPageLink } from "@/components/PrefetchPageLink"
 
-export function NotFoundPage() {
+export function NotFoundPage({
+  heading = "Page Not Found",
+}: { heading?: string }) {
   return (
     <div className="flex min-h-screen flex-col">
       <Helmet>
-        <title>404 - Page Not Found | tscircuit</title>
+        <title>404 - {heading} | tscircuit</title>
         <meta
           name="description"
           content="The page you're looking for doesn't exist."
@@ -26,7 +28,7 @@ export function NotFoundPage() {
             </div>
           </div>
           <h1 className="text-4xl font-extrabold tracking-tight lg:text-5xl mb-4">
-            Package Not Found
+            {heading}
           </h1>
           <p className="text-xl text-muted-foreground mb-8">
             The page you're looking for doesn't exist or has been moved to

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,0 +1,55 @@
+import React from "react"
+import { Helmet } from "react-helmet"
+import { Header2 } from "@/components/Header2"
+import Footer from "@/components/Footer"
+import { Button } from "@/components/ui/button"
+import { CircuitBoard } from "lucide-react"
+import { PrefetchPageLink } from "@/components/PrefetchPageLink"
+
+export function NotFoundPage() {
+  return (
+    <div className="flex min-h-screen flex-col">
+      <Helmet>
+        <title>404 - Page Not Found | tscircuit</title>
+        <meta
+          name="description"
+          content="The page you're looking for doesn't exist."
+        />
+      </Helmet>
+      <Header2 />
+      <main className="flex-1 flex items-center justify-center min-h-[90vh]">
+        <div className="container px-4 md:px-6 py-12 flex flex-col items-center text-center max-w-3xl">
+          <div className="mb-8 flex flex-col items-center justify-center">
+            <div className="mb-2">
+              <span className="text-3xl font-bold text-white bg-blue-500 px-4 py-2 rounded-md shadow-md inline-block">
+                404
+              </span>
+            </div>
+          </div>
+          <h1 className="text-4xl font-extrabold tracking-tight lg:text-5xl mb-4">
+            Circuit Disconnected
+          </h1>
+          <p className="text-xl text-muted-foreground mb-8">
+            The page you're looking for doesn't exist or has been moved to
+            another address.
+          </p>
+          <div className="flex flex-col sm:flex-row gap-4">
+            <PrefetchPageLink href="/">
+              <Button size="lg" className="bg-blue-500 hover:bg-blue-600">
+                Return Home
+              </Button>
+            </PrefetchPageLink>
+            <PrefetchPageLink href="/search">
+              <Button size="lg" variant="outline">
+                Search Packages
+              </Button>
+            </PrefetchPageLink>
+          </div>
+        </div>
+      </main>
+      <Footer />
+    </div>
+  )
+}
+
+export default NotFoundPage

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -26,7 +26,7 @@ export function NotFoundPage() {
             </div>
           </div>
           <h1 className="text-4xl font-extrabold tracking-tight lg:text-5xl mb-4">
-            Circuit Disconnected
+            Package Not Found
           </h1>
           <p className="text-xl text-muted-foreground mb-8">
             The page you're looking for doesn't exist or has been moved to

--- a/src/pages/view-package.tsx
+++ b/src/pages/view-package.tsx
@@ -35,7 +35,6 @@ export const ViewPackagePage = () => {
     const is404Error =
       packageInfoError?.status === 404 || packageReleaseError?.status === 404
     const isMissingData = !packageInfo || !packageRelease
-    console.log(is404Error, isMissingData)
     if (is404Error || isMissingData) {
       setIsNotFound(true)
       return

--- a/src/pages/view-package.tsx
+++ b/src/pages/view-package.tsx
@@ -30,15 +30,28 @@ export const ViewPackagePage = () => {
     packageRelease?.package_release_id,
   )
   useEffect(() => {
-    if (!isLoadingPackageInfo && !isLoadingPackageRelease) {
-      if (
-        packageInfoError?.status === 404 ||
-        packageReleaseError?.status === 404 ||
-        (!packageInfo && !isLoadingPackageInfo) ||
-        (!packageRelease && !isLoadingPackageRelease)
-      ) {
-        setIsNotFound(true)
-      }
+    // Early return if still loading
+    if (isLoadingPackageInfo || isLoadingPackageRelease) return
+
+    // Check for 404 errors
+    if (
+      packageInfoError?.status === 404 ||
+      packageReleaseError?.status === 404
+    ) {
+      setIsNotFound(true)
+      return
+    }
+
+    // Check if package info is missing
+    if (!packageInfo) {
+      setIsNotFound(true)
+      return
+    }
+
+    // Check if package release is missing
+    if (!packageRelease) {
+      setIsNotFound(true)
+      return
     }
   }, [
     packageInfo,
@@ -50,7 +63,7 @@ export const ViewPackagePage = () => {
   ])
 
   if (isNotFound) {
-    return <NotFoundPage />
+    return <NotFoundPage heading="Package Not Found" />
   }
 
   return (

--- a/src/pages/view-package.tsx
+++ b/src/pages/view-package.tsx
@@ -30,26 +30,13 @@ export const ViewPackagePage = () => {
     packageRelease?.package_release_id,
   )
   useEffect(() => {
-    // Early return if still loading
     if (isLoadingPackageInfo || isLoadingPackageRelease) return
 
-    // Check for 404 errors
-    if (
-      packageInfoError?.status === 404 ||
-      packageReleaseError?.status === 404
-    ) {
-      setIsNotFound(true)
-      return
-    }
-
-    // Check if package info is missing
-    if (!packageInfo) {
-      setIsNotFound(true)
-      return
-    }
-
-    // Check if package release is missing
-    if (!packageRelease) {
+    const is404Error =
+      packageInfoError?.status === 404 || packageReleaseError?.status === 404
+    const isMissingData = !packageInfo || !packageRelease
+    console.log(is404Error, isMissingData)
+    if (is404Error || isMissingData) {
       setIsNotFound(true)
       return
     }

--- a/src/pages/view-package.tsx
+++ b/src/pages/view-package.tsx
@@ -1,17 +1,27 @@
 import RepoPageContent from "@/components/ViewPackagePage/components/repo-page-content"
 import { useCurrentPackageInfo } from "@/hooks/use-current-package-info"
-import { usePackageByName } from "@/hooks/use-package-by-package-name"
 import { usePackageFiles } from "@/hooks/use-package-files"
 import { usePackageRelease } from "@/hooks/use-package-release"
 import { useLocation, useParams } from "wouter"
 import { Helmet } from "react-helmet-async"
+import { useEffect, useState } from "react"
+import NotFoundPage from "./404"
 
 export const ViewPackagePage = () => {
-  const { packageInfo } = useCurrentPackageInfo()
+  const {
+    packageInfo,
+    isLoading: isLoadingPackageInfo,
+    error: packageInfoError,
+  } = useCurrentPackageInfo()
   const { author, packageName } = useParams()
   const [, setLocation] = useLocation()
+  const [isNotFound, setIsNotFound] = useState(false)
 
-  const { data: packageRelease } = usePackageRelease({
+  const {
+    data: packageRelease,
+    isLoading: isLoadingPackageRelease,
+    error: packageReleaseError,
+  } = usePackageRelease({
     is_latest: true,
     package_name: `${author}/${packageName}`,
   })
@@ -19,6 +29,29 @@ export const ViewPackagePage = () => {
   const { data: packageFiles } = usePackageFiles(
     packageRelease?.package_release_id,
   )
+  useEffect(() => {
+    if (!isLoadingPackageInfo && !isLoadingPackageRelease) {
+      if (
+        packageInfoError?.status === 404 ||
+        packageReleaseError?.status === 404 ||
+        (!packageInfo && !isLoadingPackageInfo) ||
+        (!packageRelease && !isLoadingPackageRelease)
+      ) {
+        setIsNotFound(true)
+      }
+    }
+  }, [
+    packageInfo,
+    packageRelease,
+    isLoadingPackageInfo,
+    isLoadingPackageRelease,
+    packageInfoError,
+    packageReleaseError,
+  ])
+
+  if (isNotFound) {
+    return <NotFoundPage />
+  }
 
   return (
     <>


### PR DESCRIPTION
Add a new 404 page to handle cases where users navigate to non-existent routes or packages. Implement logic in the ViewPackagePage to detect missing packages and redirect to the 404 page. This improves user experience by providing clear feedback when resources are not found.

# Before (no showing error that snippet not even exists)

![image](https://github.com/user-attachments/assets/800e3117-d932-4daa-ace4-27cb6a347140)


# After

![image](https://github.com/user-attachments/assets/34e0b171-5767-42d0-b12e-371966ded1a0)


# This also shows 404 when not existent route is asked
![image](https://github.com/user-attachments/assets/06db9ce5-bfe2-4cb3-8699-23fa8014e47c)

