### PR TITLE
style(components): improve responsiveness and styling in package header and code viewer

### DIFF
--- a/src/components/ViewPackagePage/components/important-files-view.tsx
+++ b/src/components/ViewPackagePage/components/important-files-view.tsx
@@ -222,7 +222,12 @@ export default function ImportantFilesView({
             activeFilePath.endsWith(".jsx") ||
             activeFilePath.endsWith(".ts") ||
             activeFilePath.endsWith(".tsx")) ? (
-          <ShikiCodeViewer code={activeFileContent} filePath={activeFilePath} />
+          <div className="overflow-x-auto">
+            <ShikiCodeViewer
+              code={activeFileContent}
+              filePath={activeFilePath}
+            />
+          </div>
         ) : (
           <pre className="whitespace-pre-wrap">{activeFileContent}</pre>
         )}

--- a/src/components/ViewPackagePage/components/package-header.tsx
+++ b/src/components/ViewPackagePage/components/package-header.tsx
@@ -69,17 +69,20 @@ export default function PackageHeader({
   return (
     <header className="bg-white border-b border-gray-200 py-4">
       <div className="max-w-[1200px] mx-auto px-4">
-        <div className="flex items-center justify-between">
-          <div className="flex items-center">
+        <div className="flex items-center justify-between flex-wrap gap-y-2">
+          <div className="flex items-center min-w-0 flex-wrap">
             {author && packageName ? (
               <>
-                <h1 className="text-xl font-bold mr-2">
-                  <Link href={`/${author}`} className="text-blue-600">
+                <h1 className="text-lg md:text-xl font-bold mr-2 break-words">
+                  <Link
+                    href={`/${author}`}
+                    className="text-blue-600 hover:underline"
+                  >
                     {author}
                   </Link>
                   <span className="px-1 text-gray-500">/</span>
                   <Link
-                    className="text-blue-600"
+                    className="text-blue-600 hover:underline"
                     href={`/${author}/${packageName}`}
                   >
                     {packageName}
@@ -100,6 +103,37 @@ export default function PackageHeader({
             )}
           </div>
           <div className="items-center space-x-2 hidden md:flex">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleStarClick}
+              disabled={isStarLoading || !packageInfo?.name}
+            >
+              <Star
+                className={`w-4 h-4 mr-2 ${starData?.is_starred ? "fill-yellow-500 text-yellow-500" : ""}`}
+              />
+              {starData?.is_starred ? "Starred" : "Star"}
+              {(starData?.star_count ?? 0) > 0 && (
+                <span className="ml-1.5 bg-gray-100 text-gray-700 rounded-full px-1.5 py-0.5 text-xs font-medium">
+                  {starData?.star_count}
+                </span>
+              )}
+            </Button>
+
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleForkClick}
+              disabled={
+                isCurrentUserAuthor || isForkLoading || !packageInfo?.package_id
+              }
+            >
+              <GitFork className="w-4 h-4 mr-2" />
+              Fork
+            </Button>
+          </div>
+          {/* Mobile buttons - shown below md breakpoint */}
+          <div className="flex items-center space-x-2 md:hidden w-full justify-end pt-2">
             <Button
               variant="outline"
               size="sm"


### PR DESCRIPTION


- Add `overflow-x-auto` to `ShikiCodeViewer` container for better handling of long code lines
- Refactor `PackageHeader` layout for improved responsiveness with flex-wrap and breakpoints
- Enhance link styling with hover effects and break-word handling for long package names
- Add mobile-specific button layout for better usability on smaller screens

# fix reviews
![Screenshot 2025-04-16 185702](https://github.com/user-attachments/assets/496d276e-0f9f-4b5d-aab2-29ed570d6d32)

![Screenshot 2025-04-16 184752](https://github.com/user-attachments/assets/bc3014e7-8bbd-4113-9a6b-2e2ce9b75245)

# old previews
![Screenshot 2025-04-16 185218](https://github.com/user-attachments/assets/eb421443-223f-45f4-a11e-f813a2cb5dd6)
![Screenshot 2025-04-16 184325](https://github.com/user-attachments/assets/92751a86-6670-418f-b50c-22e4ea79a039)
![Screenshot 2025-04-16 184309](https://github.com/user-attachments/assets/09144691-9347-4308-b01e-0b34496703d2)
