### PR TITLE
feat: enhance package deletion flow by refetching user packages after successful deletion

### DIFF
--- a/src/components/dialogs/confirm-delete-package-dialog.tsx
+++ b/src/components/dialogs/confirm-delete-package-dialog.tsx
@@ -8,14 +8,19 @@ export const ConfirmDeletePackageDialog = ({
   onOpenChange,
   packageId,
   packageName,
+  refetchUserPackages,
 }: {
   open: boolean
   onOpenChange: (open: boolean) => void
   packageId: string
   packageName: string
+  refetchUserPackages?: () => void
 }) => {
   const { mutate: deletePackage, isLoading } = useDeletePackage({
-    onSuccess: () => onOpenChange(false),
+    onSuccess: () => {
+      onOpenChange(false)
+      refetchUserPackages?.()
+    },
   })
 
   return (

--- a/src/pages/user-profile.tsx
+++ b/src/pages/user-profile.tsx
@@ -36,9 +36,11 @@ export const UserProfilePage = () => {
     useConfirmDeletePackageDialog()
   const [packageToDelete, setPackageToDelete] = useState<Package | null>(null)
 
-  const { data: userPackages, isLoading: isLoadingUserPackages } = useQuery<
-    Package[]
-  >(["userPackages", username], async () => {
+  const {
+    data: userPackages,
+    isLoading: isLoadingUserPackages,
+    refetch: refetchUserPackages,
+  } = useQuery<Package[]>(["userPackages", username], async () => {
     const response = await axios.post(`/packages/list`, {
       owner_github_username: username,
     })
@@ -205,6 +207,7 @@ export const UserProfilePage = () => {
         <DeleteDialog
           packageId={packageToDelete.package_id}
           packageName={packageToDelete.unscoped_name}
+          refetchUserPackages={refetchUserPackages}
         />
       )}
       <Footer />


### PR DESCRIPTION
… 
fix #1053

This update modifies the ConfirmDeletePackageDialog to call refetchUserPackages after a package is successfully deleted, ensuring the user interface reflects the latest package data. The UserProfilePage is updated to pass the refetchUserPackages function to the DeleteDialog component.


https://github.com/user-attachments/assets/32e5070d-664a-47a4-a6ba-2be894e7769e

