### PR TITLE
feat: add trending page to display popular snippets

### DIFF
--- a/fake-snippets-api/routes/api/snippets/list_trending.ts
+++ b/fake-snippets-api/routes/api/snippets/list_trending.ts
@@ -9,6 +9,12 @@ export default withRouteSpec({
     snippets: z.array(snippetSchema),
   }),
 })(async (req, ctx) => {
+  console.log(new URL(req.url))
+  if (new URL(req.url).searchParams.get("tag") == "keyboard") {
+    return ctx.json({
+      snippets: [],
+    })
+  }
   // Get trending snippets from last 7 days
   const sevenDaysAgo = new Date()
   sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7)

--- a/fake-snippets-api/routes/api/snippets/list_trending.ts
+++ b/fake-snippets-api/routes/api/snippets/list_trending.ts
@@ -9,12 +9,6 @@ export default withRouteSpec({
     snippets: z.array(snippetSchema),
   }),
 })(async (req, ctx) => {
-  console.log(new URL(req.url))
-  if (new URL(req.url).searchParams.get("tag") == "keyboard") {
-    return ctx.json({
-      snippets: [],
-    })
-  }
   // Get trending snippets from last 7 days
   const sevenDaysAgo = new Date()
   sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -72,6 +72,7 @@ const ViewSnippetPage = lazyImport(() => import("@/pages/view-snippet"))
 const DevLoginPage = lazyImport(() => import("@/pages/dev-login"))
 const BetaPage = lazyImport(() => import("@/pages/beta"))
 const ViewPackagePage = lazyImport(() => import("@/pages/view-package"))
+const TrendingPage = lazyImport(() => import("@/pages/trending"))
 
 class ErrorBoundary extends React.Component<
   { children: React.ReactNode },
@@ -114,6 +115,7 @@ function App() {
             <Route path="/newest" component={NewestPage} />
             <Route path="/settings" component={SettingsPage} />
             <Route path="/search" component={SearchPage} />
+            <Route path="/trending" component={TrendingPage} />
             <Route path="/authorize" component={AuthenticatePage} />
             <Route path="/my-orders" component={MyOrdersPage} />
             <Route path="/orders/:orderId" component={ViewOrderPage} />

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -53,6 +53,9 @@ export default function Footer() {
               <PrefetchPageLink href="/newest" className="hover:underline">
                 Newest Snippets
               </PrefetchPageLink>
+              <PrefetchPageLink href="/trending" className="hover:underline">
+                Trending Snippets
+              </PrefetchPageLink>
               <a href="https://docs.tscircuit.com" className="hover:underline">
                 Docs
               </a>

--- a/src/components/SnippetCard.tsx
+++ b/src/components/SnippetCard.tsx
@@ -1,0 +1,159 @@
+import React from "react"
+import { Link } from "wouter"
+import { Snippet } from "fake-snippets-api/lib/db/schema"
+import { GitHubLogoIcon, StarIcon, LockClosedIcon } from "@radix-ui/react-icons"
+import { GlobeIcon, MoreVertical, PencilIcon, Trash2 } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import { OptimizedImage } from "./OptimizedImage"
+import { SnippetTypeIcon } from "./SnippetTypeIcon"
+import { timeAgo } from "@/lib/utils/timeAgo"
+
+export interface SnippetCardProps {
+  /** The snippet data to display */
+  snippet: Snippet
+  /** Base URL for snippet images */
+  baseUrl: string
+  /** Whether to show the owner name (useful in starred views) */
+  showOwner?: boolean
+  /** Whether this is the current user's snippet (enables edit/delete options) */
+  isCurrentUserSnippet?: boolean
+  /** Callback when delete is clicked */
+  onDeleteClick?: (e: React.MouseEvent, snippet: Snippet) => void
+  /** Custom class name for the card container */
+  className?: string
+  /** Custom image size (default is h-16 w-16) */
+  imageSize?: string
+  /** Custom image transform style */
+  imageTransform?: string
+  /** Whether to render the card with a link to the snippet page */
+  withLink?: boolean
+  /** Custom render function for actions */
+  renderActions?: (snippet: Snippet) => React.ReactNode
+}
+
+export const SnippetCard: React.FC<SnippetCardProps> = ({
+  snippet,
+  baseUrl,
+  showOwner = false,
+  isCurrentUserSnippet = false,
+  onDeleteClick,
+  className = "",
+  imageSize = "h-16 w-16",
+  imageTransform = "transition-transform duration-300 -rotate-45 hover:rotate-0 hover:scale-110 scale-150",
+  withLink = true,
+  renderActions,
+}) => {
+  const handleDeleteClick = (e: React.MouseEvent) => {
+    e.preventDefault() // Prevent navigation
+    if (onDeleteClick) {
+      onDeleteClick(e, snippet)
+    }
+  }
+
+  const cardContent = (
+    <div
+      className={`border p-4 rounded-md hover:shadow-md transition-shadow flex flex-col gap-4 ${className}`}
+    >
+      <div className="flex items-start gap-4">
+        <div
+          className={`${imageSize} flex-shrink-0 rounded-md overflow-hidden`}
+        >
+          <OptimizedImage
+            src={`${baseUrl}/snippets/images/${snippet.owner_name}/${snippet.unscoped_name}/pcb.svg`}
+            alt={`${snippet.owner_name}'s profile`}
+            className={`object-cover h-full w-full ${imageTransform}`}
+          />
+        </div>
+        <div className="flex-1 min-w-0">
+          <div className="flex justify-between items-start mb-[2px] -mt-[3px]">
+            <h2 className="text-md font-semibold truncate pr-[30px]">
+              {showOwner && (
+                <>
+                  <span className="text-gray-700 text-md">
+                    {snippet.owner_name}
+                  </span>
+                  <span className="mx-1">/</span>
+                </>
+              )}
+              <span className="text-gray-900">{snippet.unscoped_name}</span>
+            </h2>
+            <div className="flex items-center gap-2">
+              <SnippetTypeIcon
+                type={snippet.snippet_type}
+                className="pt-[2.5px]"
+              />
+              <div className="flex items-center gap-1 text-gray-600">
+                <StarIcon className="w-4 h-4 pt-[2.5px]" />
+                <span className="text-[16px]">{snippet.star_count || 0}</span>
+              </div>
+              {isCurrentUserSnippet && onDeleteClick && (
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-[1.5rem] w-[1.5rem]"
+                    >
+                      <MoreVertical className="h-4 w-4" />
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent>
+                    <DropdownMenuItem
+                      className="text-xs text-red-600"
+                      onClick={handleDeleteClick}
+                    >
+                      <Trash2 className="mr-2 h-3 w-3" />
+                      Delete Snippet
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              )}
+              {renderActions && renderActions(snippet)}
+            </div>
+          </div>
+          <p
+            className={`${!snippet.description && "h-[1.25rem]"} text-sm text-gray-500 mb-1 truncate max-w-xs`}
+          >
+            {snippet.description ? snippet.description : " "}
+          </p>
+          <div className={`flex items-center gap-4`}>
+            {snippet.is_private ? (
+              <div className="flex items-center text-xs gap-1 text-gray-500">
+                <LockClosedIcon height={12} width={12} />
+                <span>Private</span>
+              </div>
+            ) : (
+              <div className="flex items-center text-xs gap-1 text-gray-500">
+                <GlobeIcon height={12} width={12} />
+                <span>Public</span>
+              </div>
+            )}
+            <div className="flex items-center text-xs gap-1 text-gray-500">
+              <PencilIcon height={12} width={12} />
+              <span>{timeAgo(new Date(snippet.updated_at))}</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+
+  if (withLink) {
+    return (
+      <Link
+        key={snippet.snippet_id}
+        href={`/${snippet.owner_name}/${snippet.unscoped_name}`}
+      >
+        {cardContent}
+      </Link>
+    )
+  }
+
+  return cardContent
+}

--- a/src/pages/trending.tsx
+++ b/src/pages/trending.tsx
@@ -1,0 +1,102 @@
+import React from "react"
+import { useQuery } from "react-query"
+import { useAxios } from "@/hooks/use-axios"
+import { Snippet } from "fake-snippets-api/lib/db/schema"
+import Header from "@/components/Header"
+import Footer from "@/components/Footer"
+import { Link } from "wouter"
+import { StarFilledIcon } from "@radix-ui/react-icons"
+import { useSnippetsBaseApiUrl } from "@/hooks/use-snippets-base-api-url"
+import { OptimizedImage } from "@/components/OptimizedImage"
+import { Star } from "lucide-react"
+
+const TrendingPage: React.FC = () => {
+  const axios = useAxios()
+  const apiBaseUrl = useSnippetsBaseApiUrl()
+
+  const {
+    data: snippets,
+    isLoading,
+    error,
+  } = useQuery<Snippet[]>("trendingSnippets", async () => {
+    const response = await axios.get("/snippets/list_trending")
+    return response.data.snippets
+  })
+
+  return (
+    <div className="min-h-screen flex flex-col bg-gray-50">
+      <Header />
+      <main className="flex-grow container mx-auto px-4 py-8">
+        <div className="mb-8">
+          <h1 className="text-4xl font-bold text-gray-900 mb-2">
+            Trending Snippets
+          </h1>
+          <p className="text-gray-600">
+            Discover the most popular snippets from the last 7 days
+          </p>
+        </div>
+
+        {isLoading ? (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+            {[...Array(8)].map((_, i) => (
+              <div
+                key={i}
+                className="bg-white rounded-lg shadow-sm border border-gray-200 p-4 h-64 animate-pulse"
+              >
+                <div className="h-4 bg-gray-200 rounded w-3/4 mb-4"></div>
+                <div className="h-32 bg-gray-200 rounded mb-4"></div>
+                <div className="h-4 bg-gray-200 rounded w-1/2"></div>
+              </div>
+            ))}
+          </div>
+        ) : error ? (
+          <div className="bg-red-50 border border-red-200 text-red-700 p-4 rounded-md">
+            <h3 className="text-lg font-semibold mb-2">
+              Error Loading Snippets
+            </h3>
+            <p>
+              We couldn't load the trending snippets. Please try again later.
+            </p>
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+            {snippets?.map((snippet) => (
+              <Link
+                key={snippet.snippet_id}
+                href={`/${snippet.owner_name}/${snippet.unscoped_name}`}
+                className="group"
+              >
+                <div className="bg-white rounded-lg shadow-sm border border-gray-200 hover:border-blue-400 hover:shadow-md transition-all duration-200 overflow-hidden h-full flex flex-col">
+                  <div className="p-4 pb-2">
+                    <h3 className="font-medium text-blue-600 mb-1 truncate group-hover:underline">
+                      {snippet.owner_name}/{snippet.unscoped_name}
+                    </h3>
+                  </div>
+                  <div className="flex-grow bg-black p-2 relative overflow-hidden">
+                    <OptimizedImage
+                      src={`${apiBaseUrl}/snippets/images/${snippet.owner_name}/${snippet.unscoped_name}/pcb.svg`}
+                      alt="PCB preview"
+                      className="w-full h-full object-contain scale-[3] rotate-45 group-hover:scale-[3.5] transition-transform duration-300"
+                    />
+                  </div>
+                  <div className="p-4 pt-2 flex items-center justify-between">
+                    <div className="flex items-center text-sm text-gray-500">
+                      <Star className="w-4 h-4 mr-1 text-yellow-500" />
+                      <span>{snippet.star_count || 0} stars</span>
+                    </div>
+                    <div className="text-xs text-gray-400">
+                      {new Date(snippet.created_at).toLocaleDateString()}
+                    </div>
+                  </div>
+                </div>
+              </Link>
+            ))}
+          </div>
+        )}
+      </main>
+      <Footer />
+    </div>
+  )
+}
+
+export default TrendingPage

--- a/src/pages/trending.tsx
+++ b/src/pages/trending.tsx
@@ -72,10 +72,6 @@ const TrendingPage: React.FC = () => {
     })
   })
 
-  useEffect(() => {
-    refetch()
-  }, [category])
-
   return (
     <div className="min-h-screen flex flex-col bg-gray-50">
       <Header />

--- a/src/pages/trending.tsx
+++ b/src/pages/trending.tsx
@@ -18,15 +18,12 @@ import {
   Keyboard,
   Cpu,
   Layers,
-  Footprints,
-  Box,
   LucideBellElectric,
 } from "lucide-react"
 import { Input } from "@/components/ui/input"
 import { Badge } from "@/components/ui/badge"
 import { SnippetTypeIcon } from "@/components/SnippetTypeIcon"
 import { timeAgo } from "@/lib/utils/timeAgo"
-import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import {
   Select,
   SelectContent,
@@ -39,7 +36,6 @@ const TrendingPage: React.FC = () => {
   const axios = useAxios()
   const apiBaseUrl = useSnippetsBaseApiUrl()
   const [searchQuery, setSearchQuery] = useState("")
-  const [activeTab, setActiveTab] = useState("all")
   const [category, setCategory] = useState("all")
 
   const {
@@ -69,13 +65,6 @@ const TrendingPage: React.FC = () => {
   })
 
   const filteredByTypeSnippets = filteredSnippets?.filter((snippet) => {
-    if (
-      activeTab !== "all" &&
-      snippet.snippet_type.toLowerCase() !== activeTab.toLowerCase()
-    ) {
-      return false
-    }
-
     if (category !== "all") {
       const description = (
         (snippet.description || "") + ((snippet as any).ai_description || "")
@@ -200,49 +189,6 @@ const TrendingPage: React.FC = () => {
               </SelectContent>
             </Select>
           </div>
-
-          <Tabs
-            defaultValue="all"
-            onValueChange={setActiveTab}
-            className="mb-4"
-          >
-            <TabsList className="w-full">
-              <TabsTrigger
-                value="all"
-                className="flex-1 text-xs sm:text-sm px-1 sm:px-2"
-              >
-                All
-              </TabsTrigger>
-              <TabsTrigger
-                value="board"
-                className="flex-1 text-xs sm:text-sm px-1 sm:px-2"
-              >
-                <Box className="h-3 w-3 sm:h-3.5 sm:w-3.5 mr-0.5 sm:mr-1 hidden sm:inline" />
-                Board
-              </TabsTrigger>
-              <TabsTrigger
-                value="package"
-                className="flex-1 text-xs sm:text-sm px-1 sm:px-2"
-              >
-                <Box className="h-3 w-3 sm:h-3.5 sm:w-3.5 mr-0.5 sm:mr-1 hidden sm:inline" />
-                Package
-              </TabsTrigger>
-              <TabsTrigger
-                value="footprint"
-                className="flex-1 text-xs sm:text-sm px-1 sm:px-2"
-              >
-                <Footprints className="h-3 w-3 sm:h-3.5 sm:w-3.5 mr-0.5 sm:mr-1 hidden sm:inline" />
-                Footprint
-              </TabsTrigger>
-              <TabsTrigger
-                value="model"
-                className="flex-1 text-xs sm:text-sm px-1 sm:px-2"
-              >
-                <Layers className="h-3 w-3 sm:h-3.5 sm:w-3.5 mr-0.5 sm:mr-1 hidden sm:inline" />
-                Model
-              </TabsTrigger>
-            </TabsList>
-          </Tabs>
         </div>
 
         {isLoading ? (
@@ -293,9 +239,7 @@ const TrendingPage: React.FC = () => {
                 ? `No snippets match your search for "${searchQuery}".`
                 : category !== "all"
                   ? `No ${category} snippets found in the trending list.`
-                  : activeTab !== "all"
-                    ? `No ${activeTab} snippets found in the trending list.`
-                    : "There are no trending snippets at the moment."}
+                  : "There are no trending snippets at the moment."}
             </p>
           </div>
         ) : (

--- a/src/pages/trending.tsx
+++ b/src/pages/trending.tsx
@@ -1,18 +1,46 @@
-import React from "react"
+import React, { useState } from "react"
 import { useQuery } from "react-query"
 import { useAxios } from "@/hooks/use-axios"
 import { Snippet } from "fake-snippets-api/lib/db/schema"
 import Header from "@/components/Header"
 import Footer from "@/components/Footer"
 import { Link } from "wouter"
-import { StarFilledIcon } from "@radix-ui/react-icons"
+import { StarIcon, LockClosedIcon } from "@radix-ui/react-icons"
 import { useSnippetsBaseApiUrl } from "@/hooks/use-snippets-base-api-url"
 import { OptimizedImage } from "@/components/OptimizedImage"
-import { Star } from "lucide-react"
+import {
+  GlobeIcon,
+  PencilIcon,
+  Zap,
+  Tag,
+  Calendar,
+  Search,
+  Keyboard,
+  Cpu,
+  Layers,
+  Footprints,
+  Box,
+  LucideBellElectric,
+} from "lucide-react"
+import { Input } from "@/components/ui/input"
+import { Badge } from "@/components/ui/badge"
+import { SnippetTypeIcon } from "@/components/SnippetTypeIcon"
+import { timeAgo } from "@/lib/utils/timeAgo"
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
 
 const TrendingPage: React.FC = () => {
   const axios = useAxios()
   const apiBaseUrl = useSnippetsBaseApiUrl()
+  const [searchQuery, setSearchQuery] = useState("")
+  const [activeTab, setActiveTab] = useState("all")
+  const [category, setCategory] = useState("all")
 
   const {
     data: snippets,
@@ -23,74 +51,328 @@ const TrendingPage: React.FC = () => {
     return response.data.snippets
   })
 
+  const filteredSnippets = snippets?.filter((snippet) => {
+    if (!searchQuery) return true
+
+    const query = searchQuery.toLowerCase().trim()
+
+    const searchableFields = [
+      snippet.unscoped_name.toLowerCase(),
+      snippet.owner_name.toLowerCase(),
+      (snippet.description || "").toLowerCase(),
+    ]
+
+    return searchableFields.some((field) => {
+      const queryWords = query.split(/\s+/).filter((word) => word.length > 0)
+      return queryWords.every((word) => field.includes(word))
+    })
+  })
+
+  const filteredByTypeSnippets = filteredSnippets?.filter((snippet) => {
+    if (
+      activeTab !== "all" &&
+      snippet.snippet_type.toLowerCase() !== activeTab.toLowerCase()
+    ) {
+      return false
+    }
+
+    if (category !== "all") {
+      const description = (
+        (snippet.description || "") + ((snippet as any).ai_description || "")
+      ).toLowerCase()
+      const name = snippet.unscoped_name.toLowerCase()
+
+      switch (category) {
+        case "keyboard":
+          return (
+            description.includes("keyboard") ||
+            name.includes("keyboard") ||
+            description.includes("keycap") ||
+            name.includes("keycap") ||
+            description.includes("keyboards") ||
+            name.includes("keyboards")
+          )
+        case "microcontroller":
+          return (
+            description.includes("microcontroller") ||
+            name.includes("mcu") ||
+            description.includes("arduino") ||
+            description.includes("esp32") ||
+            description.includes("raspberry") ||
+            name.includes("arduino") ||
+            name.includes("esp32") ||
+            name.includes("raspberry")
+          )
+        case "connector":
+          return (
+            description.includes("connector") ||
+            name.includes("connector") ||
+            description.includes("jack") ||
+            name.includes("jack") ||
+            description.includes("socket") ||
+            name.includes("socket")
+          )
+        case "sensor":
+          return (
+            description.includes("sensor") ||
+            name.includes("sensor") ||
+            description.includes("detector") ||
+            name.includes("detector")
+          )
+        default:
+          return true
+      }
+    }
+
+    return true
+  })
+
   return (
     <div className="min-h-screen flex flex-col bg-gray-50">
       <Header />
       <main className="flex-grow container mx-auto px-4 py-8">
-        <div className="mb-8">
-          <h1 className="text-4xl font-bold text-gray-900 mb-2">
-            Trending Snippets
-          </h1>
-          <p className="text-gray-600">
-            Discover the most popular snippets from the last 7 days
+        <div className="mb-8 max-w-3xl">
+          <div className="flex items-center gap-2 mb-3">
+            <Zap className="w-6 h-6 text-amber-500" />
+            <h1 className="text-4xl font-bold text-gray-900">
+              Trending Snippets
+            </h1>
+          </div>
+          <p className="text-lg text-gray-600 mb-4">
+            Discover the most popular and innovative snippets from the community
+            over the last 7 days. These trending designs showcase the best in
+            circuit creativity and technical excellence.
           </p>
+          <div className="flex flex-wrap gap-3">
+            <Badge variant="secondary" className="px-3 py-1">
+              <Tag className="w-3.5 h-3.5 mr-1" />
+              <span>Most Starred</span>
+            </Badge>
+            <Badge variant="secondary" className="px-3 py-1">
+              <Calendar className="w-3.5 h-3.5 mr-1" />
+              <span>Last 7 Days</span>
+            </Badge>
+          </div>
+        </div>
+
+        <div className="mb-6">
+          <div className="flex flex-col sm:flex-row gap-4 mb-4">
+            <div className="relative flex-grow">
+              <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 h-4 w-4" />
+              <Input
+                type="text"
+                placeholder="Search trending snippets..."
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                className="pl-10"
+              />
+            </div>
+            <Select value={category} onValueChange={setCategory}>
+              <SelectTrigger className="w-full sm:w-[180px]">
+                <SelectValue placeholder="Category" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All Categories</SelectItem>
+                <SelectItem value="keyboard">
+                  <div className="flex items-center">
+                    <Keyboard className="mr-2 h-4 w-4" />
+                    <span>Keyboards</span>
+                  </div>
+                </SelectItem>
+                <SelectItem value="microcontroller">
+                  <div className="flex items-center">
+                    <Cpu className="mr-2 h-4 w-4" />
+                    <span>Microcontrollers</span>
+                  </div>
+                </SelectItem>
+                <SelectItem value="connector">
+                  <div className="flex items-center">
+                    <Layers className="mr-2 h-4 w-4" />
+                    <span>Connectors</span>
+                  </div>
+                </SelectItem>
+                <SelectItem value="sensor">
+                  <div className="flex items-center">
+                    <LucideBellElectric className="mr-2 h-4 w-4" />
+                    <span>Sensors</span>
+                  </div>
+                </SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          <Tabs
+            defaultValue="all"
+            onValueChange={setActiveTab}
+            className="mb-4"
+          >
+            <TabsList className="w-full">
+              <TabsTrigger
+                value="all"
+                className="flex-1 text-xs sm:text-sm px-1 sm:px-2"
+              >
+                All
+              </TabsTrigger>
+              <TabsTrigger
+                value="board"
+                className="flex-1 text-xs sm:text-sm px-1 sm:px-2"
+              >
+                <Box className="h-3 w-3 sm:h-3.5 sm:w-3.5 mr-0.5 sm:mr-1 hidden sm:inline" />
+                Board
+              </TabsTrigger>
+              <TabsTrigger
+                value="package"
+                className="flex-1 text-xs sm:text-sm px-1 sm:px-2"
+              >
+                <Box className="h-3 w-3 sm:h-3.5 sm:w-3.5 mr-0.5 sm:mr-1 hidden sm:inline" />
+                Package
+              </TabsTrigger>
+              <TabsTrigger
+                value="footprint"
+                className="flex-1 text-xs sm:text-sm px-1 sm:px-2"
+              >
+                <Footprints className="h-3 w-3 sm:h-3.5 sm:w-3.5 mr-0.5 sm:mr-1 hidden sm:inline" />
+                Footprint
+              </TabsTrigger>
+              <TabsTrigger
+                value="model"
+                className="flex-1 text-xs sm:text-sm px-1 sm:px-2"
+              >
+                <Layers className="h-3 w-3 sm:h-3.5 sm:w-3.5 mr-0.5 sm:mr-1 hidden sm:inline" />
+                Model
+              </TabsTrigger>
+            </TabsList>
+          </Tabs>
         </div>
 
         {isLoading ? (
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
-            {[...Array(8)].map((_, i) => (
-              <div
-                key={i}
-                className="bg-white rounded-lg shadow-sm border border-gray-200 p-4 h-64 animate-pulse"
-              >
-                <div className="h-4 bg-gray-200 rounded w-3/4 mb-4"></div>
-                <div className="h-32 bg-gray-200 rounded mb-4"></div>
-                <div className="h-4 bg-gray-200 rounded w-1/2"></div>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            {[...Array(6)].map((_, i) => (
+              <div key={i} className="border p-4 rounded-md animate-pulse">
+                <div className="flex items-start gap-4">
+                  <div className="h-16 w-16 flex-shrink-0 rounded-md bg-slate-200"></div>
+                  <div className="flex-1">
+                    <div className="h-5 bg-slate-200 rounded w-3/4 mb-2"></div>
+                    <div className="h-4 bg-slate-200 rounded w-1/2 mb-2"></div>
+                    <div className="flex gap-2">
+                      <div className="h-3 bg-slate-200 rounded w-16"></div>
+                      <div className="h-3 bg-slate-200 rounded w-16"></div>
+                    </div>
+                  </div>
+                </div>
               </div>
             ))}
           </div>
         ) : error ? (
-          <div className="bg-red-50 border border-red-200 text-red-700 p-4 rounded-md">
-            <h3 className="text-lg font-semibold mb-2">
-              Error Loading Snippets
+          <div className="bg-red-50 border border-red-200 text-red-700 p-6 rounded-xl shadow-sm max-w-2xl mx-auto">
+            <div className="flex items-start">
+              <div className="mr-4 bg-red-100 p-2 rounded-full">
+                <Search className="w-6 h-6 text-red-600" />
+              </div>
+              <div>
+                <h3 className="text-lg font-semibold mb-2">
+                  Error Loading Snippets
+                </h3>
+                <p className="text-red-600">
+                  We couldn't load the trending snippets. Please try again
+                  later.
+                </p>
+              </div>
+            </div>
+          </div>
+        ) : filteredByTypeSnippets?.length === 0 ? (
+          <div className="text-center py-12 px-4">
+            <div className="bg-slate-50 inline-flex rounded-full p-4 mb-4">
+              <Search className="w-8 h-8 text-slate-400" />
+            </div>
+            <h3 className="text-xl font-medium text-slate-900 mb-2">
+              No Matching Snippets
             </h3>
-            <p>
-              We couldn't load the trending snippets. Please try again later.
+            <p className="text-slate-500 max-w-md mx-auto mb-6">
+              {searchQuery
+                ? `No snippets match your search for "${searchQuery}".`
+                : category !== "all"
+                  ? `No ${category} snippets found in the trending list.`
+                  : activeTab !== "all"
+                    ? `No ${activeTab} snippets found in the trending list.`
+                    : "There are no trending snippets at the moment."}
             </p>
           </div>
         ) : (
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
-            {snippets?.map((snippet) => (
-              <Link
-                key={snippet.snippet_id}
-                href={`/${snippet.owner_name}/${snippet.unscoped_name}`}
-                className="group"
-              >
-                <div className="bg-white rounded-lg shadow-sm border border-gray-200 hover:border-blue-400 hover:shadow-md transition-all duration-200 overflow-hidden h-full flex flex-col">
-                  <div className="p-4 pb-2">
-                    <h3 className="font-medium text-blue-600 mb-1 truncate group-hover:underline">
-                      {snippet.owner_name}/{snippet.unscoped_name}
-                    </h3>
-                  </div>
-                  <div className="flex-grow bg-black p-2 relative overflow-hidden">
-                    <OptimizedImage
-                      src={`${apiBaseUrl}/snippets/images/${snippet.owner_name}/${snippet.unscoped_name}/pcb.svg`}
-                      alt="PCB preview"
-                      className="w-full h-full object-contain scale-[3] rotate-45 group-hover:scale-[3.5] transition-transform duration-300"
-                    />
-                  </div>
-                  <div className="p-4 pt-2 flex items-center justify-between">
-                    <div className="flex items-center text-sm text-gray-500">
-                      <Star className="w-4 h-4 mr-1 text-yellow-500" />
-                      <span>{snippet.star_count || 0} stars</span>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            {filteredByTypeSnippets
+              ?.sort((a, b) => b.updated_at.localeCompare(a.updated_at))
+              ?.map((snippet) => (
+                <Link
+                  key={snippet.snippet_id}
+                  href={`/${snippet.owner_name}/${snippet.unscoped_name}`}
+                >
+                  <div className="border p-4 rounded-md hover:shadow-md transition-shadow flex flex-col gap-4">
+                    <div className="flex items-start gap-4">
+                      <div className="h-16 w-16 flex-shrink-0 rounded-md overflow-hidden">
+                        <OptimizedImage
+                          src={`${apiBaseUrl}/snippets/images/${snippet.owner_name}/${snippet.unscoped_name}/pcb.svg`}
+                          alt={`${snippet.owner_name}'s profile`}
+                          className="object-cover h-full w-full transition-transform duration-300 -rotate-45 hover:rotate-0 hover:scale-110 scale-150"
+                        />
+                      </div>
+                      <div className="flex-1 min-w-0">
+                        <div className="flex justify-between items-start mb-[2px] -mt-[3px]">
+                          <h2 className="text-md font-semibold truncate pr-[30px]">
+                            <span className="text-gray-700 text-md">
+                              {snippet.owner_name}
+                            </span>
+                            <span className="mx-1">/</span>
+                            <span className="text-gray-900">
+                              {snippet.unscoped_name}
+                            </span>
+                          </h2>
+                          <div className="flex items-center gap-2">
+                            <SnippetTypeIcon
+                              type={snippet.snippet_type}
+                              className="pt-[2.5px]"
+                            />
+                            <div className="flex items-center gap-1 text-gray-600">
+                              <StarIcon className="w-4 h-4 pt-[2.5px]" />
+                              <span className="text-[16px]">
+                                {snippet.star_count || 0}
+                              </span>
+                            </div>
+                          </div>
+                        </div>
+                        <p
+                          className={`${
+                            !snippet.description &&
+                            !(snippet as any).ai_description &&
+                            "h-[1.25rem]"
+                          } text-sm text-gray-500 mb-1 truncate max-w-xs`}
+                        >
+                          {snippet.description ||
+                            (snippet as any).ai_description ||
+                            "No description provided yet"}
+                        </p>
+                        <div className={`flex items-center gap-4`}>
+                          {snippet.is_private ? (
+                            <div className="flex items-center text-xs gap-1 text-gray-500">
+                              <LockClosedIcon height={12} width={12} />
+                              <span>Private</span>
+                            </div>
+                          ) : (
+                            <div className="flex items-center text-xs gap-1 text-gray-500">
+                              <GlobeIcon height={12} width={12} />
+                              <span>Public</span>
+                            </div>
+                          )}
+                          <div className="flex items-center text-xs gap-1 text-gray-500">
+                            <PencilIcon height={12} width={12} />
+                            <span>{timeAgo(new Date(snippet.updated_at))}</span>
+                          </div>
+                        </div>
+                      </div>
                     </div>
-                    <div className="text-xs text-gray-400">
-                      {new Date(snippet.created_at).toLocaleDateString()}
-                    </div>
                   </div>
-                </div>
-              </Link>
-            ))}
+                </Link>
+              ))}
           </div>
         )}
       </main>

--- a/src/pages/trending.tsx
+++ b/src/pages/trending.tsx
@@ -31,6 +31,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
+import { SnippetCard } from "@/components/SnippetCard"
 
 const TrendingPage: React.FC = () => {
   const axios = useAxios()
@@ -203,75 +204,12 @@ const TrendingPage: React.FC = () => {
             {filteredSnippets
               ?.sort((a, b) => b.updated_at.localeCompare(a.updated_at))
               ?.map((snippet) => (
-                <Link
+                <SnippetCard
                   key={snippet.snippet_id}
-                  href={`/${snippet.owner_name}/${snippet.unscoped_name}`}
-                >
-                  <div className="border p-4 rounded-md hover:shadow-md transition-shadow flex flex-col gap-4">
-                    <div className="flex items-start gap-4">
-                      <div className="h-16 w-16 flex-shrink-0 rounded-md overflow-hidden">
-                        <OptimizedImage
-                          src={`${apiBaseUrl}/snippets/images/${snippet.owner_name}/${snippet.unscoped_name}/pcb.svg`}
-                          alt={`${snippet.owner_name}'s profile`}
-                          className="object-cover h-full w-full transition-transform duration-300 -rotate-45 hover:rotate-0 hover:scale-110 scale-150"
-                        />
-                      </div>
-                      <div className="flex-1 min-w-0">
-                        <div className="flex justify-between items-start mb-[2px] -mt-[3px]">
-                          <h2 className="text-md font-semibold truncate pr-[30px]">
-                            <span className="text-gray-700 text-md">
-                              {snippet.owner_name}
-                            </span>
-                            <span className="mx-1">/</span>
-                            <span className="text-gray-900">
-                              {snippet.unscoped_name}
-                            </span>
-                          </h2>
-                          <div className="flex items-center gap-2">
-                            <SnippetTypeIcon
-                              type={snippet.snippet_type}
-                              className="pt-[2.5px]"
-                            />
-                            <div className="flex items-center gap-1 text-gray-600">
-                              <StarIcon className="w-4 h-4 pt-[2.5px]" />
-                              <span className="text-[16px]">
-                                {snippet.star_count || 0}
-                              </span>
-                            </div>
-                          </div>
-                        </div>
-                        <p
-                          className={`${
-                            !snippet.description &&
-                            !(snippet as any).ai_description &&
-                            "h-[1.25rem]"
-                          } text-sm text-gray-500 mb-1 truncate max-w-xs`}
-                        >
-                          {snippet.description ||
-                            (snippet as any).ai_description ||
-                            "No description provided yet"}
-                        </p>
-                        <div className={`flex items-center gap-4`}>
-                          {snippet.is_private ? (
-                            <div className="flex items-center text-xs gap-1 text-gray-500">
-                              <LockClosedIcon height={12} width={12} />
-                              <span>Private</span>
-                            </div>
-                          ) : (
-                            <div className="flex items-center text-xs gap-1 text-gray-500">
-                              <GlobeIcon height={12} width={12} />
-                              <span>Public</span>
-                            </div>
-                          )}
-                          <div className="flex items-center text-xs gap-1 text-gray-500">
-                            <PencilIcon height={12} width={12} />
-                            <span>{timeAgo(new Date(snippet.updated_at))}</span>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </Link>
+                  snippet={snippet}
+                  baseUrl={apiBaseUrl}
+                  showOwner={true}
+                />
               ))}
           </div>
         )}

--- a/src/pages/user-profile.tsx
+++ b/src/pages/user-profile.tsx
@@ -5,25 +5,15 @@ import { useAxios } from "@/hooks/use-axios"
 import Header from "@/components/Header"
 import Footer from "@/components/Footer"
 import { Snippet } from "fake-snippets-api/lib/db/schema"
-import { Link } from "wouter"
 import { Button } from "@/components/ui/button"
-import { GitHubLogoIcon, StarIcon, LockClosedIcon } from "@radix-ui/react-icons"
+import { GitHubLogoIcon } from "@radix-ui/react-icons"
 import { Input } from "@/components/ui/input"
 import { useGlobalStore } from "@/hooks/use-global-store"
-import { GlobeIcon, MoreVertical, PencilIcon, Trash2 } from "lucide-react"
 import { useConfirmDeleteSnippetDialog } from "@/components/dialogs/confirm-delete-snippet-dialog"
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar"
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu"
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
-import { OptimizedImage } from "@/components/OptimizedImage"
 import { useSnippetsBaseApiUrl } from "@/hooks/use-snippets-base-api-url"
-import { SnippetTypeIcon } from "@/components/SnippetTypeIcon"
-import { timeAgo } from "@/lib/utils/timeAgo"
+import { SnippetCard } from "@/components/SnippetCard"
 
 export const UserProfilePage = () => {
   const { username } = useParams()
@@ -132,97 +122,16 @@ export const UserProfilePage = () => {
             {filteredSnippets
               ?.sort((a, b) => b.updated_at.localeCompare(a.updated_at))
               ?.map((snippet) => (
-                <Link
+                <SnippetCard
                   key={snippet.snippet_id}
-                  href={`/${snippet.owner_name}/${snippet.unscoped_name}`}
-                >
-                  <div className="border p-4 rounded-md hover:shadow-md transition-shadow flex flex-col gap-4">
-                    <div className="flex items-start gap-4">
-                      <div className="h-16 w-16 flex-shrink-0 rounded-md overflow-hidden">
-                        <OptimizedImage
-                          src={`${baseUrl}/snippets/images/${snippet.owner_name}/${snippet.unscoped_name}/pcb.svg`}
-                          alt={`${snippet.owner_name}'s profile`}
-                          className="object-cover h-full w-full transition-transform duration-300 -rotate-45 hover:rotate-0 hover:scale-110 scale-150"
-                        />
-                      </div>
-                      <div className="flex-1 min-w-0">
-                        <div className="flex justify-between items-start mb-[2px] -mt-[3px]">
-                          <h2 className="text-md font-semibold truncate pr-[30px]">
-                            {activeTab === "starred" && (
-                              <>
-                                <span className="text-gray-700 text-md">
-                                  {snippet.owner_name}
-                                </span>
-                                <span className="mx-1">/</span>
-                              </>
-                            )}
-                            <span className="text-gray-900">
-                              {snippet.unscoped_name}
-                            </span>
-                          </h2>
-                          <div className="flex items-center gap-2">
-                            <SnippetTypeIcon
-                              type={snippet.snippet_type}
-                              className="pt-[2.5px]"
-                            />
-                            <div className="flex items-center gap-1 text-gray-600">
-                              <StarIcon className="w-4 h-4 pt-[2.5px]" />
-                              <span className="text-[16px]">
-                                {snippet.star_count || 0}
-                              </span>
-                            </div>
-                            {isCurrentUserProfile && activeTab === "all" && (
-                              <DropdownMenu>
-                                <DropdownMenuTrigger asChild>
-                                  <Button
-                                    variant="ghost"
-                                    size="icon"
-                                    className="h-[1.5rem] w-[1.5rem]"
-                                  >
-                                    <MoreVertical className="h-4 w-4" />
-                                  </Button>
-                                </DropdownMenuTrigger>
-                                <DropdownMenuContent>
-                                  <DropdownMenuItem
-                                    className="text-xs text-red-600"
-                                    onClick={(e) =>
-                                      handleDeleteClick(e, snippet)
-                                    }
-                                  >
-                                    <Trash2 className="mr-2 h-3 w-3" />
-                                    Delete Snippet
-                                  </DropdownMenuItem>
-                                </DropdownMenuContent>
-                              </DropdownMenu>
-                            )}
-                          </div>
-                        </div>
-                        <p
-                          className={`${!snippet.description && "h-[1.25rem]"} text-sm text-gray-500 mb-1 truncate max-w-xs`}
-                        >
-                          {snippet.description ? snippet.description : " "}
-                        </p>
-                        <div className={`flex items-center gap-4`}>
-                          {snippet.is_private ? (
-                            <div className="flex items-center text-xs gap-1 text-gray-500">
-                              <LockClosedIcon height={12} width={12} />
-                              <span>Private</span>
-                            </div>
-                          ) : (
-                            <div className="flex items-center text-xs gap-1 text-gray-500">
-                              <GlobeIcon height={12} width={12} />
-                              <span>Public</span>
-                            </div>
-                          )}
-                          <div className="flex items-center text-xs gap-1 text-gray-500">
-                            <PencilIcon height={12} width={12} />
-                            <span>{timeAgo(new Date(snippet.updated_at))}</span>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </Link>
+                  snippet={snippet}
+                  baseUrl={baseUrl}
+                  showOwner={activeTab === "starred"}
+                  isCurrentUserSnippet={
+                    isCurrentUserProfile && activeTab === "all"
+                  }
+                  onDeleteClick={handleDeleteClick}
+                />
               ))}
           </div>
         )}


### PR DESCRIPTION
Introduce a new page to showcase the most popular snippets from the last 7 days. The page includes a loading state, error handling, and a grid layout for displaying snippets with their star counts and creation dates. This enhances user engagement by providing insights into trending content.

# Since asked for same as profile


![image](https://github.com/user-attachments/assets/622264a6-6f59-4604-9437-4db755aa13de)

![image](https://github.com/user-attachments/assets/62bef836-6743-4207-9703-eecc2b39fb6d)


_outdated text below_
---

![image](https://github.com/user-attachments/assets/c317fed0-795f-4a69-bca2-f6a21cfed27d)


## another opt

![image](https://github.com/user-attachments/assets/ffde03d8-3c30-4b2f-85c9-ff20f772d109)


###### /claim #469