### PR TITLE
feat(package_files): add CRUD operations for package files

### DIFF
--- a/bun-tests/fake-snippets-api/routes/package_files/create_or_update.test.ts
+++ b/bun-tests/fake-snippets-api/routes/package_files/create_or_update.test.ts
@@ -1,0 +1,578 @@
+import { getTestServer } from "bun-tests/fake-snippets-api/fixtures/get-test-server"
+import { expect, test } from "bun:test"
+
+test("create new package file with content_text", async () => {
+  const { axios } = await getTestServer()
+
+  // First create a package
+  const packageResponse = await axios.post("/api/packages/create", {
+    name: "@test/package-files-create-or-update",
+    description: "A test package for creating or updating files",
+  })
+  expect(packageResponse.status).toBe(200)
+  const createdPackage = packageResponse.data.package
+
+  // Create a package release
+  const releaseResponse = await axios.post("/api/package_releases/create", {
+    package_id: createdPackage.package_id,
+    version: "1.0.0",
+    is_latest: true,
+  })
+  expect(releaseResponse.status).toBe(200)
+  const createdRelease = releaseResponse.data.package_release
+
+  // Create a package file
+  const fileContent = "console.log('Hello, world!');"
+  const filePath = "/index.js"
+  const createResponse = await axios.post(
+    "/api/package_files/create_or_update",
+    {
+      package_release_id: createdRelease.package_release_id,
+      file_path: filePath,
+      content_text: fileContent,
+    },
+  )
+
+  expect(createResponse.status).toBe(200)
+  const responseBody = createResponse.data
+  expect(responseBody.ok).toBe(true)
+  expect(responseBody.package_file).toBeDefined()
+  expect(responseBody.package_file.package_release_id).toBe(
+    createdRelease.package_release_id,
+  )
+  expect(responseBody.package_file.file_path).toBe(filePath)
+  expect(responseBody.package_file.content_text).toBe(fileContent)
+
+  // Verify the file can be retrieved using the get endpoint
+  const getResponse = await axios.post("/api/package_files/get", {
+    package_file_id: responseBody.package_file.package_file_id,
+  })
+  expect(getResponse.status).toBe(200)
+  expect(getResponse.data.package_file.file_path).toBe(filePath)
+})
+
+test("update existing package file with content_text", async () => {
+  const { axios } = await getTestServer()
+
+  // First create a package
+  const packageResponse = await axios.post("/api/packages/create", {
+    name: "@test/package-files-update",
+    description: "A test package for updating files",
+  })
+  expect(packageResponse.status).toBe(200)
+  const createdPackage = packageResponse.data.package
+
+  // Create a package release
+  const releaseResponse = await axios.post("/api/package_releases/create", {
+    package_id: createdPackage.package_id,
+    version: "1.0.0",
+    is_latest: true,
+  })
+  expect(releaseResponse.status).toBe(200)
+  const createdRelease = releaseResponse.data.package_release
+
+  // Create a package file
+  const initialContent = "console.log('Initial content');"
+  const filePath = "/script.js"
+  const createResponse = await axios.post(
+    "/api/package_files/create_or_update",
+    {
+      package_release_id: createdRelease.package_release_id,
+      file_path: filePath,
+      content_text: initialContent,
+    },
+  )
+  expect(createResponse.status).toBe(200)
+  const initialFile = createResponse.data.package_file
+
+  // Update the file
+  const updatedContent = "console.log('Updated content');"
+  const updateResponse = await axios.post(
+    "/api/package_files/create_or_update",
+    {
+      package_release_id: createdRelease.package_release_id,
+      file_path: filePath,
+      content_text: updatedContent,
+    },
+  )
+
+  expect(updateResponse.status).toBe(200)
+  const responseBody = updateResponse.data
+  expect(responseBody.ok).toBe(true)
+  expect(responseBody.package_file).toBeDefined()
+  expect(responseBody.package_file.package_file_id).toBe(
+    initialFile.package_file_id,
+  )
+  expect(responseBody.package_file.package_release_id).toBe(
+    createdRelease.package_release_id,
+  )
+  expect(responseBody.package_file.file_path).toBe(filePath)
+  expect(responseBody.package_file.content_text).toBe(updatedContent)
+
+  // Verify the file was updated using the get endpoint
+  const getResponse = await axios.post("/api/package_files/get", {
+    package_file_id: responseBody.package_file.package_file_id,
+  })
+  expect(getResponse.status).toBe(200)
+  expect(getResponse.data.package_file.file_path).toBe(filePath)
+})
+
+test("create package file with content_base64", async () => {
+  const { axios } = await getTestServer()
+
+  // First create a package
+  const packageResponse = await axios.post("/api/packages/create", {
+    name: "@test/package-files-create-or-update-base64",
+    description: "A test package for creating files with base64",
+  })
+  expect(packageResponse.status).toBe(200)
+  const createdPackage = packageResponse.data.package
+
+  // Create a package release
+  const releaseResponse = await axios.post("/api/package_releases/create", {
+    package_id: createdPackage.package_id,
+    version: "1.0.0",
+    is_latest: true,
+  })
+  expect(releaseResponse.status).toBe(200)
+  const createdRelease = releaseResponse.data.package_release
+
+  // Create a package file with base64 content
+  const fileContent = "export const sum = (a, b) => a + b;"
+  const base64Content = Buffer.from(fileContent).toString("base64")
+  const filePath = "/utils.js"
+  const createResponse = await axios.post(
+    "/api/package_files/create_or_update",
+    {
+      package_release_id: createdRelease.package_release_id,
+      file_path: filePath,
+      content_base64: base64Content,
+    },
+  )
+
+  expect(createResponse.status).toBe(200)
+  const responseBody = createResponse.data
+  expect(responseBody.ok).toBe(true)
+  expect(responseBody.package_file).toBeDefined()
+  expect(responseBody.package_file.file_path).toBe(filePath)
+  expect(responseBody.package_file.content_text).toBe(fileContent)
+
+  // Verify the file can be retrieved using the get endpoint
+  const getResponse = await axios.post("/api/package_files/get", {
+    package_file_id: responseBody.package_file.package_file_id,
+  })
+  expect(getResponse.status).toBe(200)
+  expect(getResponse.data.package_file.file_path).toBe(filePath)
+})
+
+test("create package file using package_name_with_version", async () => {
+  const { axios } = await getTestServer()
+
+  // First create a package
+  const packageName = "@test/package-files-create-or-update-by-name"
+  const version = "2.0.0"
+  const packageResponse = await axios.post("/api/packages/create", {
+    name: packageName,
+    description: "A test package for creating files by name",
+  })
+  expect(packageResponse.status).toBe(200)
+  const createdPackage = packageResponse.data.package
+
+  // Create a package release
+  const releaseResponse = await axios.post("/api/package_releases/create", {
+    package_id: createdPackage.package_id,
+    version,
+    is_latest: true,
+  })
+  expect(releaseResponse.status).toBe(200)
+
+  // Create a package file using package_name_with_version
+  const fileContent = "# README\nThis is a test package."
+  const filePath = "/README.md"
+  const createResponse = await axios.post(
+    "/api/package_files/create_or_update",
+    {
+      package_name_with_version: `${packageName}@${version}`,
+      file_path: filePath,
+      content_text: fileContent,
+    },
+  )
+
+  expect(createResponse.status).toBe(200)
+  const responseBody = createResponse.data
+  expect(responseBody.ok).toBe(true)
+  expect(responseBody.package_file).toBeDefined()
+  expect(responseBody.package_file.file_path).toBe(filePath)
+  expect(responseBody.package_file.content_text).toBe(fileContent)
+
+  // Verify the file can be retrieved using the list endpoint
+  const listResponse = await axios.post("/api/package_files/list", {
+    package_name_with_version: `${packageName}@${version}`,
+  })
+  expect(listResponse.status).toBe(200)
+  expect(listResponse.data.ok).toBe(true)
+  expect(listResponse.data.package_files.length).toBeGreaterThan(0)
+  const foundFile = listResponse.data.package_files.find(
+    (file: any) => file.file_path === filePath,
+  )
+  expect(foundFile).toBeDefined()
+})
+
+test("create release tarball package file", async () => {
+  const { axios } = await getTestServer()
+
+  // First create a package
+  const packageResponse = await axios.post("/api/packages/create", {
+    name: "@test/package-files-create-or-update-tarball",
+    description: "A test package for creating tarball files",
+  })
+  expect(packageResponse.status).toBe(200)
+  const createdPackage = packageResponse.data.package
+
+  // Create a package release
+  const releaseResponse = await axios.post("/api/package_releases/create", {
+    package_id: createdPackage.package_id,
+    version: "1.0.0",
+    is_latest: true,
+  })
+  expect(releaseResponse.status).toBe(200)
+  const createdRelease = releaseResponse.data.package_release
+
+  // Create a release tarball package file
+  const npmPackOutput = { filename: "test-1.0.0.tgz", size: 1024 }
+  const createResponse = await axios.post(
+    "/api/package_files/create_or_update",
+    {
+      package_release_id: createdRelease.package_release_id,
+      file_path: "/test-1.0.0.tgz",
+      content_text: "tarball content",
+      is_release_tarball: true,
+      npm_pack_output: npmPackOutput,
+    },
+  )
+
+  expect(createResponse.status).toBe(200)
+  const responseBody = createResponse.data
+  expect(responseBody.ok).toBe(true)
+  expect(responseBody.package_file).toBeDefined()
+  expect(responseBody.package_file.package_release_id).toBe(
+    createdRelease.package_release_id,
+  )
+  expect(responseBody.package_file.file_path).toBe("/test-1.0.0.tgz")
+  expect(responseBody.package_file.content_text).toBe("tarball content")
+  expect(responseBody.package_file.is_release_tarball).toBe(true)
+  expect(responseBody.package_file.npm_pack_output).toEqual(npmPackOutput)
+})
+
+test("create_or_update - 404 for non-existent package release", async () => {
+  const { axios } = await getTestServer()
+
+  try {
+    await axios.post("/api/package_files/create_or_update", {
+      package_release_id: "non-existent-id",
+      file_path: "/test.js",
+      content_text: "console.log('test');",
+    })
+    throw new Error("Expected request to fail")
+  } catch (error: any) {
+    expect(error.status).toBe(404)
+    expect(error.data.error.error_code).toBe("package_release_not_found")
+    expect(error.data.error.message).toBe("Package release not found")
+  }
+})
+
+test("create_or_update - 404 for non-existent package", async () => {
+  const { axios } = await getTestServer()
+
+  try {
+    await axios.post("/api/package_files/create_or_update", {
+      package_name_with_version: "non-existent-package@1.0.0",
+      file_path: "/test.js",
+      content_text: "console.log('test');",
+    })
+    throw new Error("Expected request to fail")
+  } catch (error: any) {
+    expect(error.status).toBe(404)
+    expect(error.data.error.error_code).toBe("package_release_not_found")
+    expect(error.data.error.message).toBe("Package release not found")
+  }
+})
+
+test("create_or_update - 400 for missing content", async () => {
+  const { axios } = await getTestServer()
+
+  // First create a package and release
+  const packageResponse = await axios.post("/api/packages/create", {
+    name: "@test/package-files-create-or-update-error",
+    description: "A test package for error cases",
+  })
+  const createdPackage = packageResponse.data.package
+
+  const releaseResponse = await axios.post("/api/package_releases/create", {
+    package_id: createdPackage.package_id,
+    version: "1.0.0",
+  })
+  const createdRelease = releaseResponse.data.package_release
+
+  try {
+    await axios.post("/api/package_files/create_or_update", {
+      package_release_id: createdRelease.package_release_id,
+      file_path: "/test.js",
+      // Missing both content_text and content_base64
+    })
+    throw new Error("Expected request to fail")
+  } catch (error: any) {
+    expect(error.status).toBe(400)
+    expect(error.data.message).toContain("content")
+  }
+})
+
+test("create_or_update - 400 for both content_text and content_base64", async () => {
+  const { axios } = await getTestServer()
+
+  // First create a package and release
+  const packageResponse = await axios.post("/api/packages/create", {
+    name: "@test/package-files-create-or-update-error-2",
+    description: "Another test package for error cases",
+  })
+  const createdPackage = packageResponse.data.package
+
+  const releaseResponse = await axios.post("/api/package_releases/create", {
+    package_id: createdPackage.package_id,
+    version: "1.0.0",
+  })
+  const createdRelease = releaseResponse.data.package_release
+
+  try {
+    await axios.post("/api/package_files/create_or_update", {
+      package_release_id: createdRelease.package_release_id,
+      file_path: "/test.js",
+      content_text: "console.log('test');",
+      content_base64: "Y29uc29sZS5sb2coJ3Rlc3QnKTs=", // Both content_text and content_base64
+    })
+    throw new Error("Expected request to fail")
+  } catch (error: any) {
+    expect(error.status).toBe(400)
+    expect(error.data.message).toContain("content")
+  }
+})
+
+test("create_or_update - 400 for release tarball without npm_pack_output", async () => {
+  const { axios } = await getTestServer()
+
+  // First create a package and release
+  const packageResponse = await axios.post("/api/packages/create", {
+    name: "@test/package-files-create-or-update-tarball-error",
+    description: "Test package for tarball error cases",
+  })
+  const createdPackage = packageResponse.data.package
+
+  const releaseResponse = await axios.post("/api/package_releases/create", {
+    package_id: createdPackage.package_id,
+    version: "1.0.0",
+  })
+  const createdRelease = releaseResponse.data.package_release
+
+  try {
+    await axios.post("/api/package_files/create_or_update", {
+      package_release_id: createdRelease.package_release_id,
+      file_path: "/test-1.0.0.tgz",
+      content_text: "tarball content",
+      is_release_tarball: true,
+      // Missing npm_pack_output
+    })
+    throw new Error("Expected request to fail")
+  } catch (error: any) {
+    expect(error.status).toBe(400)
+    expect(error.data.error.error_code).toBe("missing_options")
+    expect(error.data.error.message).toBe(
+      "npm_pack_output is required for release tarballs",
+    )
+  }
+})
+
+test("create_or_update - 404 for npm_pack_output without is_release_tarball", async () => {
+  const { axios } = await getTestServer()
+
+  // First create a package and release
+  const packageResponse = await axios.post("/api/packages/create", {
+    name: "@test/package-files-create-or-update-tarball-error-2",
+    description: "Test package for tarball error cases",
+  })
+  const createdPackage = packageResponse.data.package
+
+  const releaseResponse = await axios.post("/api/package_releases/create", {
+    package_id: createdPackage.package_id,
+    version: "1.0.0",
+  })
+  const createdRelease = releaseResponse.data.package_release
+
+  try {
+    await axios.post("/api/package_files/create_or_update", {
+      package_release_id: createdRelease.package_release_id,
+      file_path: "/test.js",
+      content_text: "console.log('test');",
+      npm_pack_output: { filename: "test.tgz", size: 1024 },
+      // Missing is_release_tarball: true
+    })
+    throw new Error("Expected request to fail")
+  } catch (error: any) {
+    expect(error.status).toBe(404)
+    expect(error.data.error.error_code).toBe("invalid_options")
+    expect(error.data.error.message).toBe(
+      "npm_pack_output is only valid for release tarballs",
+    )
+  }
+})
+
+test("update package file with content_base64", async () => {
+  const { axios } = await getTestServer()
+
+  // First create a package
+  const packageResponse = await axios.post("/api/packages/create", {
+    name: "@test/package-files-update-base64",
+    description: "A test package for updating files with base64",
+  })
+  expect(packageResponse.status).toBe(200)
+  const createdPackage = packageResponse.data.package
+
+  // Create a package release
+  const releaseResponse = await axios.post("/api/package_releases/create", {
+    package_id: createdPackage.package_id,
+    version: "1.0.0",
+    is_latest: true,
+  })
+  expect(releaseResponse.status).toBe(200)
+  const createdRelease = releaseResponse.data.package_release
+
+  // Create a package file
+  const initialContent = "console.log('Initial content');"
+  const filePath = "/script.js"
+  const createResponse = await axios.post(
+    "/api/package_files/create_or_update",
+    {
+      package_release_id: createdRelease.package_release_id,
+      file_path: filePath,
+      content_text: initialContent,
+    },
+  )
+  expect(createResponse.status).toBe(200)
+  const initialFile = createResponse.data.package_file
+
+  // Update the file with base64 content
+  const updatedContent = "console.log('Updated with base64');"
+  const base64Content = Buffer.from(updatedContent).toString("base64")
+  const updateResponse = await axios.post(
+    "/api/package_files/create_or_update",
+    {
+      package_release_id: createdRelease.package_release_id,
+      file_path: filePath,
+      content_base64: base64Content,
+    },
+  )
+
+  expect(updateResponse.status).toBe(200)
+  const responseBody = updateResponse.data
+  expect(responseBody.ok).toBe(true)
+  expect(responseBody.package_file).toBeDefined()
+  expect(responseBody.package_file.package_file_id).toBe(
+    initialFile.package_file_id,
+  )
+  expect(responseBody.package_file.content_text).toBe(updatedContent)
+
+  // Verify the file was updated using the get endpoint
+  const getResponse = await axios.post("/api/package_files/get", {
+    package_file_id: responseBody.package_file.package_file_id,
+  })
+  expect(getResponse.status).toBe(200)
+  expect(getResponse.data.package_file.file_path).toBe(filePath)
+})
+
+test("create_or_update detects correct content mimetype", async () => {
+  const { axios } = await getTestServer()
+
+  // First create a package
+  const packageResponse = await axios.post("/api/packages/create", {
+    name: "@test/package-files-mimetype",
+    description: "A test package for testing mimetypes",
+  })
+  expect(packageResponse.status).toBe(200)
+  const createdPackage = packageResponse.data.package
+
+  // Create a package release
+  const releaseResponse = await axios.post("/api/package_releases/create", {
+    package_id: createdPackage.package_id,
+    version: "1.0.0",
+    is_latest: true,
+  })
+  expect(releaseResponse.status).toBe(200)
+  const createdRelease = releaseResponse.data.package_release
+
+  // Test different file extensions
+  const testCases = [
+    { ext: ".ts", path: "/file.ts", expected: "text/typescript" },
+    { ext: ".tsx", path: "/file.tsx", expected: "text/typescript" },
+    { ext: ".js", path: "/file.js", expected: "application/javascript" },
+    { ext: ".json", path: "/file.json", expected: "application/json" },
+    { ext: ".md", path: "/file.md", expected: "text/markdown" },
+    { ext: ".html", path: "/file.html", expected: "text/html" },
+    { ext: ".css", path: "/file.css", expected: "text/css" },
+    {
+      ext: ".unknown",
+      path: "/file.unknown",
+      expected: "application/octet-stream",
+    },
+  ]
+
+  for (const testCase of testCases) {
+    const createResponse = await axios.post(
+      "/api/package_files/create_or_update",
+      {
+        package_release_id: createdRelease.package_release_id,
+        file_path: testCase.path,
+        content_text: `Test content for ${testCase.ext} file`,
+      },
+    )
+
+    expect(createResponse.status).toBe(200)
+    expect(createResponse.data.package_file.content_mimetype).toBe(
+      testCase.expected,
+    )
+  }
+})
+
+test("create_or_update respects provided content_mimetype", async () => {
+  const { axios } = await getTestServer()
+
+  // First create a package
+  const packageResponse = await axios.post("/api/packages/create", {
+    name: "@test/package-files-custom-mimetype",
+    description: "A test package for custom mimetypes",
+  })
+  expect(packageResponse.status).toBe(200)
+  const createdPackage = packageResponse.data.package
+
+  // Create a package release
+  const releaseResponse = await axios.post("/api/package_releases/create", {
+    package_id: createdPackage.package_id,
+    version: "1.0.0",
+    is_latest: true,
+  })
+  expect(releaseResponse.status).toBe(200)
+  const createdRelease = releaseResponse.data.package_release
+
+  // Create a file with custom mimetype
+  const customMimetype = "application/custom+json"
+  const createResponse = await axios.post(
+    "/api/package_files/create_or_update",
+    {
+      package_release_id: createdRelease.package_release_id,
+      file_path: "/data.json",
+      content_text: '{"custom":true}',
+      content_mimetype: customMimetype,
+    },
+  )
+
+  expect(createResponse.status).toBe(200)
+  expect(createResponse.data.package_file.content_mimetype).toBe(customMimetype)
+})

