### PR TITLE
fix(CodeEditor): support react syntax for old .ts packages

### DIFF
--- a/src/components/package-port/CodeEditor.tsx
+++ b/src/components/package-port/CodeEditor.tsx
@@ -283,7 +283,12 @@ export const CodeEditor = ({
     const tsExtensions =
       currentFile.endsWith(".tsx") || currentFile.endsWith(".ts")
         ? [
-            tsFacet.of({ env, path: currentFile }),
+            tsFacet.of({
+              env,
+              path: currentFile.endsWith(".ts")
+                ? currentFile.replace(/\.ts$/, ".tsx")
+                : currentFile,
+            }),
             tsSync(),
             tsLinter(),
             autocompletion({ override: [tsAutocomplete()] }),


### PR DESCRIPTION
Ensure that .ts files are correctly processed by replacing the extension with .tsx in the tsFacet configuration. This prevents potential issues with TypeScript file handling in the CodeEditor component.

closes #1014