### PR TITLE
feat(view-package): pass file_path to onEditClicked handler

### DIFF
--- a/src/components/HiddenFilesDropdown.tsx
+++ b/src/components/HiddenFilesDropdown.tsx
@@ -6,7 +6,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
-import { Settings, Check } from "lucide-react"
+import { MoreVertical, Check } from "lucide-react"
 
 interface HiddenFilesDropdownProps {
   showHiddenFiles: boolean
@@ -21,7 +21,7 @@ export default function HiddenFilesDropdown({
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
         <button className="ml-2 text-gray-500 hover:text-gray-600 dark:hover:text-gray-400 focus:outline-none">
-          <Settings className="h-4 w-4" />
+          <MoreVertical className="h-4 w-4" />
         </button>
       </DropdownMenuTrigger>
       <DropdownMenuContent

--- a/src/components/ViewPackagePage/components/important-files-view.tsx
+++ b/src/components/ViewPackagePage/components/important-files-view.tsx
@@ -19,7 +19,7 @@ interface PackageFile {
 interface ImportantFilesViewProps {
   importantFiles?: PackageFile[]
   isLoading?: boolean
-  onEditClicked?: () => void
+  onEditClicked?: (file_path?: string | null) => void
 
   aiDescription?: string
   aiUsageInstructions?: string
@@ -203,7 +203,7 @@ export default function ImportantFilesView({
         <div className="ml-auto flex items-center">
           <button
             className="hover:bg-gray-200 dark:hover:bg-[#30363d] p-1 rounded-md"
-            onClick={onEditClicked}
+            onClick={() => onEditClicked?.(activeFilePath)}
           >
             <Edit className="h-4 w-4" />
             <span className="sr-only">Edit</span>

--- a/src/pages/view-package.tsx
+++ b/src/pages/view-package.tsx
@@ -50,8 +50,13 @@ export const ViewPackagePage = () => {
             `/editor?package_id=${packageInfo?.package_id}&file_path=${file.file_path}`,
           )
         }}
-        onEditClicked={() => {
-          setLocation(`/editor?package_id=${packageInfo?.package_id}`)
+        onEditClicked={(file_path?: string) => {
+          console.log("file_path", file_path)
+          setLocation(
+            `/editor?package_id=${packageInfo?.package_id}${
+              file_path ? `&file_path=${file_path}` : ""
+            }`,
+          )
         }}
       />
     </>


### PR DESCRIPTION
Modify the onEditClicked handler to accept an optional file_path parameter and include it in the navigation URL. This allows for more precise editing of specific files within the package.