### PR TITLE
Add ready_to_build property for package releases

### DIFF
--- a/bun-tests/fake-snippets-api/fixtures/get-test-server.ts
+++ b/bun-tests/fake-snippets-api/fixtures/get-test-server.ts
@@ -106,6 +106,7 @@ const seedDatabase = (db: DbClient) => {
     is_locked: false,
     has_transpiled: true,
     transpilation_error: null,
+    ready_to_build: true,
   })
 
   return { account, account2, order, packageRelease }

--- a/bun-tests/fake-snippets-api/routes/package_releases/update.test.ts
+++ b/bun-tests/fake-snippets-api/routes/package_releases/update.test.ts
@@ -24,6 +24,7 @@ test("update package release", async () => {
     package_release_id: release.package_release_id,
     is_locked: true,
     license: "MIT",
+    ready_to_build: true,
   })
 
   expect(response.status).toBe(200)
@@ -35,6 +36,7 @@ test("update package release", async () => {
   )
   expect(updatedRelease?.is_locked).toBe(true)
   expect(updatedRelease?.license).toBe("MIT")
+  expect(updatedRelease?.ready_to_build).toBe(true)
 })
 
 test("update package release using package_name_with_version", async () => {
@@ -59,6 +61,7 @@ test("update package release using package_name_with_version", async () => {
   const response = await axios.post("/api/package_releases/update", {
     package_name_with_version: `${packageName}@${version}`,
     is_locked: true,
+    ready_to_build: true,
   })
 
   expect(response.status).toBe(200)
@@ -67,6 +70,7 @@ test("update package release using package_name_with_version", async () => {
   // Verify the release was updated
   const updatedRelease = db.packageReleases.find((pr) => pr.version === version)
   expect(updatedRelease?.is_locked).toBe(true)
+  expect(updatedRelease?.ready_to_build).toBe(true)
 })
 
 test.skip("update package release - handle is_latest flag", async () => {

--- a/fake-snippets-api/lib/db/autoload-dev-packages.ts
+++ b/fake-snippets-api/lib/db/autoload-dev-packages.ts
@@ -120,7 +120,7 @@ const loadPackageWithDependencies = async (
     latest_package_release_id: release.package_release_id,
   })
 
-  db.addPackageRelease({
+  const addedRelease = db.addPackageRelease({
     ...release,
     created_at: new Date().toISOString(),
   })
@@ -131,6 +131,11 @@ const loadPackageWithDependencies = async (
       created_at: new Date().toISOString(),
     })
   }
+
+  db.updatePackageRelease({
+    ...addedRelease,
+    ready_to_build: true,
+  })
 
   loadedPackages.add(packageKey)
   console.log(`✓ Loaded ${packageKey}`)

--- a/fake-snippets-api/lib/db/db-client.ts
+++ b/fake-snippets-api/lib/db/db-client.ts
@@ -354,7 +354,7 @@ const initializer = combine(databaseSchema.parse({}), (set, get) => ({
       ...state,
       packageReleases: state.packageReleases.map((pr) =>
         pr.package_release_id === newPackageRelease.package_release_id
-          ? { ...pr, fs_sha: fsSha }
+          ? { ...pr, fs_sha: fsSha, ready_to_build: true }
           : pr,
       ),
       packages: state.packages.map((pkg) =>
@@ -1242,6 +1242,7 @@ const initializer = combine(databaseSchema.parse({}), (set, get) => ({
   ): PackageRelease => {
     const newPackageRelease = {
       package_release_id: `package_release_${Date.now()}`,
+      ready_to_build: false,
       ...packageRelease,
     }
     set((state) => ({

--- a/fake-snippets-api/lib/db/schema.ts
+++ b/fake-snippets-api/lib/db/schema.ts
@@ -176,6 +176,7 @@ export const packageReleaseSchema = z.object({
   has_transpiled: z.boolean().default(false),
   transpilation_error: z.string().nullable().optional(),
   fs_sha: z.string().nullable().optional(),
+  ready_to_build: z.boolean().default(false),
 })
 export type PackageRelease = z.infer<typeof packageReleaseSchema>
 

--- a/fake-snippets-api/routes/api/package_releases/create.ts
+++ b/fake-snippets-api/routes/api/package_releases/create.ts
@@ -79,6 +79,7 @@ export default withRouteSpec({
     // Setting the transpiled as true on creation
     has_transpiled: true,
     transpilation_error: null,
+    ready_to_build: false,
   })
 
   // Update the package's latest_package_release_id if this is the latest release

--- a/fake-snippets-api/routes/api/package_releases/update.ts
+++ b/fake-snippets-api/routes/api/package_releases/update.ts
@@ -11,6 +11,7 @@ export default withRouteSpec({
     is_latest: z.boolean().optional(),
     license: z.string().optional(),
     fs_sha: z.string().optional(),
+    ready_to_build: z.boolean().optional(),
   }),
   jsonResponse: z.object({
     ok: z.boolean(),
@@ -23,6 +24,7 @@ export default withRouteSpec({
     is_latest,
     license,
     fs_sha,
+    ready_to_build,
   } = req.jsonBody
   let releaseId = package_release_id
 
@@ -47,7 +49,7 @@ export default withRouteSpec({
     })
   }
 
-  const delta = { is_locked, is_latest, license, fs_sha }
+  const delta = { is_locked, is_latest, license, fs_sha, ready_to_build }
   if (
     Object.keys(delta).filter(
       (k) => delta[k as keyof typeof delta] !== undefined,
@@ -76,6 +78,7 @@ export default withRouteSpec({
     ...(is_latest !== undefined && { is_latest }),
     ...(license !== undefined && { license }),
     ...(fs_sha !== undefined && { fs_sha }),
+    ...(ready_to_build !== undefined && { ready_to_build }),
   }
 
   // Handle is_latest updates atomically

--- a/fake-snippets-api/routes/api/packages/fork.ts
+++ b/fake-snippets-api/routes/api/packages/fork.ts
@@ -159,6 +159,12 @@ export default withRouteSpec({
     })
   }
 
+  // Mark the new release as ready to build
+  ctx.db.updatePackageRelease({
+    ...forkedPackageRelease,
+    ready_to_build: true,
+  })
+
   return ctx.json({
     package: publicMapPackage(forkedPackage),
   })

--- a/fake-snippets-api/routes/api/snippets/create.ts
+++ b/fake-snippets-api/routes/api/snippets/create.ts
@@ -148,6 +148,12 @@ export default withRouteSpec({
       })
     }
 
+    // Mark the package release as ready to build now that files are saved
+    ctx.db.updatePackageRelease({
+      ...newPackageRelease,
+      ready_to_build: true,
+    })
+
     // Create the snippet response object
     const snippetResponse = {
       snippet_id: newPackage.package_id,

--- a/src/hooks/useUpdatePackageFilesMutation.ts
+++ b/src/hooks/useUpdatePackageFilesMutation.ts
@@ -85,6 +85,12 @@ export function useUpdatePackageFilesMutation({
           }
         }
       }
+
+      // Mark the release as ready to build after all file updates
+      await axios.post("/package_releases/update", {
+        package_name_with_version: newPackage.package_name_with_version,
+        ready_to_build: true,
+      })
       return updatedFilesCount
     },
     onSuccess: (updatedFilesCount) => {


### PR DESCRIPTION
## Summary
- default `ready_to_build` flag on package releases
- expose `ready_to_build` from creation routes
- mark releases ready after uploading files
- seed fake API with `ready_to_build`

## Testing
- `bun test` *(fails: get schematic svg of a package)*

------
https://chatgpt.com/codex/tasks/task_b_684077db5ef4832e8f1f5f84604081bc