### PR TITLE
Fix tooltip overflow

### DIFF
--- a/src/components/CodeEditor.tsx
+++ b/src/components/CodeEditor.tsx
@@ -327,13 +327,94 @@ export const CodeEditor = ({
                 textDecorationColor: "rgba(0, 0, 255, 0.3)",
                 cursor: "pointer",
               },
+              ".code-editor-tooltip": {
+                maxWidth: "200px",
+                whiteSpace: "normal",
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                padding: "4px 8px",
+                borderRadius: "4px",
+                backgroundColor: "white",
+                border: "1px solid #ddd",
+                boxShadow: "0 2px 8px rgba(0, 0, 0, 0.15)",
+                zIndex: "100",
+                fontSize: "12px",
+              },
               ".cm-tooltip": {
-                maxWidth: "none",
+                maxWidth: "500px",
                 overflow: "visible",
+                position: "absolute",
+                zIndex: "9999",
+                backgroundColor: "white",
+                border: "1px solid #ddd",
+                boxShadow: "0 2px 8px rgba(0, 0, 0, 0.15)",
+                borderRadius: "4px",
               },
               ".cm-tooltip-hover": {
-                maxWidth: "none",
+                maxWidth: "none !important",
+                padding: "6px 10px",
+                lineHeight: "1.3",
+                overflow: "visible !important",
+                zIndex: "1000",
+              },
+              ".cm-tooltip-hover .cm-tooltip-section": {
+                maxWidth: "none !important",
+                fontFamily: "monospace",
+                fontSize: "12px",
+                whiteSpace: "pre-wrap",
+                color: "#333",
+                overflow: "visible !important",
+              },
+              ".cm-tooltip-section": {
+                maxWidth: "none !important",
+                overflow: "visible !important",
+                textOverflow: "ellipsis",
+              },
+              ".cm-tooltip-lint": {
+                maxWidth: "500px",
                 overflow: "visible",
+              },
+              ".cm-completionInfo": {
+                maxWidth: "500px",
+                overflow: "visible",
+              },
+              ".cm-tooltipText": {
+                fontFamily: "monospace",
+                fontSize: "12px",
+                whiteSpace: "pre-wrap",
+                overflow: "visible",
+              },
+              ".cm-completionInfo.cm-completionInfo-right": {
+                left: "100%",
+                right: "auto",
+              },
+              ".cm-tooltip-autocomplete": {
+                "& > ul": {
+                  maxHeight: "300px",
+                  overflow: "auto",
+                },
+                "& > ul > li": {
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                },
+              },
+              ".cm-tooltip *": {
+                overflow: "visible !important",
+                whiteSpace: "pre-wrap !important",
+              },
+              ".cm-type": {
+                color: "#0000cc",
+              },
+              ".cm-typeName, .cm-interface": {
+                color: "#0000cc",
+                fontWeight: "bold",
+              },
+              ".cm-propertyName": {
+                color: "#660e7a",
+              },
+              ".cm-keyword": {
+                color: "#0000ff",
+                fontWeight: "bold",
               },
             }),
             EditorView.decorations.of((view) => {

--- a/src/components/CodeEditor.tsx
+++ b/src/components/CodeEditor.tsx
@@ -277,6 +277,7 @@ export const CodeEditor = ({
                       above: true,
                       create() {
                         const dom = document.createElement("div")
+                        dom.className = "code-editor-tooltip"
                         dom.textContent = "Ctrl/Cmd+Click to open snippet"
                         return { dom }
                       },
@@ -325,6 +326,14 @@ export const CodeEditor = ({
                 textDecoration: "underline",
                 textDecorationColor: "rgba(0, 0, 255, 0.3)",
                 cursor: "pointer",
+              },
+              ".cm-tooltip": {
+                maxWidth: "none",
+                overflow: "visible",
+              },
+              ".cm-tooltip-hover": {
+                maxWidth: "none",
+                overflow: "visible",
               },
             }),
             EditorView.decorations.of((view) => {

--- a/src/components/CodeEditor.tsx
+++ b/src/components/CodeEditor.tsx
@@ -322,7 +322,7 @@ export const CodeEditor = ({
               },
             }),
             EditorView.theme({
-              ".cm-content .cm-underline": {
+                ".cm-content .cm-underline": {
                 textDecoration: "underline",
                 textDecorationColor: "rgba(0, 0, 255, 0.3)",
                 cursor: "pointer",
@@ -345,10 +345,10 @@ export const CodeEditor = ({
                 overflow: "visible",
                 position: "absolute",
                 zIndex: "9999",
-                backgroundColor: "white",
-                border: "1px solid #ddd",
-                boxShadow: "0 2px 8px rgba(0, 0, 0, 0.15)",
-                borderRadius: "4px",
+                backgroundColor: "hsl(var(--background))",
+                border: "1px solid hsl(var(--border))",
+                boxShadow: "0 2px 10px rgba(0, 0, 0, 0.15)",
+                borderRadius: "0.5rem",
               },
               ".cm-tooltip-hover": {
                 maxWidth: "none !important",
@@ -356,13 +356,20 @@ export const CodeEditor = ({
                 lineHeight: "1.3",
                 overflow: "visible !important",
                 zIndex: "1000",
+                backgroundColor: "white",
+                color: "black",
+                borderRadius: "0.5rem",
+                boxShadow: "0 4px 12px rgba(0, 0, 0, 0.10)",
+                border: "1px solid #e2e8f0",
+                fontSize: "0.875rem",
+                transition: "opacity 150ms ease-in-out, transform 150ms ease-in-out",
               },
               ".cm-tooltip-hover .cm-tooltip-section": {
                 maxWidth: "none !important",
-                fontFamily: "monospace",
-                fontSize: "12px",
+                fontFamily: "var(--font-sans)",
+                fontSize: "0.875rem",
                 whiteSpace: "pre-wrap",
-                color: "#333",
+                color: "black",
                 overflow: "visible !important",
               },
               ".cm-tooltip-section": {
@@ -379,8 +386,8 @@ export const CodeEditor = ({
                 overflow: "visible",
               },
               ".cm-tooltipText": {
-                fontFamily: "monospace",
-                fontSize: "12px",
+                fontFamily: "var(--font-sans)",
+                fontSize: "0.875rem",
                 whiteSpace: "pre-wrap",
                 overflow: "visible",
               },

--- a/src/components/CodeEditor.tsx
+++ b/src/components/CodeEditor.tsx
@@ -322,7 +322,7 @@ export const CodeEditor = ({
               },
             }),
             EditorView.theme({
-                ".cm-content .cm-underline": {
+              ".cm-content .cm-underline": {
                 textDecoration: "underline",
                 textDecorationColor: "rgba(0, 0, 255, 0.3)",
                 cursor: "pointer",
@@ -362,7 +362,8 @@ export const CodeEditor = ({
                 boxShadow: "0 4px 12px rgba(0, 0, 0, 0.10)",
                 border: "1px solid #e2e8f0",
                 fontSize: "0.875rem",
-                transition: "opacity 150ms ease-in-out, transform 150ms ease-in-out",
+                transition:
+                  "opacity 150ms ease-in-out, transform 150ms ease-in-out",
               },
               ".cm-tooltip-hover .cm-tooltip-section": {
                 maxWidth: "none !important",

--- a/src/index.css
+++ b/src/index.css
@@ -1,16 +1,27 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
 @layer base {
   :root {
     --radius: 0.5rem;
   }
 }
 
+/* Override styles for CodeMirror tooltips to fix overflow issues */
+.cm-tooltip-hover {
+  bottom: auto !important;
+  transform: none !important;
+  height: auto !important;
+  max-height: none !important;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.2) !important;
+}
+
 @keyframes fadeIn {
   from {
     opacity: 0;
   }
+
   to {
     opacity: 1;
   }


### PR DESCRIPTION
/claim #867
before this pull request the :- 
![image](https://github.com/user-attachments/assets/e454c8e4-9b46-453d-99e0-565aae8875cb)
after the pull request it looks like this :-
![image](https://github.com/user-attachments/assets/35591214-c986-4ddc-8487-0e11e6a54b48)
