### PR TITLE
feat: add package name editing to edit package details dialog

### DIFF
--- a/src/components/ViewPackagePage/components/mobile-sidebar.tsx
+++ b/src/components/ViewPackagePage/components/mobile-sidebar.tsx
@@ -211,6 +211,7 @@ const MobileSidebar = ({
           packageAuthor={packageInfo.owner_github_username}
           onUpdate={handlePackageUpdate}
           packageName={packageInfo.name}
+          unscopedPackageName={packageInfo.unscoped_name}
           currentDefaultView={packageInfo.default_view}
         />
       )}

--- a/src/components/ViewPackagePage/components/sidebar-about-section.tsx
+++ b/src/components/ViewPackagePage/components/sidebar-about-section.tsx
@@ -161,6 +161,7 @@ export default function SidebarAboutSection() {
 
       {packageInfo && (
         <EditPackageDetailsDialog
+          unscopedPackageName={packageInfo.unscoped_name}
           packageReleaseId={packageInfo.latest_package_release_id}
           packageId={packageInfo.package_id}
           currentDescription={

--- a/src/hooks/use-package-details-form.ts
+++ b/src/hooks/use-package-details-form.ts
@@ -16,6 +16,7 @@ interface PackageDetailsForm {
   license: string | null
   visibility: string
   defaultView: string
+  unscopedPackageName: string
 }
 
 interface UsePackageDetailsFormProps {
@@ -24,6 +25,7 @@ interface UsePackageDetailsFormProps {
   initialLicense: string | null
   initialVisibility: string
   initialDefaultView: string
+  initialUnscopedPackageName: string
   isDialogOpen: boolean
 }
 
@@ -33,6 +35,7 @@ export const usePackageDetailsForm = ({
   initialLicense,
   initialVisibility,
   initialDefaultView,
+  initialUnscopedPackageName,
   isDialogOpen,
 }: UsePackageDetailsFormProps) => {
   const [formData, setFormData] = useState<PackageDetailsForm>({
@@ -41,6 +44,7 @@ export const usePackageDetailsForm = ({
     license: initialLicense || null,
     visibility: initialVisibility,
     defaultView: initialDefaultView,
+    unscopedPackageName: initialUnscopedPackageName,
   })
   const [websiteError, setWebsiteError] = useState<string | null>(null)
 
@@ -52,6 +56,7 @@ export const usePackageDetailsForm = ({
         license: initialLicense || null,
         visibility: initialVisibility,
         defaultView: initialDefaultView,
+        unscopedPackageName: initialUnscopedPackageName,
       })
       setWebsiteError(null)
     }
@@ -62,6 +67,7 @@ export const usePackageDetailsForm = ({
     initialLicense,
     initialVisibility,
     initialDefaultView,
+    initialUnscopedPackageName,
   ])
 
   useEffect(() => {
@@ -93,7 +99,8 @@ export const usePackageDetailsForm = ({
       formData.website !== initialWebsite ||
       formData.license !== initialLicense ||
       formData.visibility !== initialVisibility ||
-      formData.defaultView !== initialDefaultView,
+      formData.defaultView !== initialDefaultView ||
+      formData.unscopedPackageName !== initialUnscopedPackageName,
     [
       formData,
       initialDescription,
@@ -101,6 +108,7 @@ export const usePackageDetailsForm = ({
       initialLicense,
       initialVisibility,
       initialDefaultView,
+      initialUnscopedPackageName,
     ],
   )
 


### PR DESCRIPTION
- Add unscopedPackageName field to dialog form
- Update form validation to track package name changes
- Implement package name update in API calls
- Add client-side URL navigation when package name changes
- Improve error handling with detailed error messages
- Add autoComplete="off" to form inputs
- Add spellCheck={false} to description textarea