### PR TITLE
fix(tree-view): correct syntax error in selectedTreeVariants and sync selected item

### DIFF
--- a/src/components/ui/tree-view.tsx
+++ b/src/components/ui/tree-view.tsx
@@ -9,7 +9,7 @@ const treeVariants = cva(
 )
 
 const selectedTreeVariants = cva(
-  "before:opacity-100 before:bg-slate-100/70 text-accent-foreground' dark:before:bg-slate-800/70",
+  "before:opacity-100 before:bg-slate-100/70 text-accent-foreground dark:before:bg-slate-800/70",
 )
 
 const dragOverVariants = cva(
@@ -57,6 +57,10 @@ const TreeView = React.forwardRef<HTMLDivElement, TreeProps>(
     const [selectedItemId, setSelectedItemId] = React.useState<
       string | undefined
     >(initialSelectedItemId)
+
+    React.useEffect(() => {
+      setSelectedItemId(initialSelectedItemId)
+    }, [initialSelectedItemId])
 
     const [draggedItem, setDraggedItem] = React.useState<TreeDataItem | null>(
       null,


### PR DESCRIPTION
fix #876 
fix #881

refactor(FileSidebar): improve tree data transformation logic and handle hidden files

- Fix syntax error in `selectedTreeVariants` by removing an extra single quote
- Add `useEffect` to sync `selectedItemId` with `initialSelectedItemId` in `TreeView`
- Refactor `transformFilesToTreeData` to handle paths starting with a slash and filter hidden files
- Convert nested object structure to array structure for tree data