### PR TITLE
refactor(Footer): remove "Create with AI" from list and add as standalone link

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -26,7 +26,6 @@ export default function Footer() {
                 { name: "Home", href: "/" },
                 { name: "Dashboard", href: "/dashboard" },
                 { name: "Editor", href: "/editor" },
-                { name: "Create with AI", href: "https://chat.tscircuit.com" },
                 {
                   name: "My Profile",
                   href: `/${session?.github_username}`,
@@ -44,6 +43,13 @@ export default function Footer() {
                     {item.name}
                   </PrefetchPageLink>
                 ))}
+              <a
+                href="https://chat.tscircuit.com"
+                className="hover:underline"
+                target="_blank"
+              >
+                Create with AI
+              </a>
             </footer>
           </div>
 


### PR DESCRIPTION
The "Create with AI" link was moved from the list of navigation items to a standalone link in the footer. This change improves the layout and ensures the link opens in a new tab for better user experience.

# fixes this


https://github.com/user-attachments/assets/4427e452-121c-43f6-b36e-8fabac791579

