### PR TITLE
Fix Cmd+Enter newline issue

### DIFF
--- a/src/components/package-port/CodeEditor.tsx
+++ b/src/components/package-port/CodeEditor.tsx
@@ -386,6 +386,13 @@ export const CodeEditor = ({
                 }
                 return false
               },
+              keydown: (event) => {
+                if ((event.metaKey || event.ctrlKey) && event.key === "Enter") {
+                  event.preventDefault()
+                  return true
+                }
+                return false
+              },
             }),
             EditorView.theme({
               ".cm-tooltip-hover": {


### PR DESCRIPTION
## Summary
- prevent newline when executing Cmd+Enter inside the code editor

## Testing
- `bun run lint`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_b_684318face0c832e9f7814323ac21991