### PR TITLE
fix(CodeEditor): ensure consistent path handling in fsMap

### DIFF
--- a/src/components/package-port/CodeEditor.tsx
+++ b/src/components/package-port/CodeEditor.tsx
@@ -136,7 +136,7 @@ export const CodeEditor = ({
         fsMap.set(filename, content)
       })
     })
-    console.info(fsMap.keys())
+
     const system = createSystem(fsMap)
     const env = createVirtualTypeScriptEnvironment(system, [], ts, {
       jsx: ts.JsxEmit.ReactJSX,

--- a/src/components/package-port/CodeEditor.tsx
+++ b/src/components/package-port/CodeEditor.tsx
@@ -122,7 +122,7 @@ export const CodeEditor = ({
 
     const fsMap = new Map<string, string>()
     files.forEach(({ path, content }) => {
-      fsMap.set(path, content)
+      fsMap.set(`${path.startsWith("/") ? "" : "/"}${path}`, content)
     })
     ;(window as any).__DEBUG_CODE_EDITOR_FS_MAP = fsMap
 
@@ -136,7 +136,7 @@ export const CodeEditor = ({
         fsMap.set(filename, content)
       })
     })
-
+    console.info(fsMap.keys())
     const system = createSystem(fsMap)
     const env = createVirtualTypeScriptEnvironment(system, [], ts, {
       jsx: ts.JsxEmit.ReactJSX,
@@ -185,7 +185,7 @@ export const CodeEditor = ({
       delegate: {
         started: () => {
           const manualEditsTypeDeclaration = `
-				  declare module "*.json" {
+				  declare module "manual-edits.json" {
 				  const value: {
 					  pcb_placements?: any[],
             schematic_placements?: any[],


### PR DESCRIPTION
The commit ensures that paths in the `fsMap` are consistently prefixed with a forward slash if they don't already start with one. This prevents potential issues with path resolution in the virtual file system. Additionally, a debug log statement was added to inspect the keys of the `fsMap` for troubleshooting purposes.

##### /claim #948

close #948