### PR TITLE
test(package_releases): ensure is_latest flag update is verified correctly

### DIFF
--- a/bun-tests/fake-snippets-api/routes/package_releases/update.test.ts
+++ b/bun-tests/fake-snippets-api/routes/package_releases/update.test.ts
@@ -92,18 +92,20 @@ test("update package release - handle is_latest flag", async () => {
   })
 
   // Update second release to be latest
-  await axios.post("/api/package_releases/update", {
-    package_release_id: release2.data.package_release.package_release_id,
-    is_latest: true,
-  })
-
-  // Verify first release is no longer latest
-  const firstRelease = db.packageReleases.find(
-    (pr) =>
-      pr.package_release_id ===
-      release1.data.package_release.package_release_id,
-  )
-  expect(firstRelease?.is_latest).toBe(false)
+  await axios
+    .post("/api/package_releases/update", {
+      package_release_id: release2.data.package_release.package_release_id,
+      is_latest: true,
+    })
+    .finally(() => {
+      // Verify first release is no longer latest
+      const firstRelease = db.packageReleases.find(
+        (pr) =>
+          pr.package_release_id ===
+          release1.data.package_release.package_release_id,
+      )
+      expect(firstRelease?.is_latest).toBe(false)
+    })
 
   // Verify second release is now latest
   const secondRelease = db.packageReleases.find(


### PR DESCRIPTION


The test was refactored to use `.finally()` to verify the `is_latest` flag update immediately after the API call. This ensures the verification logic is executed even if the request fails, improving test reliability.