### PR TITLE
feat(CodeEditor): add state to track editor readiness

### DIFF
--- a/src/components/package-port/CodeEditor.tsx
+++ b/src/components/package-port/CodeEditor.tsx
@@ -63,6 +63,7 @@ export const CodeEditor = ({
   const [cursorPosition, setCursorPosition] = useState<number | null>(null)
   const [code, setCode] = useState(files[0]?.content || "")
   const [currentFile, setCurrentFile] = useState<string>("")
+  const [isCodeEditorReady, setIsCodeEditorReady] = useState(false)
 
   const { highlighter, isLoading } = useShikiHighlighter()
 
@@ -185,6 +186,9 @@ export const CodeEditor = ({
         return fetch(input, init)
       },
       delegate: {
+        finished: () => {
+          setIsCodeEditorReady(true)
+        },
         started: () => {
           const manualEditsTypeDeclaration = `
 				  declare module "manual-edits.json" {
@@ -542,7 +546,9 @@ export const CodeEditor = ({
         )}
         <div
           ref={editorRef}
-          className="flex-1 overflow-auto [&_.cm-editor]:h-full [&_.cm-scroller]:!h-full"
+          className={`flex-1 overflow-auto [&_.cm-editor]:h-full [&_.cm-scroller]:!h-full ${
+            !isCodeEditorReady ? "opacity-50" : ""
+          }`}
         />
       </div>
     </div>


### PR DESCRIPTION
Introduce `isCodeEditorReady` state to manage editor opacity based on its readiness. This improves user experience by visually indicating when the editor is fully loaded and functional.
> ignore errors, fixed in my other prs


fix #1031


https://github.com/user-attachments/assets/9927437b-206a-4170-b375-51b2950bba1d

