### PR TITLE
refactor(EditorNav): remove unused hasUnrunChanges prop

### DIFF
--- a/src/components/package-port/CodeAndPreview.tsx
+++ b/src/components/package-port/CodeAndPreview.tsx
@@ -221,8 +221,6 @@ export function CodeAndPreview({ pkg }: Props) {
     manualEditsFileContent: state.manualEditsFileContent,
   })
 
-  const hasUnrunChanges = entryPointCode !== state.lastRunCode
-
   const hasUnsavedChanges = useMemo(
     () =>
       !updatePackageMutation.isLoading &&
@@ -272,15 +270,6 @@ export function CodeAndPreview({ pkg }: Props) {
       toast({
         title: "Not Logged In",
         description: "You must be logged in to save your package.",
-        variant: "destructive",
-      })
-      return
-    }
-
-    if (hasUnrunChanges) {
-      toast({
-        title: "Warning",
-        description: "You must run the package before saving your changes.",
         variant: "destructive",
       })
       return
@@ -368,7 +357,6 @@ export function CodeAndPreview({ pkg }: Props) {
           setState((prev) => ({ ...prev, showPreview: !prev.showPreview }))
         }
         previewOpen={state.showPreview}
-        hasUnrunChanges={hasUnrunChanges}
       />
       <div
         className={`flex ${state.showPreview ? "flex-col md:flex-row" : ""}`}

--- a/src/components/package-port/EditorNav.tsx
+++ b/src/components/package-port/EditorNav.tsx
@@ -59,7 +59,6 @@ export default function EditorNav({
   onSave,
   packageType,
   isSaving,
-  hasUnrunChanges,
 }: {
   pkg?: Package | null
   circuitJson?: AnyCircuitElement[] | null
@@ -70,7 +69,6 @@ export default function EditorNav({
   onTogglePreview: () => void
   isSaving: boolean
   onSave: () => void
-  hasUnrunChanges: boolean
 }) {
   const [, navigate] = useLocation()
   const isLoggedIn = useGlobalStore((s) => Boolean(s.session))


### PR DESCRIPTION
The `hasUnrunChanges` prop was not used within the `EditorNav` component, so it has been removed to clean up the code and improve maintainability.