### PR TITLE
Fix the overflow and tooltip ui when hovering over code components

### DIFF
--- a/src/components/CodeEditor.tsx
+++ b/src/components/CodeEditor.tsx
@@ -321,10 +321,21 @@ export const CodeEditor = ({
               },
             }),
             EditorView.theme({
-              ".cm-content .cm-underline": {
-                textDecoration: "underline",
-                textDecorationColor: "rgba(0, 0, 255, 0.3)",
-                cursor: "pointer",
+              ".cm-tooltip-hover": {
+                maxWidth: "600px",
+                padding: "12px",
+                maxHeight: "400px",
+                borderRadius: "0.5rem",
+                backgroundColor: "#fff",
+                color: "#0f172a",
+                border: "1px solid #e2e8f0",
+                boxShadow: "0 4px 12px rgba(0, 0, 0, 0.08)",
+                fontSize: "14px",
+                fontFamily: "monospace",
+                whiteSpace: "pre-wrap",
+                lineHeight: "1.6",
+                overflow: "auto",
+                zIndex: "9999",
               },
             }),
             EditorView.decorations.of((view) => {

--- a/src/components/CodeEditor.tsx
+++ b/src/components/CodeEditor.tsx
@@ -336,7 +336,7 @@ export const CodeEditor = ({
                 lineHeight: "1.6",
                 overflow: "auto",
                 zIndex: "9999",
-              }
+              },
             }),
             EditorView.decorations.of((view) => {
               const decorations = []

--- a/src/components/CodeEditor.tsx
+++ b/src/components/CodeEditor.tsx
@@ -336,7 +336,7 @@ export const CodeEditor = ({
                 lineHeight: "1.6",
                 overflow: "auto",
                 zIndex: "9999",
-              },
+              }
             }),
             EditorView.decorations.of((view) => {
               const decorations = []

--- a/src/components/CodeEditor.tsx
+++ b/src/components/CodeEditor.tsx
@@ -337,6 +337,7 @@ export const CodeEditor = ({
                 overflow: "auto",
                 zIndex: "9999",
               },
+              
             }),
             EditorView.decorations.of((view) => {
               const decorations = []

--- a/src/components/CodeEditor.tsx
+++ b/src/components/CodeEditor.tsx
@@ -337,7 +337,6 @@ export const CodeEditor = ({
                 overflow: "auto",
                 zIndex: "9999",
               },
-              
             }),
             EditorView.decorations.of((view) => {
               const decorations = []

--- a/src/components/package-port/CodeEditor.tsx
+++ b/src/components/package-port/CodeEditor.tsx
@@ -343,10 +343,21 @@ export const CodeEditor = ({
               },
             }),
             EditorView.theme({
-              ".cm-content .cm-underline": {
-                textDecoration: "underline",
-                textDecorationColor: "rgba(0, 0, 255, 0.3)",
-                cursor: "pointer",
+              ".cm-tooltip-hover": {
+                maxWidth: "600px",
+                padding: "12px",
+                maxHeight: "400px",
+                borderRadius: "0.5rem",
+                backgroundColor: "#fff",
+                color: "#0f172a",
+                border: "1px solid #e2e8f0",
+                boxShadow: "0 4px 12px rgba(0, 0, 0, 0.08)",
+                fontSize: "14px",
+                fontFamily: "monospace",
+                whiteSpace: "pre-wrap",
+                lineHeight: "1.6",
+                overflow: "auto",
+                zIndex: "9999",
               },
             }),
             EditorView.decorations.of((view) => {

--- a/src/components/package-port/CodeEditor.tsx
+++ b/src/components/package-port/CodeEditor.tsx
@@ -359,7 +359,6 @@ export const CodeEditor = ({
                 overflow: "auto",
                 zIndex: "9999",
               },
-              
             }),
             EditorView.decorations.of((view) => {
               const decorations = []

--- a/src/components/package-port/CodeEditor.tsx
+++ b/src/components/package-port/CodeEditor.tsx
@@ -359,6 +359,7 @@ export const CodeEditor = ({
                 overflow: "auto",
                 zIndex: "9999",
               },
+              
             }),
             EditorView.decorations.of((view) => {
               const decorations = []

--- a/src/components/package-port/CodeEditor.tsx
+++ b/src/components/package-port/CodeEditor.tsx
@@ -358,7 +358,7 @@ export const CodeEditor = ({
                 lineHeight: "1.6",
                 overflow: "auto",
                 zIndex: "9999",
-              },
+              }
             }),
             EditorView.decorations.of((view) => {
               const decorations = []

--- a/src/components/package-port/CodeEditor.tsx
+++ b/src/components/package-port/CodeEditor.tsx
@@ -358,7 +358,7 @@ export const CodeEditor = ({
                 lineHeight: "1.6",
                 overflow: "auto",
                 zIndex: "9999",
-              }
+              },
             }),
             EditorView.decorations.of((view) => {
               const decorations = []


### PR DESCRIPTION
/claim #867

![image](https://github.com/user-attachments/assets/3c3933ae-bd98-4591-a49e-e4c473d7cd83)
