### PR TITLE
Enable prefetch for Online Example link

### DIFF
--- a/src/pages/landing.tsx
+++ b/src/pages/landing.tsx
@@ -73,7 +73,7 @@ export function LandingPage() {
                       </Button>
                     </a>
                     <PrefetchPageLink
-                      href="/quickstart"
+                      href="/seveibar/usb-c-flashlight#3d"
                       className="w-[70vw] min-[500px]:w-auto"
                     >
                       <Button


### PR DESCRIPTION
## Summary
- reintroduce `PrefetchPageLink` for the Online Example button
- link internally to `/seveibar/usb-c-flashlight#3d`

## Testing
- `bun run format`
- `bun x playwright test` *(fails: browsers missing)*