### PR TITLE
feat: add JLCPCB package generation endpoint and update import dialog

### DIFF
--- a/fake-snippets-api/routes/api/packages/generate_from_jlcpcb.ts
+++ b/fake-snippets-api/routes/api/packages/generate_from_jlcpcb.ts
@@ -1,0 +1,111 @@
+import { withRouteSpec } from "fake-snippets-api/lib/middleware/with-winter-spec"
+import { z } from "zod"
+import { packageSchema } from "fake-snippets-api/lib/db/schema"
+import {
+  fetchEasyEDAComponent,
+  convertRawEasyEdaToTs,
+  normalizeManufacturerPartNumber,
+  EasyEdaJsonSchema,
+} from "easyeda"
+
+export default withRouteSpec({
+  methods: ["POST"],
+  auth: "session",
+  jsonBody: z.object({
+    jlcpcb_part_number: z.string().min(1, "JLCPCB part number is required"),
+  }),
+  jsonResponse: z.object({
+    ok: z.boolean(),
+    package: packageSchema,
+  }),
+})(async (req, ctx) => {
+  const { jlcpcb_part_number } = req.jsonBody
+
+  try {
+    const rawEasyJson = await fetchEasyEDAComponent(jlcpcb_part_number)
+
+    if (!rawEasyJson) {
+      return ctx.error(404, {
+        error_code: "component_not_found",
+        message: `Component with JLCPCB part number ${jlcpcb_part_number} not found`,
+      })
+    }
+
+    const betterEasy = await EasyEdaJsonSchema.parse(rawEasyJson)
+
+    const tsxComponent = await convertRawEasyEdaToTs(rawEasyJson)
+
+    const componentName = normalizeManufacturerPartNumber(
+      betterEasy.dataStr.head.c_para["Manufacturer Part"] ?? "",
+    )
+      .replace(/[^a-zA-Z0-9-_]/g, "-")
+      .replace(/--/g, "-")
+
+    const packageName = `${ctx.auth.github_username}/${componentName}`
+
+    const existingPackage = ctx.db.packages.find((p) => p.name === packageName)
+
+    if (existingPackage) {
+      return ctx.json({
+        ok: true,
+        package: existingPackage,
+      })
+    }
+
+    const newPackage = {
+      name: packageName,
+      unscoped_name: componentName,
+      owner_name: ctx.auth.github_username,
+      code: tsxComponent,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+      description: `Generated from JLCPCB part number ${jlcpcb_part_number}`,
+      creator_account_id: ctx.auth.account_id,
+      owner_org_id: ctx.auth.personal_org_id,
+      owner_github_username: ctx.auth.github_username,
+      latest_package_release_id: null,
+      latest_package_release_fs_sha: null,
+      latest_version: null,
+      license: null,
+      ai_description: "placeholder ai description",
+      ai_usage_instructions: "placeholder ai usage instructions",
+    }
+
+    const createdPackage = ctx.db.addPackage(newPackage)
+
+    const createdPackageRelease = ctx.db.addPackageRelease({
+      package_id: createdPackage.package_id,
+      version: "1.0.0",
+      created_at: new Date().toISOString(),
+      is_latest: true,
+      is_locked: false,
+    })
+
+    ctx.db.updatePackage(createdPackage.package_id, {
+      latest_package_release_id: createdPackageRelease.package_release_id,
+    })
+
+    ctx.db.addPackageFile({
+      package_release_id: createdPackageRelease.package_release_id,
+      file_path: "index.tsx",
+      content_text: String(tsxComponent),
+      created_at: new Date().toISOString(),
+    })
+
+    return ctx.json({
+      ok: true,
+      package: createdPackage as any,
+    })
+  } catch (error: any) {
+    if (String(error).includes("Component not found")) {
+      return ctx.error(404, {
+        error_code: "component_not_found",
+        message: `Component with JLCPCB part number ${jlcpcb_part_number} not found`,
+      })
+    }
+    return ctx.error(500, {
+      error_code: "package_generation_failed",
+      message: `Failed to generate package from JLCPCB part: ${error.message || String(error)}`,
+    })
+  }
+})

--- a/src/components/JLCPCBImportDialog.tsx
+++ b/src/components/JLCPCBImportDialog.tsx
@@ -50,31 +50,16 @@ export function JLCPCBImportDialog({
     setHasBeenImportedToAccountAlready(false)
 
     try {
-      const apiUrl = `/packages/get?name=${session?.github_username}/${partNumber}`
-
-      const existingPackageRes = await axios.get(apiUrl, {
-        validateStatus: (status) => true,
+      const response = await axios.post("/packages/generate_from_jlcpcb", {
+        jlcpcb_part_number: partNumber,
       })
-
-      if (existingPackageRes.status !== 404) {
-        setHasBeenImportedToAccountAlready(true)
+      if (!response.data.ok) {
+        setError("Failed to generate package from JLCPCB part")
         setIsLoading(false)
         return
       }
 
-      const response = await axios
-        .post("/snippets/generate_from_jlcpcb", {
-          jlcpcb_part_number: partNumber,
-        })
-        .catch((e) => e)
-
-      const { snippet, error } = response.data
-
-      if (error) {
-        setError(error.message)
-        setIsLoading(false)
-        return
-      }
+      const { package: generatedPackage } = response.data
 
       toast({
         title: "Import Successful",
@@ -82,13 +67,21 @@ export function JLCPCBImportDialog({
       })
 
       onOpenChange(false)
-      navigate(`/editor?package_id=${snippet.snippet_id}`)
-    } catch (error) {
-      toast({
-        title: "Import Failed",
-        description: "Failed to import the JLCPCB component. Please try again.",
-        variant: "destructive",
-      })
+      navigate(`/editor?package_id=${generatedPackage.package_id}`)
+    } catch (error: any) {
+      if (error.response?.status === 404) {
+        setError(`Component with JLCPCB part number ${partNumber} not found`)
+      } else if (error.response?.data?.message) {
+        setError(error.response.data.message)
+      } else {
+        setError("Failed to import the JLCPCB component. Please try again.")
+        toast({
+          title: "Import Failed",
+          description:
+            "Failed to import the JLCPCB component. Please try again.",
+          variant: "destructive",
+        })
+      }
     } finally {
       setIsLoading(false)
     }
@@ -116,6 +109,7 @@ export function JLCPCBImportDialog({
             className="mt-3"
             placeholder="Enter JLCPCB part number (e.g., C46749)"
             value={partNumber}
+            disabled={isLoading}
             onChange={(e) => {
               setPartNumber(e.target.value)
               setError(null)


### PR DESCRIPTION
- Implemented a new API endpoint for generating packages from JLCPCB part numbers.
- Updated the JLCPCBImportDialog component to utilize the new endpoint for package generation.
- Enhanced error handling for component not found and import failures.