### PR TITLE
feat: disable code editor during save operations and improve package creation flow

### DIFF
--- a/src/components/package-port/CodeAndPreview.tsx
+++ b/src/components/package-port/CodeAndPreview.tsx
@@ -164,9 +164,9 @@ export function CodeAndPreview({ pkg }: Props) {
     )
   }
 
-  if ((!pkg && urlParams.package_id) || isLoading) {
+  if (urlParams.package_id && (!pkg || isLoading)) {
     return (
-      <div className="flex items-center justify-center h-64">
+      <div className="flex items-center justify-center h-[60vh]">
         <div className="flex flex-col items-center justify-center">
           <div className="text-lg text-gray-500 mb-4">Loading</div>
           <Loader2 className="w-16 h-16 animate-spin text-gray-400" />
@@ -200,6 +200,7 @@ export function CodeAndPreview({ pkg }: Props) {
           )}
         >
           <CodeEditor
+            isSaving={isSaving}
             handleCreateFile={createFile}
             handleDeleteFile={deleteFile}
             currentFile={currentFile}

--- a/src/components/package-port/CodeEditor.tsx
+++ b/src/components/package-port/CodeEditor.tsx
@@ -49,6 +49,7 @@ export const CodeEditor = ({
   onCodeChange,
   readOnly = false,
   files = [],
+  isSaving = false,
   isStreaming = false,
   showImportAndFormatButtons = true,
   onFileContentChanged,
@@ -60,6 +61,7 @@ export const CodeEditor = ({
 }: {
   onCodeChange: (code: string, filename?: string) => void
   files: PackageFile[]
+  isSaving?: boolean
   handleCreateFile: (props: ICreateFileProps) => ICreateFileResult
   handleDeleteFile: (props: IDeleteFileProps) => IDeleteFileResult
   readOnly?: boolean
@@ -242,7 +244,7 @@ export const CodeEditor = ({
         ? json()
         : javascript({ typescript: true, jsx: true }),
       keymap.of([indentWithTab]),
-      EditorState.readOnly.of(readOnly),
+      EditorState.readOnly.of(readOnly || isSaving),
       EditorView.updateListener.of((update) => {
         if (update.docChanged) {
           const newContent = update.state.doc.toString()
@@ -448,7 +450,7 @@ export const CodeEditor = ({
     return () => {
       view.destroy()
     }
-  }, [!isStreaming, currentFile, code !== "", Boolean(highlighter)])
+  }, [!isStreaming, currentFile, code !== "", Boolean(highlighter), isSaving])
 
   const updateCurrentEditorContent = (newContent: string) => {
     if (viewRef.current) {

--- a/src/hooks/use-create-package-mutation.ts
+++ b/src/hooks/use-create-package-mutation.ts
@@ -2,7 +2,6 @@ import type { Package } from "fake-snippets-api/lib/db/schema"
 import { useMutation } from "react-query"
 import { useAxios } from "./use-axios"
 import { useGlobalStore } from "./use-global-store"
-import { useUrlParams } from "./use-url-params"
 
 export const useCreatePackageMutation = ({
   onSuccess,
@@ -42,13 +41,7 @@ export const useCreatePackageMutation = ({
     },
     {
       onSuccess: (pkg: Package) => {
-        const url = new URL(window.location.href)
-        url.searchParams.set("package_id", pkg.package_id)
-        url.searchParams.delete("template")
-        url.searchParams.delete("should_create_package")
-        window.history.pushState({}, "", url.toString())
         onSuccess?.(pkg)
-        window.dispatchEvent(new Event("popstate"))
       },
       onError: (error: any) => {
         console.error("Error creating package:", error)


### PR DESCRIPTION
…
fix #1198 

- disable CodeEditor when isSaving prop is true
- improve loading condition logic and increase loading screen height
- refactor package creation flow for better separation of concerns
- move URL management from mutation hook to file management hook