### PR TITLE
feat(SearchComponent): add autofocus prop to control input focus

### DIFF
--- a/src/components/Header2.tsx
+++ b/src/components/Header2.tsx
@@ -17,7 +17,7 @@ const SearchButtonComponent = () => {
       {isExpanded ? (
         <div className="flex items-center gap-2">
           <div className="w-32 bg-white">
-            <SearchComponent />
+            <SearchComponent autofocus />
           </div>
           {/* <Button
             variant="ghost"

--- a/src/components/SearchComponent.tsx
+++ b/src/components/SearchComponent.tsx
@@ -9,6 +9,7 @@ import { PrefetchPageLink } from "./PrefetchPageLink"
 
 interface SearchComponentProps {
   onResultsFetched?: (results: any[]) => void // optional
+  autofocus?: boolean
 }
 
 const LinkWithNewTabHandling = ({
@@ -43,6 +44,7 @@ const LinkWithNewTabHandling = ({
 
 const SearchComponent: React.FC<SearchComponentProps> = ({
   onResultsFetched,
+  autofocus = false,
 }) => {
   const [searchQuery, setSearchQuery] = useState("")
   const [showResults, setShowResults] = useState(false)
@@ -74,7 +76,9 @@ const SearchComponent: React.FC<SearchComponentProps> = ({
 
   // Focus input on mount
   useEffect(() => {
-    inputRef.current?.focus()
+    if (autofocus) {
+      inputRef.current?.focus()
+    }
   }, [])
 
   useEffect(() => {


### PR DESCRIPTION
The autofocus prop allows conditional focus on the search input, improving user experience by focusing only when explicitly needed


resolve #960 