### PR TITLE
fix: Add destructive toast variant for download error

### DIFF
--- a/src/components/DownloadButtonAndMenu.tsx
+++ b/src/components/DownloadButtonAndMenu.tsx
@@ -91,6 +91,7 @@ export function DownloadButtonAndMenu({
                 toast({
                   title: "Error Downloading 3D Model",
                   description: error.toString(),
+                  variant: "destructive",
                 })
               }
             }}
@@ -113,6 +114,7 @@ export function DownloadButtonAndMenu({
                 toast({
                   title: "Error Downloading Fabrication Files",
                   description: error.toString(),
+                  variant: "destructive",
                 })
               })
             }}


### PR DESCRIPTION
- Added a toast with variant: "destructive" on download error.
- Displays a user-friendly title and the error message.
