### PR TITLE
Add package build schema and endpoint

### DIFF
--- a/fake-snippets-api/lib/db/db-client.ts
+++ b/fake-snippets-api/lib/db/db-client.ts
@@ -15,6 +15,7 @@ import {
   type Package,
   type PackageFile,
   type PackageRelease,
+  packageReleaseSchema,
   type Session,
   type Snippet,
   databaseSchema,
@@ -276,7 +277,7 @@ const initializer = combine(databaseSchema.parse({}), (set, get) => ({
     }
 
     // Create package release
-    const newPackageRelease = {
+    const newPackageRelease = packageReleaseSchema.parse({
       package_release_id: `package_release_${nextId}`,
       package_id: newPackage.package_id,
       version: "0.0.1",
@@ -286,7 +287,7 @@ const initializer = combine(databaseSchema.parse({}), (set, get) => ({
       updated_at: currentTime,
       has_transpiled: true,
       transpilation_error: null,
-    }
+    })
 
     // Add all the files
     const packageFiles: PackageFile[] = []
@@ -1238,16 +1239,19 @@ const initializer = combine(databaseSchema.parse({}), (set, get) => ({
     )
   },
   addPackageRelease: (
-    packageRelease: Omit<PackageRelease, "package_release_id">,
+    packageRelease: Omit<
+      z.input<typeof packageReleaseSchema>,
+      "package_release_id"
+    >,
   ): PackageRelease => {
-    const newPackageRelease = {
+    const parsed = packageReleaseSchema.parse({
       package_release_id: `package_release_${Date.now()}`,
       ...packageRelease,
-    }
+    })
     set((state) => ({
-      packageReleases: [...state.packageReleases, newPackageRelease],
+      packageReleases: [...state.packageReleases, parsed],
     }))
-    return newPackageRelease
+    return parsed
   },
   updatePackageRelease: (packageRelease: PackageRelease): void => {
     set((state) => ({

--- a/fake-snippets-api/lib/db/schema.ts
+++ b/fake-snippets-api/lib/db/schema.ts
@@ -176,6 +176,31 @@ export const packageReleaseSchema = z.object({
   has_transpiled: z.boolean().default(false),
   transpilation_error: z.string().nullable().optional(),
   fs_sha: z.string().nullable().optional(),
+  // Build Status and Display
+  display_status: z
+    .enum(["pending", "building", "successful", "failed"])
+    .default("pending"),
+  total_build_duration_ms: z.number().nullable().optional(),
+
+  // Transpilation Process
+  transpilation_display_status: z
+    .enum(["pending", "building", "successful", "failed"])
+    .default("pending"),
+  transpilation_in_progress: z.boolean().default(false),
+  transpilation_started_at: z.string().datetime().nullable().optional(),
+  transpilation_completed_at: z.string().datetime().nullable().optional(),
+  transpilation_logs: z.array(z.any()).default([]),
+  transpilation_is_stale: z.boolean().default(false),
+
+  // Circuit JSON Build Process
+  circuit_json_build_display_status: z
+    .enum(["pending", "building", "successful", "failed"])
+    .default("pending"),
+  circuit_json_build_in_progress: z.boolean().default(false),
+  circuit_json_build_started_at: z.string().datetime().nullable().optional(),
+  circuit_json_build_completed_at: z.string().datetime().nullable().optional(),
+  circuit_json_build_logs: z.array(z.any()).default([]),
+  circuit_json_build_is_stale: z.boolean().default(false),
 })
 export type PackageRelease = z.infer<typeof packageReleaseSchema>
 

--- a/fake-snippets-api/routes/api/package_releases/rebuild.ts
+++ b/fake-snippets-api/routes/api/package_releases/rebuild.ts
@@ -1,0 +1,32 @@
+import { withRouteSpec } from "fake-snippets-api/lib/middleware/with-winter-spec"
+import { packageReleaseSchema } from "fake-snippets-api/lib/db/schema"
+import { z } from "zod"
+
+export default withRouteSpec({
+  methods: ["POST"],
+  auth: "session",
+  jsonBody: z.object({
+    package_release_id: z.string(),
+  }),
+  jsonResponse: z.object({
+    ok: z.boolean(),
+    package_release: packageReleaseSchema,
+  }),
+})(async (req, ctx) => {
+  const { package_release_id } = req.jsonBody
+
+  const release = ctx.db.getPackageReleaseById(package_release_id)
+
+  if (!release) {
+    return ctx.error(404, {
+      error_code: "package_release_not_found",
+      message: "Package release not found",
+    })
+  }
+
+  // In a real API this would trigger a rebuild. Here we simply return the release.
+  return ctx.json({
+    ok: true,
+    package_release: release,
+  })
+})

--- a/src/components/PackageBuildsPage/PackageBuildDetailsPage.tsx
+++ b/src/components/PackageBuildsPage/PackageBuildDetailsPage.tsx
@@ -2,11 +2,11 @@
 
 import { useState } from "react"
 import { BuildPreviewContent } from "./build-preview-content"
-import { DeploymentDetailsPanel } from "./deployment-details-panel"
-import { DeploymentHeader } from "./deployment-header"
+import { PackageBuildDetailsPanel } from "./package-build-details-panel"
+import { PackageBuildHeader } from "./package-build-header"
 import { CollapsibleSection } from "./collapsible-section"
 
-export const DeploymentDetailsPage = () => {
+export const PackageBuildDetailsPage = () => {
   const [openSections, setOpenSections] = useState<Record<string, boolean>>({})
 
   const toggleSection = (section: string) => {
@@ -18,7 +18,7 @@ export const DeploymentDetailsPage = () => {
 
   return (
     <div className="min-h-screen bg-gray-50 text-gray-900">
-      <DeploymentHeader />
+      <PackageBuildHeader />
 
       <div className="px-6 py-6 container mx-auto">
         {/* Main Content */}
@@ -31,7 +31,7 @@ export const DeploymentDetailsPage = () => {
           </div>
 
           {/* Details Panel */}
-          <DeploymentDetailsPanel />
+          <PackageBuildDetailsPanel />
         </div>
 
         {/* Collapsible Sections */}

--- a/src/components/PackageBuildsPage/build-preview-content.tsx
+++ b/src/components/PackageBuildsPage/build-preview-content.tsx
@@ -3,7 +3,7 @@ export function BuildPreviewContent() {
     <div className="flex items-center justify-center">
       <img
         src="https://placehold.co/600x400/000/31343C"
-        alt="Deployment preview"
+        alt="Package build preview"
         className="object-contain rounded p-2 max-h-[400px]"
       />
     </div>

--- a/src/components/PackageBuildsPage/package-build-details-panel.tsx
+++ b/src/components/PackageBuildsPage/package-build-details-panel.tsx
@@ -1,7 +1,7 @@
 import { Globe, GitBranch, GitCommit, Clock } from "lucide-react"
 import { Badge } from "@/components/ui/badge"
 
-export function DeploymentDetailsPanel() {
+export function PackageBuildDetailsPanel() {
   return (
     <div className="space-y-6 bg-white p-4 border border-gray-200 rounded-lg">
       {/* Created */}

--- a/src/components/PackageBuildsPage/package-build-header.tsx
+++ b/src/components/PackageBuildsPage/package-build-header.tsx
@@ -8,7 +8,7 @@ import {
 } from "@/components/ui/dropdown-menu"
 import { useParams } from "wouter"
 
-export function DeploymentHeader() {
+export function PackageBuildHeader() {
   const { author, packageName } = useParams()
 
   return (

--- a/src/hooks/use-current-package-release.ts
+++ b/src/hooks/use-current-package-release.ts
@@ -1,0 +1,28 @@
+import { useParams } from "wouter"
+import { useCurrentPackageId } from "./use-current-package-id"
+import { useUrlParams } from "./use-url-params"
+import { usePackageRelease } from "./use-package-release"
+
+export const useCurrentPackageRelease = () => {
+  const { packageId } = useCurrentPackageId()
+  const urlParams = useUrlParams()
+  const { author, packageName } = useParams()
+
+  const version = urlParams.version
+  const releaseId = urlParams.package_release_id
+
+  let query: Parameters<typeof usePackageRelease>[0] | null = null
+
+  if (releaseId) {
+    query = { package_release_id: releaseId }
+  } else if (version && author && packageName) {
+    query = { package_name_with_version: `${author}/${packageName}@${version}` }
+  } else if (author && packageName) {
+    query = { package_name: `${author}/${packageName}`, is_latest: true }
+  } else if (packageId) {
+    query = { package_id: packageId, is_latest: true }
+  }
+
+  const { data: packageRelease, ...rest } = usePackageRelease(query)
+  return { packageRelease, ...rest }
+}

--- a/src/pages/package-builds.tsx
+++ b/src/pages/package-builds.tsx
@@ -6,7 +6,7 @@ import { Helmet } from "react-helmet-async"
 import { useCurrentPackageId } from "@/hooks/use-current-package-id"
 import { NotFound } from "@/components/NotFound"
 import { ErrorOutline } from "@/components/ErrorOutline"
-import { DeploymentDetailsPage } from "@/components/PackageBuildsPage/DeploymentDetailsPage"
+import { PackageBuildDetailsPage } from "@/components/PackageBuildsPage/PackageBuildDetailsPage"
 
 export const EditorPage = () => {
   const { packageId } = useCurrentPackageId()
@@ -26,7 +26,7 @@ export const EditorPage = () => {
         )}
       </Helmet>
       <Header />
-      <DeploymentDetailsPage />
+      <PackageBuildDetailsPage />
       <Footer />
     </div>
   )


### PR DESCRIPTION
## Summary
- extend package release schema with build status fields
- add rebuild package release API endpoint
- rename deployment components to package build versions
- add hook to fetch the current package release

## Testing
- `bun run format`

------
https://chatgpt.com/codex/tasks/task_b_684097a683cc832e8639e3d5dc053916