### PR TITLE
fix: Manual edits failing to render circuits having the `manual-edits.json` file

### DIFF
--- a/fake-snippets-api/lib/db/autoload-packages.json
+++ b/fake-snippets-api/lib/db/autoload-packages.json
@@ -1,3 +1,36 @@
 {
-  "packages": []
+  "packages": [
+    {
+      "owner": "Abse2001",
+      "name": "Arduino-Nano-Servo-Breakout"
+    },
+    {
+      "owner": "ShiboSoftwareDev",
+      "name": "Wifi-Camera-Module"
+    },
+    {
+      "owner": "imrishabh18",
+      "name": "Arduino-nano"
+    },
+    {
+      "owner": "seveibar",
+      "name": "usb-c-flashlight"
+    },
+    {
+      "owner": "seveibar",
+      "name": "nine-key-keyboard"
+    },
+    {
+      "owner": "AnasSarkiz",
+      "name": "grid-of-LEDs-with-an-ESP32"
+    },
+    {
+      "owner": "seveibar",
+      "name": "keyboard-default60"
+    },
+    {
+      "owner": "imrishabh18",
+      "name": "motor-driver-breakout"
+    }
+  ]
 }

--- a/src/components/package-port/CodeAndPreview.tsx
+++ b/src/components/package-port/CodeAndPreview.tsx
@@ -32,7 +32,22 @@ export interface PackageFile {
   content: string
 }
 
-const DEFAULT_MANUAL_EDITS = ""
+interface CodeAndPreviewState {
+  pkgFilesWithContent: PackageFile[]
+  initialFilesLoad: PackageFile[]
+  showPreview: boolean
+  fullScreen: boolean
+  dts: string
+  lastSavedAt: number
+  circuitJson: null | any
+  isPrivate: boolean
+  lastRunCode: string
+  code: string
+  manualEditsFileContent: string
+  pkgFilesLoaded: boolean
+}
+
+const DEFAULT_MANUAL_EDITS = "{}"
 const DEFAULT_CODE = `
 export default () => (
   <board width="10mm" height="10mm">
@@ -81,20 +96,6 @@ export function CodeAndPreview({ pkg }: Props) {
       return manualEditsFileFromHook.data.content_text
     else return null
   }, [manualEditsFileFromHook.data])
-  interface CodeAndPreviewState {
-    pkgFilesWithContent: PackageFile[]
-    initialFilesLoad: PackageFile[]
-    showPreview: boolean
-    fullScreen: boolean
-    dts: string
-    lastSavedAt: number
-    circuitJson: null | any
-    isPrivate: boolean
-    lastRunCode: string
-    code: string
-    manualEditsFileContent: string
-    pkgFilesLoaded: boolean
-  }
 
   const [state, setState] = useState<CodeAndPreviewState>({
     pkgFilesWithContent: !pkg
@@ -292,6 +293,7 @@ export function CodeAndPreview({ pkg }: Props) {
   }
 
   const fsMap = useMemo(() => {
+    const manualEditsContent = state.manualEditsFileContent || defaultManualEditsContent || DEFAULT_MANUAL_EDITS;
     return {
       ...state.pkgFilesWithContent.reduce(
         (acc, file) => {
@@ -301,10 +303,11 @@ export function CodeAndPreview({ pkg }: Props) {
         {} as Record<string, string>,
       ),
       "index.tsx": state.code,
-      "manual-edits.json": state.manualEditsFileContent,
+      "manual-edits.json": manualEditsContent,
     }
   }, [
     state.manualEditsFileContent,
+    defaultManualEditsContent,
     entryPointCode,
     state.code,
     packageType,

--- a/src/components/package-port/CodeAndPreview.tsx
+++ b/src/components/package-port/CodeAndPreview.tsx
@@ -293,7 +293,10 @@ export function CodeAndPreview({ pkg }: Props) {
   }
 
   const fsMap = useMemo(() => {
-    const manualEditsContent = state.manualEditsFileContent || defaultManualEditsContent || DEFAULT_MANUAL_EDITS;
+    const manualEditsContent =
+      state.manualEditsFileContent ||
+      defaultManualEditsContent ||
+      DEFAULT_MANUAL_EDITS
     return {
       ...state.pkgFilesWithContent.reduce(
         (acc, file) => {


### PR DESCRIPTION
Adding back the previous deleted file to autoload packages

![image](https://github.com/user-attachments/assets/3a31ba17-47e9-4c90-86a3-bf284d9aea02)
