### PR TITLE
fix: add isLoadingFiles check to prevent premature rendering

### DIFF
--- a/src/components/package-port/CodeAndPreview.tsx
+++ b/src/components/package-port/CodeAndPreview.tsx
@@ -321,7 +321,7 @@ export function CodeAndPreview({ pkg }: Props) {
     state.pkgFilesWithContent,
   ])
 
-  if ((!pkg && urlParams.package_id) || pkgFiles.isLoading) {
+  if ((!pkg && urlParams.package_id) || pkgFiles.isLoading || isLoadingFiles) {
     return (
       <div className="flex items-center justify-center h-64">
         <div className="flex flex-col items-center justify-center">

--- a/src/components/package-port/EditorNav.tsx
+++ b/src/components/package-port/EditorNav.tsx
@@ -187,7 +187,8 @@ export default function EditorNav({
   }
 
   const canSavePackage = Boolean(
-    isLoggedIn && pkg?.owner_github_username === session?.github_username,
+    isLoggedIn &&
+      (!pkg || pkg?.owner_github_username === session?.github_username),
   )
   return (
     <nav className="lg:flex w-screen items-center justify-between px-2 py-3 border-b border-gray-200 bg-white text-sm border-t">
@@ -250,7 +251,7 @@ export default function EditorNav({
             variant="outline"
             size="sm"
             className={"ml-1 h-6 px-2 text-xs save-button"}
-            disabled={canSavePackage ? !hasUnsavedChanges : !isLoggedIn}
+            disabled={canSavePackage && pkg ? !hasUnsavedChanges : !isLoggedIn}
             onClick={canSavePackage ? onSave : () => forkSnippet()}
           >
             {canSavePackage ? (


### PR DESCRIPTION
The condition for rendering the loading state was incomplete, causing the component to render prematurely. Added `isLoadingFiles` to the condition to ensure the loading state is displayed correctly while files are being loaded.

resolve #939