### PR TITLE
feat(EditorNav): add keyboard shortcut to save package

### DIFF
--- a/src/components/package-port/EditorNav.tsx
+++ b/src/components/package-port/EditorNav.tsx
@@ -33,7 +33,7 @@ import {
   Sparkles,
   Trash2,
 } from "lucide-react"
-import { useEffect, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 import { useQueryClient } from "react-query"
 import { Link, useLocation } from "wouter"
 import { useAxios } from "@/hooks/use-axios"
@@ -186,9 +186,13 @@ export default function EditorNav({
     }
   }
 
-  const canSavePackage = Boolean(
-    isLoggedIn &&
-      (!pkg || pkg?.owner_github_username === session?.github_username),
+  const canSavePackage = useMemo(
+    () =>
+      Boolean(
+        isLoggedIn &&
+          (!pkg || pkg?.owner_github_username === session?.github_username),
+      ),
+    [isLoggedIn, pkg, session?.github_username],
   )
 
   useEffect(() => {

--- a/src/components/package-port/EditorNav.tsx
+++ b/src/components/package-port/EditorNav.tsx
@@ -201,7 +201,7 @@ export default function EditorNav({
     }
     window.addEventListener("keydown", handleKeyDown)
     return () => window.removeEventListener("keydown", handleKeyDown)
-  }, [onSave, hasUnsavedChanges, isLoggedIn, canSavePackage])
+  }, [onSave, hasUnsavedChanges, canSavePackage])
   return (
     <nav className="lg:flex w-screen items-center justify-between px-2 py-3 border-b border-gray-200 bg-white text-sm border-t">
       <div className="lg:flex items-center my-2 ">

--- a/src/components/package-port/EditorNav.tsx
+++ b/src/components/package-port/EditorNav.tsx
@@ -190,6 +190,18 @@ export default function EditorNav({
     isLoggedIn &&
       (!pkg || pkg?.owner_github_username === session?.github_username),
   )
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && e.key === "s") {
+        e.preventDefault()
+        if (!hasUnsavedChanges || !canSavePackage) return
+        onSave()
+      }
+    }
+    window.addEventListener("keydown", handleKeyDown)
+    return () => window.removeEventListener("keydown", handleKeyDown)
+  }, [onSave, hasUnsavedChanges, isLoggedIn, canSavePackage])
   return (
     <nav className="lg:flex w-screen items-center justify-between px-2 py-3 border-b border-gray-200 bg-white text-sm border-t">
       <div className="lg:flex items-center my-2 ">


### PR DESCRIPTION
Add a keyboard shortcut (Ctrl/Cmd + S) to trigger the save functionality in the EditorNav component. This enhances user experience by allowing quick saves without manually clicking the save button.


fix #981