### PR TITLE
refactor(CodeEditor): "tscircuit" alias for core && expand ATA run condition to include .ts files

### DIFF
--- a/src/components/package-port/CodeEditor.tsx
+++ b/src/components/package-port/CodeEditor.tsx
@@ -139,6 +139,10 @@ export const CodeEditor = ({
       resolveJsonModule: true,
     })
 
+    // Add alias for tscircuit -> @tscircuit/core
+    const tscircuitAliasDeclaration = `declare module "tscircuit" { export * from "@tscircuit/core"; }`
+    env.createFile("tscircuit-alias.d.ts", tscircuitAliasDeclaration)
+
     // Initialize ATA
     const ataConfig: ATABootstrapConfig = {
       projectName: "my-project",
@@ -383,8 +387,7 @@ export const CodeEditor = ({
 
     viewRef.current = view
 
-    // Initial ATA run for index.tsx
-    if (currentFile === "index.tsx") {
+    if (currentFile.endsWith(".tsx") || currentFile.endsWith(".ts")) {
       ata(`${defaultImports}${code}`)
     }
     // files.forEach(({path, content}) => {


### PR DESCRIPTION
The ATA (Automatic Type Acquisition) initialization was previously limited to `index.tsx`. This change extends it to include all `.tsx` and `.ts` files, ensuring type acquisition works consistently across all TypeScript files.


related to #828