### PR TITLE
chore: update circuit-json-to-gerber dependency to v0.0.18

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -57,7 +57,7 @@
         "change-case": "^5.4.4",
         "circuit-json": "^0.0.136",
         "circuit-json-to-bom-csv": "^0.0.6",
-        "circuit-json-to-gerber": "^0.0.17",
+        "circuit-json-to-gerber": "^0.0.18",
         "circuit-json-to-pnp-csv": "^0.0.6",
         "circuit-json-to-readable-netlist": "^0.0.8",
         "circuit-json-to-tscircuit": "^0.0.4",
@@ -1018,7 +1018,7 @@
 
     "circuit-json-to-connectivity-map": ["circuit-json-to-connectivity-map@0.0.20", "", { "dependencies": { "@tscircuit/math-utils": "^0.0.9" }, "peerDependencies": { "typescript": "^5.0.0" } }, "sha512-q8McyEomIZdprsSjGQv5puKLlMOM5w9EGRYA4TxaHPBLe03BoqVoN8wQxhdqmmbe4Tpa30KQFH9eISGVMs6HGg=="],
 
-    "circuit-json-to-gerber": ["circuit-json-to-gerber@0.0.17", "", { "dependencies": { "@tscircuit/alphabet": "^0.0.2", "fast-json-stable-stringify": "^2.1.0" }, "peerDependencies": { "circuit-json": "^0.0.153", "typescript": "^5.0.0" }, "bin": { "circuit-to-gerber": "dist/cli.js" } }, "sha512-NTnL1WX0z83uglfyfC4IAuv3swu4ob0l/1tXinLS9NprqlI10/ha8V9+IMUYKjjTLzwkLXB4/SAhoAR1ZdVqHQ=="],
+    "circuit-json-to-gerber": ["circuit-json-to-gerber@0.0.18", "", { "dependencies": { "@tscircuit/alphabet": "^0.0.2", "fast-json-stable-stringify": "^2.1.0" }, "peerDependencies": { "circuit-json": "^0.0.164", "typescript": "^5.0.0" }, "bin": { "circuit-to-gerber": "dist/cli.js" } }, "sha512-Xl+SyBfyaAJa7N+15ezsQkn/kf6ovLWH1noBlBFJ6SZOQkZj3yOU4RNGNr2BO58N5zlIg8R1i1rpw6PZlhbxzg=="],
 
     "circuit-json-to-pnp-csv": ["circuit-json-to-pnp-csv@0.0.6", "", { "dependencies": { "papaparse": "^5.4.1" }, "peerDependencies": { "@tscircuit/soup-util": "*", "typescript": "^5.0.0" } }, "sha512-E5bbw0EfOk+6DUaldmsaogzfFni91IwBHI6hzQTbS1qczhqMmUNYkRTpePqa3ewZ12oLLURLbHnd9HDGjxlJ+w=="],
 

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "change-case": "^5.4.4",
     "circuit-json": "^0.0.136",
     "circuit-json-to-bom-csv": "^0.0.6",
-    "circuit-json-to-gerber": "^0.0.17",
+    "circuit-json-to-gerber": "^0.0.18",
     "circuit-json-to-pnp-csv": "^0.0.6",
     "circuit-json-to-readable-netlist": "^0.0.8",
     "circuit-json-to-tscircuit": "^0.0.4",


### PR DESCRIPTION
This commit updates the `circuit-json-to-gerber` dependency to version 0.0.18 to ensure compatibility with the latest changes and improvements in the library.

closes https://github.com/tscircuit/circuit-json-to-gerber/issues/30
