### PR TITLE
add missing generate-images command in dev script

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "playwright": "bunx playwright test",
     "playwright:update": "bunx playwright test --update-snapshots",
     "start:playwright-server": "bun run build:fake-api && vite --port 5177",
-    "dev": "bun run build:fake-api && AUTOLOAD_PACKAGES=true vite",
+    "dev": "bun run generate-images && bun run build:fake-api && AUTOLOAD_PACKAGES=true vite",
     "dev:registry": "SNIPPETS_API_URL=http://localhost:3100 vite",
     "build": "bun run generate-images && bun run generate-sitemap && bun run build:fake-api && tsc -b && vite build",
     "preview": "vite preview",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "playwright": "bunx playwright test",
     "playwright:update": "bunx playwright test --update-snapshots",
     "start:playwright-server": "bun run build:fake-api && vite --port 5177",
-    "dev": "bun run generate-images && bun run build:fake-api && AUTOLOAD_PACKAGES=true vite",
+    "dev": "test -d public/assets || bun run generate-images && bun run build:fake-api && AUTOLOAD_PACKAGES=true vite",
     "dev:registry": "SNIPPETS_API_URL=http://localhost:3100 vite",
     "build": "bun run generate-images && bun run generate-sitemap && bun run build:fake-api && tsc -b && vite build",
     "preview": "vite preview",


### PR DESCRIPTION
fix: not able to generate static images at the time of `bun run dev` locally

# before:

![image](https://github.com/user-attachments/assets/c4bf09e6-ed25-4879-8b2b-70556d12758f)

# after: 

![Screenshot from 2025-06-04 14-05-58](https://github.com/user-attachments/assets/7a225863-151a-451a-9637-e3d65972da28)