--- a/bun-tests/fake-snippets-api/routes/package_files/create_or_update.test.ts
+++ b/bun-tests/fake-snippets-api/routes/package_files/create_or_update.test.ts
@@ -4,7 +4,6 @@ import { expect, test } from "bun:test"
 test("create new package file with content_text", async () => {
   const { axios } = await getTestServer()
 
-  // First create a package
   const packageResponse = await axios.post("/api/packages/create", {
     name: "@test/package-files-create-or-update",
     description: "A test package for creating or updating files",
@@ -12,7 +11,6 @@ test("create new package file with content_text", async () => {
   expect(packageResponse.status).toBe(200)
   const createdPackage = packageResponse.data.package
 
-  // Create a package release
   const releaseResponse = await axios.post("/api/package_releases/create", {
     package_id: createdPackage.package_id,
     version: "1.0.0",
@@ -21,7 +19,6 @@ test("create new package file with content_text", async () => {
   expect(releaseResponse.status).toBe(200)
   const createdRelease = releaseResponse.data.package_release
 
-  // Create a package file
   const fileContent = "console.log('Hello, world!');"
   const filePath = "/index.js"
   const createResponse = await axios.post(
@@ -43,7 +40,6 @@ test("create new package file with content_text", async () => {
   expect(responseBody.package_file.file_path).toBe(filePath)
   expect(responseBody.package_file.content_text).toBe(fileContent)
 
-  // Verify the file can be retrieved using the get endpoint
   const getResponse = await axios.post("/api/package_files/get", {
     package_file_id: responseBody.package_file.package_file_id,
   })
@@ -54,7 +50,6 @@ test("create new package file with content_text", async () => {
 test("update existing package file with content_text", async () => {
   const { axios } = await getTestServer()
 
-  // First create a package
   const packageResponse = await axios.post("/api/packages/create", {
     name: "@test/package-files-update",
     description: "A test package for updating files",
@@ -62,7 +57,6 @@ test("update existing package file with content_text", async () => {
   expect(packageResponse.status).toBe(200)
   const createdPackage = packageResponse.data.package
 
-  // Create a package release
   const releaseResponse = await axios.post("/api/package_releases/create", {
     package_id: createdPackage.package_id,
     version: "1.0.0",
@@ -71,7 +65,6 @@ test("update existing package file with content_text", async () => {
   expect(releaseResponse.status).toBe(200)
   const createdRelease = releaseResponse.data.package_release
 
-  // Create a package file
   const initialContent = "console.log('Initial content');"
   const filePath = "/script.js"
   const createResponse = await axios.post(
@@ -85,7 +78,6 @@ test("update existing package file with content_text", async () => {
   expect(createResponse.status).toBe(200)
   const initialFile = createResponse.data.package_file
 
-  // Update the file
   const updatedContent = "console.log('Updated content');"
   const updateResponse = await axios.post(
     "/api/package_files/create_or_update",
@@ -109,7 +101,6 @@ test("update existing package file with content_text", async () => {
   expect(responseBody.package_file.file_path).toBe(filePath)
   expect(responseBody.package_file.content_text).toBe(updatedContent)
 
-  // Verify the file was updated using the get endpoint
   const getResponse = await axios.post("/api/package_files/get", {
     package_file_id: responseBody.package_file.package_file_id,
   })
@@ -120,7 +111,6 @@ test("update existing package file with content_text", async () => {
 test("create package file with content_base64", async () => {
   const { axios } = await getTestServer()
 
-  // First create a package
   const packageResponse = await axios.post("/api/packages/create", {
     name: "@test/package-files-create-or-update-base64",
     description: "A test package for creating files with base64",
@@ -128,7 +118,6 @@ test("create package file with content_base64", async () => {
   expect(packageResponse.status).toBe(200)
   const createdPackage = packageResponse.data.package
 
-  // Create a package release
   const releaseResponse = await axios.post("/api/package_releases/create", {
     package_id: createdPackage.package_id,
     version: "1.0.0",
@@ -137,7 +126,6 @@ test("create package file with content_base64", async () => {
   expect(releaseResponse.status).toBe(200)
   const createdRelease = releaseResponse.data.package_release
 
-  // Create a package file with base64 content
   const fileContent = "export const sum = (a, b) => a + b;"
   const base64Content = Buffer.from(fileContent).toString("base64")
   const filePath = "/utils.js"
@@ -157,7 +145,6 @@ test("create package file with content_base64", async () => {
   expect(responseBody.package_file.file_path).toBe(filePath)
   expect(responseBody.package_file.content_text).toBe(fileContent)
 
-  // Verify the file can be retrieved using the get endpoint
   const getResponse = await axios.post("/api/package_files/get", {
     package_file_id: responseBody.package_file.package_file_id,
   })
@@ -168,7 +155,6 @@ test("create package file with content_base64", async () => {
 test("create package file using package_name_with_version", async () => {
   const { axios } = await getTestServer()
 
-  // First create a package
   const packageName = "@test/package-files-create-or-update-by-name"
   const version = "2.0.0"
   const packageResponse = await axios.post("/api/packages/create", {
@@ -178,7 +164,6 @@ test("create package file using package_name_with_version", async () => {
   expect(packageResponse.status).toBe(200)
   const createdPackage = packageResponse.data.package
 
-  // Create a package release
   const releaseResponse = await axios.post("/api/package_releases/create", {
     package_id: createdPackage.package_id,
     version,
@@ -186,7 +171,6 @@ test("create package file using package_name_with_version", async () => {
   })
   expect(releaseResponse.status).toBe(200)
 
-  // Create a package file using package_name_with_version
   const fileContent = "# README\nThis is a test package."
   const filePath = "/README.md"
   const createResponse = await axios.post(
@@ -205,7 +189,6 @@ test("create package file using package_name_with_version", async () => {
   expect(responseBody.package_file.file_path).toBe(filePath)
   expect(responseBody.package_file.content_text).toBe(fileContent)
 
-  // Verify the file can be retrieved using the list endpoint
   const listResponse = await axios.post("/api/package_files/list", {
     package_name_with_version: `${packageName}@${version}`,
   })
@@ -221,7 +204,6 @@ test("create package file using package_name_with_version", async () => {
 test("create release tarball package file", async () => {
   const { axios } = await getTestServer()
 
-  // First create a package
   const packageResponse = await axios.post("/api/packages/create", {
     name: "@test/package-files-create-or-update-tarball",
     description: "A test package for creating tarball files",
@@ -229,7 +211,6 @@ test("create release tarball package file", async () => {
   expect(packageResponse.status).toBe(200)
   const createdPackage = packageResponse.data.package
 
-  // Create a package release
   const releaseResponse = await axios.post("/api/package_releases/create", {
     package_id: createdPackage.package_id,
     version: "1.0.0",
@@ -238,7 +219,6 @@ test("create release tarball package file", async () => {
   expect(releaseResponse.status).toBe(200)
   const createdRelease = releaseResponse.data.package_release
 
-  // Create a release tarball package file
   const npmPackOutput = { filename: "test-1.0.0.tgz", size: 1024 }
   const createResponse = await axios.post(
     "/api/package_files/create_or_update",
@@ -301,7 +281,6 @@ test("create_or_update - 404 for non-existent package", async () => {
 test("create_or_update - 400 for missing content", async () => {
   const { axios } = await getTestServer()
 
-  // First create a package and release
   const packageResponse = await axios.post("/api/packages/create", {
     name: "@test/package-files-create-or-update-error",
     description: "A test package for error cases",
@@ -318,7 +297,6 @@ test("create_or_update - 400 for missing content", async () => {
     await axios.post("/api/package_files/create_or_update", {
       package_release_id: createdRelease.package_release_id,
       file_path: "/test.js",
-      // Missing both content_text and content_base64
     })
     throw new Error("Expected request to fail")
   } catch (error: any) {
@@ -330,7 +308,6 @@ test("create_or_update - 400 for missing content", async () => {
 test("create_or_update - 400 for both content_text and content_base64", async () => {
   const { axios } = await getTestServer()
 
-  // First create a package and release
   const packageResponse = await axios.post("/api/packages/create", {
     name: "@test/package-files-create-or-update-error-2",
     description: "Another test package for error cases",
@@ -348,7 +325,7 @@ test("create_or_update - 400 for both content_text and content_base64", async ()
       package_release_id: createdRelease.package_release_id,
       file_path: "/test.js",
       content_text: "console.log('test');",
-      content_base64: "Y29uc29sZS5sb2coJ3Rlc3QnKTs=", // Both content_text and content_base64
+      content_base64: "Y29uc29sZS5sb2coJ3Rlc3QnKTs=",
     })
     throw new Error("Expected request to fail")
   } catch (error: any) {
@@ -360,7 +337,6 @@ test("create_or_update - 400 for both content_text and content_base64", async ()
 test("create_or_update - 400 for release tarball without npm_pack_output", async () => {
   const { axios } = await getTestServer()
 
-  // First create a package and release
   const packageResponse = await axios.post("/api/packages/create", {
     name: "@test/package-files-create-or-update-tarball-error",
     description: "Test package for tarball error cases",
@@ -379,7 +355,6 @@ test("create_or_update - 400 for release tarball without npm_pack_output", async
       file_path: "/test-1.0.0.tgz",
       content_text: "tarball content",
       is_release_tarball: true,
-      // Missing npm_pack_output
     })
     throw new Error("Expected request to fail")
   } catch (error: any) {
@@ -394,7 +369,6 @@ test("create_or_update - 400 for release tarball without npm_pack_output", async
 test("create_or_update - 404 for npm_pack_output without is_release_tarball", async () => {
   const { axios } = await getTestServer()
 
-  // First create a package and release
   const packageResponse = await axios.post("/api/packages/create", {
     name: "@test/package-files-create-or-update-tarball-error-2",
     description: "Test package for tarball error cases",
@@ -413,7 +387,6 @@ test("create_or_update - 404 for npm_pack_output without is_release_tarball", as
       file_path: "/test.js",
       content_text: "console.log('test');",
       npm_pack_output: { filename: "test.tgz", size: 1024 },
-      // Missing is_release_tarball: true
     })
     throw new Error("Expected request to fail")
   } catch (error: any) {
@@ -428,7 +401,6 @@ test("create_or_update - 404 for npm_pack_output without is_release_tarball", as
 test("update package file with content_base64", async () => {
   const { axios } = await getTestServer()
 
-  // First create a package
   const packageResponse = await axios.post("/api/packages/create", {
     name: "@test/package-files-update-base64",
     description: "A test package for updating files with base64",
@@ -436,7 +408,6 @@ test("update package file with content_base64", async () => {
   expect(packageResponse.status).toBe(200)
   const createdPackage = packageResponse.data.package
 
-  // Create a package release
   const releaseResponse = await axios.post("/api/package_releases/create", {
     package_id: createdPackage.package_id,
     version: "1.0.0",
@@ -445,7 +416,6 @@ test("update package file with content_base64", async () => {
   expect(releaseResponse.status).toBe(200)
   const createdRelease = releaseResponse.data.package_release
 
-  // Create a package file
   const initialContent = "console.log('Initial content');"
   const filePath = "/script.js"
   const createResponse = await axios.post(
@@ -459,7 +429,6 @@ test("update package file with content_base64", async () => {
   expect(createResponse.status).toBe(200)
   const initialFile = createResponse.data.package_file
 
-  // Update the file with base64 content
   const updatedContent = "console.log('Updated with base64');"
   const base64Content = Buffer.from(updatedContent).toString("base64")
   const updateResponse = await axios.post(
@@ -480,7 +449,6 @@ test("update package file with content_base64", async () => {
   )
   expect(responseBody.package_file.content_text).toBe(updatedContent)
 
-  // Verify the file was updated using the get endpoint
   const getResponse = await axios.post("/api/package_files/get", {
     package_file_id: responseBody.package_file.package_file_id,
   })
@@ -491,7 +459,6 @@ test("update package file with content_base64", async () => {
 test("create_or_update detects correct content mimetype", async () => {
   const { axios } = await getTestServer()
 
-  // First create a package
   const packageResponse = await axios.post("/api/packages/create", {
     name: "@test/package-files-mimetype",
     description: "A test package for testing mimetypes",
@@ -499,7 +466,6 @@ test("create_or_update detects correct content mimetype", async () => {
   expect(packageResponse.status).toBe(200)
   const createdPackage = packageResponse.data.package
 
-  // Create a package release
   const releaseResponse = await axios.post("/api/package_releases/create", {
     package_id: createdPackage.package_id,
     version: "1.0.0",
@@ -508,7 +474,6 @@ test("create_or_update detects correct content mimetype", async () => {
   expect(releaseResponse.status).toBe(200)
   const createdRelease = releaseResponse.data.package_release
 
-  // Test different file extensions
   const testCases = [
     { ext: ".ts", path: "/file.ts", expected: "text/typescript" },
     { ext: ".tsx", path: "/file.tsx", expected: "text/typescript" },
@@ -544,7 +509,6 @@ test("create_or_update detects correct content mimetype", async () => {
 test("create_or_update respects provided content_mimetype", async () => {
   const { axios } = await getTestServer()
 
-  // First create a package
   const packageResponse = await axios.post("/api/packages/create", {
     name: "@test/package-files-custom-mimetype",
     description: "A test package for custom mimetypes",
@@ -552,7 +516,6 @@ test("create_or_update respects provided content_mimetype", async () => {
   expect(packageResponse.status).toBe(200)
   const createdPackage = packageResponse.data.package
 
-  // Create a package release
   const releaseResponse = await axios.post("/api/package_releases/create", {
     package_id: createdPackage.package_id,
     version: "1.0.0",
@@ -561,7 +524,6 @@ test("create_or_update respects provided content_mimetype", async () => {
   expect(releaseResponse.status).toBe(200)
   const createdRelease = releaseResponse.data.package_release
 
-  // Create a file with custom mimetype
   const customMimetype = "application/custom+json"
   const createResponse = await axios.post(
     "/api/package_files/create_or_update",
@@ -575,4 +537,39 @@ test("create_or_update respects provided content_mimetype", async () => {
 
   expect(createResponse.status).toBe(200)
   expect(createResponse.data.package_file.content_mimetype).toBe(customMimetype)
+})
+
+test("create_or_update - 403 for unauthorized user", async () => {
+  const { axios, db } = await getTestServer()
+
+  const pkg = {
+    name: "@test/package-files-create-or-update-unauthorized",
+    owner_org_id: "different-org",
+    created_at: "2023-01-01T00:00:00Z",
+    updated_at: "2023-01-01T00:00:00Z",
+    description: "A test package for unauthorized create/update",
+  }
+  const addedPackage: any = db.addPackage(pkg as any)
+
+  const releaseResponse = await axios.post("/api/package_releases/create", {
+    package_id: addedPackage.package_id,
+    version: "1.0.0",
+  })
+  expect(releaseResponse.status).toBe(200)
+  const createdRelease = releaseResponse.data.package_release
+
+  try {
+    await axios.post("/api/package_files/create_or_update", {
+      package_release_id: createdRelease.package_release_id,
+      file_path: "/test.js",
+      content_text: "console.log('test');",
+    })
+    throw new Error("Expected request to fail")
+  } catch (error: any) {
+    expect(error.status).toBe(403)
+    expect(error.data.error.error_code).toBe("forbidden")
+    expect(error.data.error.message).toBe(
+      "You don't have permission to modify files in this package",
+    )
+  }
 })

--- a/bun-tests/fake-snippets-api/routes/package_files/delete.test.ts
+++ b/bun-tests/fake-snippets-api/routes/package_files/delete.test.ts
@@ -1,0 +1,168 @@
+import { getTestServer } from "bun-tests/fake-snippets-api/fixtures/get-test-server"
+import { expect, test } from "bun:test"
+
+test("delete package file using package_release_id", async () => {
+  const { axios } = await getTestServer()
+
+  // First create a package
+  const packageResponse = await axios.post("/api/packages/create", {
+    name: "@test/package-files-delete",
+    description: "A test package for deleting files",
+  })
+  expect(packageResponse.status).toBe(200)
+  const createdPackage = packageResponse.data.package
+
+  // Create a package release
+  const releaseResponse = await axios.post("/api/package_releases/create", {
+    package_id: createdPackage.package_id,
+    version: "1.0.0",
+    is_latest: true,
+  })
+  expect(releaseResponse.status).toBe(200)
+  const createdRelease = releaseResponse.data.package_release
+
+  // Create a package file
+  const filePath = "/index.js"
+  const createResponse = await axios.post("/api/package_files/create", {
+    package_release_id: createdRelease.package_release_id,
+    file_path: filePath,
+    content_text: "console.log('Hello, world!');",
+  })
+  expect(createResponse.status).toBe(200)
+  const createdFile = createResponse.data.package_file
+
+  // Delete the file
+  const deleteResponse = await axios.post("/api/package_files/delete", {
+    package_release_id: createdRelease.package_release_id,
+    file_path: filePath,
+  })
+
+  expect(deleteResponse.status).toBe(200)
+  expect(deleteResponse.data.ok).toBe(true)
+
+  // Verify the file is deleted by trying to get it
+  try {
+    await axios.post("/api/package_files/get", {
+      package_file_id: createdFile.package_file_id,
+    })
+    throw new Error("Expected request to fail")
+  } catch (error: any) {
+    expect(error.status).toBe(404)
+    expect(error.data.message).toBe("Package file not found")
+  }
+})
+
+test("delete package file using package_name_with_version", async () => {
+  const { axios } = await getTestServer()
+
+  // First create a package
+  const packageName = "@test/package-files-delete-by-name"
+  const version = "2.0.0"
+  const packageResponse = await axios.post("/api/packages/create", {
+    name: packageName,
+    description: "A test package for deleting files by name",
+  })
+  expect(packageResponse.status).toBe(200)
+  const createdPackage = packageResponse.data.package
+
+  // Create a package release
+  const releaseResponse = await axios.post("/api/package_releases/create", {
+    package_id: createdPackage.package_id,
+    version,
+    is_latest: true,
+  })
+  expect(releaseResponse.status).toBe(200)
+
+  // Create a package file
+  const filePath = "/README.md"
+  const createResponse = await axios.post("/api/package_files/create", {
+    package_name_with_version: `${packageName}@${version}`,
+    file_path: filePath,
+    content_text: "# Test Package\nThis is a test package.",
+  })
+  expect(createResponse.status).toBe(200)
+  const createdFile = createResponse.data.package_file
+
+  // Delete the file using package_name_with_version
+  const deleteResponse = await axios.post("/api/package_files/delete", {
+    package_name_with_version: `${packageName}@${version}`,
+    file_path: filePath,
+  })
+
+  expect(deleteResponse.status).toBe(200)
+  expect(deleteResponse.data.ok).toBe(true)
+
+  // Verify the file is deleted
+  try {
+    await axios.post("/api/package_files/get", {
+      package_file_id: createdFile.package_file_id,
+    })
+    throw new Error("Expected request to fail")
+  } catch (error: any) {
+    expect(error.status).toBe(404)
+    expect(error.data.message).toBe("Package file not found")
+  }
+})
+
+test("delete package file - 404 for non-existent package name", async () => {
+  const { axios } = await getTestServer()
+
+  try {
+    await axios.post("/api/package_files/delete", {
+      package_name_with_version: "non-existent-id",
+      file_path: "/test.js",
+    })
+  } catch (error: any) {
+    expect(error.status).toBe(404)
+    expect(error.data.error.error_code).toBe("package_release_not_found")
+    expect(error.data.error.message).toBe("Package release not found")
+  }
+})
+
+test("delete package file - 404 for non-existent package", async () => {
+  const { axios } = await getTestServer()
+
+  try {
+    await axios.post("/api/package_files/delete", {
+      package_name_with_version: "non-existent-package@1.0.0",
+      file_path: "/test.js",
+    })
+    throw new Error("Expected request to fail")
+  } catch (error: any) {
+    expect(error.status).toBe(404)
+    expect(error.data.error.error_code).toBe("package_release_not_found")
+    expect(error.data.error.message).toBe("Package release not found")
+  }
+})
+
+test("delete package file - 404 for non-existent file", async () => {
+  const { axios } = await getTestServer()
+
+  // First create a package
+  const packageResponse = await axios.post("/api/packages/create", {
+    name: "@test/package-files-delete-error",
+    description: "A test package for delete error cases",
+  })
+  expect(packageResponse.status).toBe(200)
+  const createdPackage = packageResponse.data.package
+
+  // Create a package release
+  const releaseResponse = await axios.post("/api/package_releases/create", {
+    package_id: createdPackage.package_id,
+    version: "1.0.0",
+  })
+  expect(releaseResponse.status).toBe(200)
+  const createdRelease = releaseResponse.data.package_release
+
+  try {
+    await axios.post("/api/package_files/delete", {
+      package_release_id: createdRelease.package_release_id,
+      file_path: "/non-existent-file.js",
+    })
+    throw new Error("Expected request to fail")
+  } catch (error: any) {
+    expect(error.status).toBe(404)
+    expect(error.data.error.error_code).toBe("file_not_found")
+    expect(error.data.error.message).toBe("Package file not found")
+  }
+})

--- a/bun-tests/fake-snippets-api/routes/package_files/delete.test.ts
+++ b/bun-tests/fake-snippets-api/routes/package_files/delete.test.ts
@@ -4,7 +4,6 @@ import { expect, test } from "bun:test"
 test("delete package file using package_release_id", async () => {
   const { axios } = await getTestServer()
 
-  // First create a package
   const packageResponse = await axios.post("/api/packages/create", {
     name: "@test/package-files-delete",
     description: "A test package for deleting files",
@@ -12,7 +11,6 @@ test("delete package file using package_release_id", async () => {
   expect(packageResponse.status).toBe(200)
   const createdPackage = packageResponse.data.package
 
-  // Create a package release
   const releaseResponse = await axios.post("/api/package_releases/create", {
     package_id: createdPackage.package_id,
     version: "1.0.0",
@@ -21,7 +19,6 @@ test("delete package file using package_release_id", async () => {
   expect(releaseResponse.status).toBe(200)
   const createdRelease = releaseResponse.data.package_release
 
-  // Create a package file
   const filePath = "/index.js"
   const createResponse = await axios.post("/api/package_files/create", {
     package_release_id: createdRelease.package_release_id,
@@ -31,7 +28,6 @@ test("delete package file using package_release_id", async () => {
   expect(createResponse.status).toBe(200)
   const createdFile = createResponse.data.package_file
 
-  // Delete the file
   const deleteResponse = await axios.post("/api/package_files/delete", {
     package_release_id: createdRelease.package_release_id,
     file_path: filePath,
@@ -40,7 +36,6 @@ test("delete package file using package_release_id", async () => {
   expect(deleteResponse.status).toBe(200)
   expect(deleteResponse.data.ok).toBe(true)
 
-  // Verify the file is deleted by trying to get it
   try {
     await axios.post("/api/package_files/get", {
       package_file_id: createdFile.package_file_id,
@@ -55,7 +50,6 @@ test("delete package file using package_release_id", async () => {
 test("delete package file using package_name_with_version", async () => {
   const { axios } = await getTestServer()
 
-  // First create a package
   const packageName = "@test/package-files-delete-by-name"
   const version = "2.0.0"
   const packageResponse = await axios.post("/api/packages/create", {
@@ -65,7 +59,6 @@ test("delete package file using package_name_with_version", async () => {
   expect(packageResponse.status).toBe(200)
   const createdPackage = packageResponse.data.package
 
-  // Create a package release
   const releaseResponse = await axios.post("/api/package_releases/create", {
     package_id: createdPackage.package_id,
     version,
@@ -73,7 +66,6 @@ test("delete package file using package_name_with_version", async () => {
   })
   expect(releaseResponse.status).toBe(200)
 
-  // Create a package file
   const filePath = "/README.md"
   const createResponse = await axios.post("/api/package_files/create", {
     package_name_with_version: `${packageName}@${version}`,
@@ -83,7 +75,6 @@ test("delete package file using package_name_with_version", async () => {
   expect(createResponse.status).toBe(200)
   const createdFile = createResponse.data.package_file
 
-  // Delete the file using package_name_with_version
   const deleteResponse = await axios.post("/api/package_files/delete", {
     package_name_with_version: `${packageName}@${version}`,
     file_path: filePath,
@@ -92,7 +83,6 @@ test("delete package file using package_name_with_version", async () => {
   expect(deleteResponse.status).toBe(200)
   expect(deleteResponse.data.ok).toBe(true)
 
-  // Verify the file is deleted
   try {
     await axios.post("/api/package_files/get", {
       package_file_id: createdFile.package_file_id,
@@ -138,7 +128,6 @@ test("delete package file - 404 for non-existent package", async () => {
 test("delete package file - 404 for non-existent file", async () => {
   const { axios } = await getTestServer()
 
-  // First create a package
   const packageResponse = await axios.post("/api/packages/create", {
     name: "@test/package-files-delete-error",
     description: "A test package for delete error cases",
@@ -146,7 +135,6 @@ test("delete package file - 404 for non-existent file", async () => {
   expect(packageResponse.status).toBe(200)
   const createdPackage = packageResponse.data.package
 
-  // Create a package release
   const releaseResponse = await axios.post("/api/package_releases/create", {
     package_id: createdPackage.package_id,
     version: "1.0.0",
@@ -170,17 +158,15 @@ test("delete package file - 404 for non-existent file", async () => {
 test("delete package file - 403 for unauthorized user", async () => {
   const { axios, db } = await getTestServer()
 
-  // Create a package with a different owner
   const pkg = {
     name: "@test/package-files-delete-unauthorized",
-    owner_org_id: "different-org", // Different from the personal_org_id in auth
+    owner_org_id: "different-org",
     created_at: "2023-01-01T00:00:00Z",
     updated_at: "2023-01-01T00:00:00Z",
     description: "A test package for unauthorized delete",
   }
   const addedPackage: any = db.addPackage(pkg as any)
 
-  // Create a package release
   const releaseResponse = await axios.post("/api/package_releases/create", {
     package_id: addedPackage.package_id,
     version: "1.0.0",
@@ -188,7 +174,6 @@ test("delete package file - 403 for unauthorized user", async () => {
   expect(releaseResponse.status).toBe(200)
   const createdRelease = releaseResponse.data.package_release
 
-  // Create a package file
   const filePath = "/test.js"
   const createResponse = await axios.post("/api/package_files/create", {
     package_release_id: createdRelease.package_release_id,
@@ -197,7 +182,6 @@ test("delete package file - 403 for unauthorized user", async () => {
   })
   expect(createResponse.status).toBe(200)
 
-  // Attempt to delete the file as an unauthorized user
   try {
     await axios.post("/api/package_files/delete", {
       package_release_id: createdRelease.package_release_id,

--- a/bun-tests/fake-snippets-api/routes/package_files/delete.test.ts
+++ b/bun-tests/fake-snippets-api/routes/package_files/delete.test.ts
@@ -196,3 +196,38 @@ test("delete package file - 403 for unauthorized user", async () => {
     )
   }
 })
+
+test("delete package file - 400 when neither package_release_id nor package_name_with_version is provided", async () => {
+  const { axios } = await getTestServer()
+
+  try {
+    await axios.post("/api/package_files/delete", {
+      file_path: "/test.js",
+    })
+    throw new Error("Expected request to fail")
+  } catch (error: any) {
+    console.log(59, error)
+    expect(error.status).toBe(400)
+    expect(error.data.message).toInclude(
+      "Must specify either package_release_id or package_name_with_version",
+    )
+  }
+})
+
+test("delete package file - 400 when both package_release_id and package_name_with_version are provided", async () => {
+  const { axios } = await getTestServer()
+
+  try {
+    await axios.post("/api/package_files/delete", {
+      package_release_id: "some-id",
+      package_name_with_version: "@test/package@1.0.0",
+      file_path: "/test.js",
+    })
+    throw new Error("Expected request to fail")
+  } catch (error: any) {
+    expect(error.status).toBe(400)
+    expect(error.data.message).toInclude(
+      "Cannot specify both package_release_id and package_name_with_version",
+    )
+  }
+})

--- a/fake-snippets-api/lib/db/db-client.ts
+++ b/fake-snippets-api/lib/db/db-client.ts
@@ -1147,6 +1147,20 @@ const initializer = combine(databaseSchema.parse({}), (set, get) => ({
       ),
     }))
   },
+  deletePackageFile: (packageFileId: string): boolean => {
+    let deleted = false
+    set((state) => {
+      const index = state.packageFiles.findIndex(
+        (file) => file.package_file_id === packageFileId,
+      )
+      if (index !== -1) {
+        state.packageFiles.splice(index, 1)
+        deleted = true
+      }
+      return state
+    })
+    return deleted
+  },
   addPackageFile: (
     packageFile: Omit<PackageFile, "package_file_id">,
   ): PackageFile => {
@@ -1158,6 +1172,20 @@ const initializer = combine(databaseSchema.parse({}), (set, get) => ({
       packageFiles: [...state.packageFiles, newPackageFile],
     }))
     return newPackageFile
+  },
+  updatePackageFile: (
+    packageFileId: string,
+    updates: Partial<Omit<PackageFile, "package_file_id">>,
+  ): PackageFile => {
+    set((state) => ({
+      packageFiles: state.packageFiles.map((file) =>
+        file.package_file_id === packageFileId ? { ...file, ...updates } : file,
+      ),
+    }))
+    const state = get()
+    return state.packageFiles.find(
+      (file) => file.package_file_id === packageFileId,
+    )!
   },
   getStarCount: (packageId: string): number => {
     const state = get()

--- a/fake-snippets-api/lib/db/schema.ts
+++ b/fake-snippets-api/lib/db/schema.ts
@@ -138,6 +138,9 @@ export const packageFileSchema = z.object({
   file_path: z.string(),
   content_text: z.string().nullable().optional(),
   created_at: z.string().datetime(),
+  content_mimetype: z.string().nullable().optional(),
+  is_release_tarball: z.boolean().optional(),
+  npm_pack_output: z.any().nullable().optional(),
 })
 export type PackageFile = z.infer<typeof packageFileSchema>
 

--- a/fake-snippets-api/routes/api/package_files/create_or_update.ts
+++ b/fake-snippets-api/routes/api/package_files/create_or_update.ts
@@ -1,0 +1,159 @@
+import * as zt from "fake-snippets-api/lib/db/schema"
+import { findPackageReleaseId } from "fake-snippets-api/lib/package_release/find-package-release-id"
+import { withRouteSpec } from "fake-snippets-api/lib/with-winter-spec"
+import { z } from "zod"
+
+const routeSpec = {
+  methods: ["POST"],
+  auth: "none",
+  jsonBody: z
+    .object({
+      file_path: z.string(),
+      is_release_tarball: z.boolean().optional().default(false),
+      content_mimetype: z.string().optional(),
+      content_text: z.string().optional(),
+      content_base64: z.string().optional(),
+      package_release_id: z.string().optional(),
+      package_name_with_version: z.string().optional(),
+      npm_pack_output: z.any().optional(),
+    })
+    .refine((v) => {
+      if (v.package_release_id) return true
+      if (v.package_name_with_version) return true
+      return false
+    }, "Must specify either package_release_id or package_name_with_version")
+    .refine((v) => {
+      if (v.package_release_id && v.package_name_with_version) return false
+      return true
+    }, "Cannot specify both package_release_id and package_name_with_version")
+    .refine((v) => {
+      if (v.content_base64 && v.content_text) return false
+      if (!v.content_base64 && !v.content_text) return false
+      return true
+    }, "Either content_base64 or content_text is required"),
+  jsonResponse: z.object({
+    ok: z.boolean(),
+    package_file: zt.packageFileSchema,
+  }),
+} as const
+
+export default withRouteSpec(routeSpec)(async (req, ctx) => {
+  const {
+    file_path,
+    content_mimetype: providedContentMimetype,
+    content_base64,
+    content_text,
+    is_release_tarball,
+    npm_pack_output,
+  } = req.jsonBody
+
+  if (is_release_tarball && !npm_pack_output) {
+    return ctx.error(400, {
+      error_code: "missing_options",
+      message: "npm_pack_output is required for release tarballs",
+    })
+  }
+
+  if (!is_release_tarball && npm_pack_output) {
+    return ctx.error(404, {
+      error_code: "invalid_options",
+      message: "npm_pack_output is only valid for release tarballs",
+    })
+  }
+
+  let packageReleaseId = req.jsonBody.package_release_id
+
+  if (!packageReleaseId && req.jsonBody.package_name_with_version) {
+    const foundPackageReleaseId = await findPackageReleaseId(
+      req.jsonBody.package_name_with_version,
+      ctx,
+    )
+    if (foundPackageReleaseId) {
+      packageReleaseId = foundPackageReleaseId
+    }
+  }
+
+  if (!packageReleaseId) {
+    return ctx.error(404, {
+      error_code: "package_release_not_found",
+      message: "Package release not found",
+    })
+  }
+
+  // Verify the package release exists
+  const packageRelease = ctx.db.packageReleases.find(
+    (pr) => pr.package_release_id === packageReleaseId,
+  )
+
+  if (!packageRelease) {
+    return ctx.error(404, {
+      error_code: "package_release_not_found",
+      message: "Package release not found",
+    })
+  }
+
+  // Check if file exists
+  const exisitingFile = ctx.db.packageFiles.find(
+    (pf) =>
+      pf.package_release_id === packageReleaseId && pf.file_path === file_path,
+  )
+
+  // Determine content mimetype
+  const contentMimetype =
+    providedContentMimetype ||
+    (file_path.endsWith(".ts") || file_path.endsWith(".tsx")
+      ? "text/typescript"
+      : null) ||
+    (file_path.endsWith(".js") ? "application/javascript" : null) ||
+    (file_path.endsWith(".json") ? "application/json" : null) ||
+    (file_path.endsWith(".md") ? "text/markdown" : null) ||
+    (file_path.endsWith(".html") ? "text/html" : null) ||
+    (file_path.endsWith(".css") ? "text/css" : null) ||
+    "application/octet-stream"
+
+  if (exisitingFile) {
+    const package_file = ctx.db.updatePackageFile(
+      exisitingFile.package_file_id,
+      {
+        content_text:
+          content_text ||
+          (content_base64
+            ? Buffer.from(content_base64, "base64").toString()
+            : null),
+        content_mimetype: contentMimetype,
+        is_release_tarball: is_release_tarball || false,
+        npm_pack_output: npm_pack_output || null,
+      },
+    )
+
+    return ctx.json({
+      ok: true,
+      package_file,
+    })
+  }
+
+  // Create the package file
+  const newPackageFile = {
+    package_file_id: crypto.randomUUID(),
+    package_release_id: packageReleaseId,
+    file_path,
+    content_text:
+      content_text ||
+      (content_base64
+        ? Buffer.from(content_base64, "base64").toString()
+        : null),
+    content_mimetype: contentMimetype,
+    is_directory: false,
+    is_release_tarball: is_release_tarball || false,
+    npm_pack_output: npm_pack_output || null,
+    created_at: new Date().toISOString(),
+  }
+
+  // Add to the test database
+  ctx.db.addPackageFile(newPackageFile)
+
+  return ctx.json({
+    ok: true,
+    package_file: newPackageFile,
+  })
+})

--- a/fake-snippets-api/routes/api/package_files/delete.ts
+++ b/fake-snippets-api/routes/api/package_files/delete.ts
@@ -5,11 +5,21 @@ import { findPackageReleaseId } from "fake-snippets-api/lib/package_release/find
 export default withRouteSpec({
   methods: ["POST"],
   auth: "session",
-  jsonBody: z.object({
-    package_release_id: z.string().optional(),
-    package_name_with_version: z.string().optional(),
-    file_path: z.string(),
-  }),
+  jsonBody: z
+    .object({
+      package_release_id: z.string().optional(),
+      package_name_with_version: z.string().optional(),
+      file_path: z.string(),
+    })
+    .refine((v) => {
+      if (v.package_release_id) return true
+      if (v.package_name_with_version) return true
+      return false
+    }, "Must specify either package_release_id or package_name_with_version")
+    .refine((v) => {
+      if (v.package_release_id && v.package_name_with_version) return false
+      return true
+    }, "Cannot specify both package_release_id and package_name_with_version"),
   jsonResponse: z.object({
     ok: z.boolean(),
   }),

--- a/fake-snippets-api/routes/api/package_files/delete.ts
+++ b/fake-snippets-api/routes/api/package_files/delete.ts
@@ -35,6 +35,38 @@ export default withRouteSpec({
     })
   }
 
+  // Get the package release to check permissions
+  const packageRelease = ctx.db.packageReleases.find(
+    (pr) => pr.package_release_id === packageReleaseId,
+  )
+
+  if (!packageRelease) {
+    return ctx.error(404, {
+      error_code: "package_release_not_found",
+      message: "Package release not found",
+    })
+  }
+
+  // Get the package to check permissions
+  const existingpackage = ctx.db.packages.find(
+    (p) => p.package_id === packageRelease.package_id,
+  )
+
+  if (!existingpackage) {
+    return ctx.error(404, {
+      error_code: "package_not_found",
+      message: "Package not found",
+    })
+  }
+
+  // Check if user has permission to delete the file
+  if (existingpackage.creator_account_id !== ctx.auth.account_id) {
+    return ctx.error(403, {
+      error_code: "forbidden",
+      message: "You don't have permission to delete files in this package",
+    })
+  }
+
   // Find the file
   const packageFile = ctx.db.packageFiles.find(
     (f) =>

--- a/fake-snippets-api/routes/api/package_files/delete.ts
+++ b/fake-snippets-api/routes/api/package_files/delete.ts
@@ -1,0 +1,64 @@
+import { withRouteSpec } from "fake-snippets-api/lib/middleware/with-winter-spec"
+import { z } from "zod"
+import { findPackageReleaseId } from "fake-snippets-api/lib/package_release/find-package-release-id"
+
+export default withRouteSpec({
+  methods: ["POST"],
+  auth: "session",
+  jsonBody: z.object({
+    package_release_id: z.string().optional(),
+    package_name_with_version: z.string().optional(),
+    file_path: z.string(),
+  }),
+  jsonResponse: z.object({
+    ok: z.boolean(),
+  }),
+})(async (req, ctx) => {
+  const { file_path } = req.jsonBody
+
+  let packageReleaseId = req.jsonBody.package_release_id
+
+  if (!packageReleaseId && req.jsonBody.package_name_with_version) {
+    const foundPackageReleaseId = await findPackageReleaseId(
+      req.jsonBody.package_name_with_version,
+      ctx,
+    )
+    if (foundPackageReleaseId) {
+      packageReleaseId = foundPackageReleaseId
+    }
+  }
+
+  if (!packageReleaseId) {
+    return ctx.error(404, {
+      error_code: "package_release_not_found",
+      message: "Package release not found",
+    })
+  }
+
+  // Find the file
+  const packageFile = ctx.db.packageFiles.find(
+    (f) =>
+      f.file_path === file_path && f.package_release_id === packageReleaseId,
+  )
+
+  if (!packageFile) {
+    return ctx.error(404, {
+      error_code: "file_not_found",
+      message: "Package file not found",
+    })
+  }
+
+  // Delete the file using deletePackageFile method
+  const deleted = ctx.db.deletePackageFile(packageFile.package_file_id)
+
+  if (!deleted) {
+    return ctx.error(500, {
+      error_code: "file_deletion_failed",
+      message: "Failed to delete package file",
+    })
+  }
+
+  return ctx.json({
+    ok: true,
+  })
+})


### PR DESCRIPTION
Introduce new functionality to create, update, and delete package files. This includes:
- Adding new fields to the package file schema (`content_mimetype`, `is_release_tarball`, `npm_pack_output`).
- Implementing `deletePackageFile` and `updatePackageFile` methods in the DB client.
- Creating new API routes for file deletion and creation/updating.
- Adding comprehensive tests for the new functionality.
fix #830 