### PR TITLE
Add PCB SVG download option

### DIFF
--- a/src/components/DownloadButtonAndMenu.tsx
+++ b/src/components/DownloadButtonAndMenu.tsx
@@ -13,6 +13,7 @@ import { downloadFabricationFiles } from "@/lib/download-fns/download-fabricatio
 import { downloadSchematicSvg } from "@/lib/download-fns/download-schematic-svg"
 import { downloadReadableNetlist } from "@/lib/download-fns/download-readable-netlist"
 import { downloadAssemblySvg } from "@/lib/download-fns/download-assembly-svg"
+import { downloadPcbSvg } from "@/lib/download-fns/download-pcb-svg"
 import { downloadKicadFiles } from "@/lib/download-fns/download-kicad-files"
 import { AnyCircuitElement } from "circuit-json"
 import { ChevronDown, Download, Hammer } from "lucide-react"
@@ -169,6 +170,18 @@ export function DownloadButtonAndMenu({
           >
             <Download className="mr-1 h-3 w-3" />
             <span className="flex-grow mr-6">Assembly SVG</span>
+            <span className="text-[0.6rem] opacity-80 bg-blue-500 text-white font-mono rounded-md px-1 text-center py-0.5 mr-1">
+              svg
+            </span>
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            className="text-xs"
+            onSelect={() => {
+              downloadPcbSvg(circuitJson, snippetUnscopedName || "circuit")
+            }}
+          >
+            <Download className="mr-1 h-3 w-3" />
+            <span className="flex-grow mr-6">PCB SVG</span>
             <span className="text-[0.6rem] opacity-80 bg-blue-500 text-white font-mono rounded-md px-1 text-center py-0.5 mr-1">
               svg
             </span>

--- a/src/lib/download-fns/download-pcb-svg.ts
+++ b/src/lib/download-fns/download-pcb-svg.ts
@@ -7,6 +7,6 @@ export const downloadPcbSvg = (
   fileName: string,
 ) => {
   const svg = convertCircuitJsonToPcbSvg(circuitJson)
-  const blob = new Blob([svg], { type: "image/svg" })
+const blob = new Blob([svg], { type: "image/svg+xml" })
   saveAs(blob, fileName + ".svg")
 }

--- a/src/lib/download-fns/download-pcb-svg.ts
+++ b/src/lib/download-fns/download-pcb-svg.ts
@@ -1,0 +1,12 @@
+import { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToPcbSvg } from "circuit-to-svg"
+import { saveAs } from "file-saver"
+
+export const downloadPcbSvg = (
+  circuitJson: AnyCircuitElement[],
+  fileName: string,
+) => {
+  const svg = convertCircuitJsonToPcbSvg(circuitJson)
+  const blob = new Blob([svg], { type: "image/svg" })
+  saveAs(blob, fileName + ".svg")
+}


### PR DESCRIPTION
## Summary
- allow downloading PCB view as SVG
- support new PCB SVG option in download menu

## Testing
- `bun run format`
- `npx playwright test --list`
- `npx playwright test` *(fails: npm warn Unknown env config, then long build; interrupted)*

------
https://chatgpt.com/codex/tasks/task_b_6841b00b4d4c832e83dd78c1572f4cae