### PR TITLE
refactor: streamline error handling and update snippet creation logic in JLCPCB component generation

### DIFF
--- a/fake-snippets-api/routes/api/snippets/generate_from_jlcpcb.ts
+++ b/fake-snippets-api/routes/api/snippets/generate_from_jlcpcb.ts
@@ -17,20 +17,13 @@ export default withRouteSpec({
 
   try {
     // Fetch the EasyEDA component data
-    const rawEasyJson = await fetchEasyEDAComponent(jlcpcb_part_number).catch(
-      (e) => {
-        throw new Error(`Error in fetchEasyEDAComponent: ${e.toString()}`)
-      },
-    )
+    const rawEasyJson = await fetchEasyEDAComponent(jlcpcb_part_number)
 
     // Convert to TypeScript React component
-    const tsxComponent = await convertRawEasyEdaToTs(rawEasyJson).catch((e) => {
-      throw new Error(`Error in convertRawEasyEdaToTs ${e.toString()}`)
-    })
+    const tsxComponent = await convertRawEasyEdaToTs(rawEasyJson)
 
     // Create a new snippet
     const newSnippet = {
-      snippet_id: `snippet_${ctx.db.idCounter + 1}`,
       name: `${ctx.auth.github_username}/${jlcpcb_part_number}`,
       unscoped_name: jlcpcb_part_number,
       owner_name: ctx.auth.github_username,
@@ -41,15 +34,16 @@ export default withRouteSpec({
       description: `Generated from JLCPCB part number ${jlcpcb_part_number}`,
     }
 
-    ctx.db.addSnippet(newSnippet as any)
+    const createdSnippet = ctx.db.addSnippet(newSnippet as any)
 
     return ctx.json({
-      snippet: newSnippet as any,
+      snippet: createdSnippet as any,
     })
   } catch (error: any) {
+    console.error(error)
     return ctx.error(500, {
       error_code: "jlcpcb_generation_failed",
-      message: `Failed to generate snippet from JLCPCB part: ${error.message}\n\n${error.stack}`,
+      message: `Failed to generate snippet from JLCPCB part: ${error.message}`,
     })
   }
 })

--- a/fake-snippets-api/routes/api/snippets/generate_from_jlcpcb.ts
+++ b/fake-snippets-api/routes/api/snippets/generate_from_jlcpcb.ts
@@ -42,7 +42,7 @@ export default withRouteSpec({
   } catch (error: any) {
     return ctx.error(500, {
       error_code: "jlcpcb_generation_failed",
-      message: `Failed to generate snippet from JLCPCB part: ${error.message}`,
+      message: `Failed to generate package from JLCPCB part: ${error.message}`,
     })
   }
 })

--- a/fake-snippets-api/routes/api/snippets/generate_from_jlcpcb.ts
+++ b/fake-snippets-api/routes/api/snippets/generate_from_jlcpcb.ts
@@ -40,7 +40,6 @@ export default withRouteSpec({
       snippet: createdSnippet as any,
     })
   } catch (error: any) {
-    console.error(error)
     return ctx.error(500, {
       error_code: "jlcpcb_generation_failed",
       message: `Failed to generate snippet from JLCPCB part: ${error.message}`,

--- a/fake-snippets-api/routes/api/snippets/generate_from_jlcpcb.ts
+++ b/fake-snippets-api/routes/api/snippets/generate_from_jlcpcb.ts
@@ -34,10 +34,10 @@ export default withRouteSpec({
       description: `Generated from JLCPCB part number ${jlcpcb_part_number}`,
     }
 
-    const createdSnippet = ctx.db.addSnippet(newSnippet as any)
+    const createdPackage = ctx.db.addSnippet(newSnippet as any)
 
     return ctx.json({
-      snippet: createdSnippet as any,
+      snippet: createdPackage as any,
     })
   } catch (error: any) {
     return ctx.error(500, {

--- a/src/components/JLCPCBImportDialog.tsx
+++ b/src/components/JLCPCBImportDialog.tsx
@@ -5,6 +5,7 @@ import {
   DialogHeader,
   DialogTitle,
   DialogFooter,
+  DialogDescription,
 } from "@/components/ui/dialog"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -60,7 +61,7 @@ export function JLCPCBImportDialog({
             <div>
               <PrefetchPageLink
                 className="text-blue-500 hover:underline"
-                href={`/editor?snippet_id=${existingSnippetRes.data.snippet.snippet_id}`}
+                href={`/editor?package_id=${existingSnippetRes.data.snippet.snippet_id}`}
               >
                 View {partNumber}
               </PrefetchPageLink>
@@ -86,9 +87,8 @@ export function JLCPCBImportDialog({
         description: "JLCPCB component has been imported successfully.",
       })
       onOpenChange(false)
-      navigate(`/editor?snippet_id=${snippet.snippet_id}`)
+      navigate(`/editor?package_id=${snippet.snippet_id}`)
     } catch (error) {
-      console.error("Error importing JLCPCB component:", error)
       toast({
         title: "Import Failed",
         description: "Failed to import the JLCPCB component. Please try again.",
@@ -104,8 +104,11 @@ export function JLCPCBImportDialog({
       <DialogContent>
         <DialogHeader>
           <DialogTitle>Import from JLCPCB</DialogTitle>
+          <DialogDescription>
+            Enter the JLCPCB part number to import the component.
+          </DialogDescription>
         </DialogHeader>
-        <div className="py-4">
+        <div className="py-4 text-center">
           <a
             href="https://yaqwsx.github.io/jlcparts/#/"
             target="_blank"

--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -113,7 +113,7 @@ export const DashboardPage = () => {
                         myPackages.slice(0, 3).map((pkg) => (
                           <div key={pkg.package_id}>
                             <PrefetchPageLink
-                              href={`/editor?snippet_id=${pkg.package_id}`}
+                              href={`/editor?package_id=${pkg.package_id}`}
                               className="text-blue-600 hover:underline"
                             >
                               <Button


### PR DESCRIPTION
… 
fix #1038
- Removed redundant error handling in fetch and conversion functions.
- Updated snippet creation to return the created snippet instead of a new object.
- Adjusted navigation links in JLCPCBImportDialog and DashboardPage to use `package_id` instead of `snippet_id`.
- Added a description to the JLCPCB import dialog for better user guidance.
- Sync with registry-api