### PR TITLE
Change syntax highlighting for markdown to tsx

### DIFF
--- a/src/components/ViewPackagePage/components/markdown-viewer.tsx
+++ b/src/components/ViewPackagePage/components/markdown-viewer.tsx
@@ -24,7 +24,7 @@ export default function MarkdownViewer({
                 dom.innerHTML = highlighter.codeToHtml(
                   children?.toString() || "",
                   {
-                    lang: "typescript",
+                    lang: "tsx",
                     themes: {
                       light: "github-light",
                       dark: "github-dark",


### PR DESCRIPTION
Closes: #965 

<img width="855" alt="Screenshot 2025-04-26 at 3 10 43 PM" src="https://github.com/user-attachments/assets/dd9b1c73-97ad-4456-889e-99a8c8135bb0" />
