### PR TITLE
Fix case insensitive usernames

### DIFF
--- a/bun-tests/fake-snippets-api/routes/accounts/get.test.ts
+++ b/bun-tests/fake-snippets-api/routes/accounts/get.test.ts
@@ -51,3 +51,14 @@ test("POST /api/accounts/get - should return 404 if account not found", async ()
     expect(error.data.error.message).toBe("Account not found")
   }
 })
+
+test("POST /api/accounts/get - should be case insensitive", async () => {
+  const { axios } = await getTestServer()
+
+  const response = await axios.post("/api/accounts/get", {
+    github_username: "TestUser",
+  })
+
+  expect(response.status).toBe(200)
+  expect(response.data.account.github_username).toBe("testuser")
+})

--- a/fake-snippets-api/routes/api/accounts/get.ts
+++ b/fake-snippets-api/routes/api/accounts/get.ts
@@ -17,7 +17,8 @@ export default withRouteSpec({
   if (req.method === "POST") {
     const { github_username } = req.jsonBody
     account = ctx.db.accounts.find(
-      (acc: Account) => acc.github_username === github_username,
+      (acc: Account) =>
+        acc.github_username.toLowerCase() === github_username.toLowerCase(),
     )
   } else {
     account = ctx.db.getAccount(ctx.auth.account_id)


### PR DESCRIPTION
## Summary
- normalize user lookups so user profile pages work with case-insensitive usernames
- update fake API endpoint `/api/accounts/get` to lookup accounts by username without case sensitivity
- add regression tests for case-insensitive account lookup
- display the GitHub username from the db using `githubUsername`

## Testing
- `bun test`


------
https://chatgpt.com/codex/tasks/task_b_68434309fec48327a0b2ad887d662db8