### PR TITLE
Update package release mutation to handle existing versions

### DIFF
--- a/src/hooks/use-create-package-release-mutation.ts
+++ b/src/hooks/use-create-package-release-mutation.ts
@@ -29,21 +29,71 @@ export const useCreatePackageReleaseMutation = ({
         )
       }
 
-      const {
-        data: { package_release: newPackageRelease },
-      } = await axios.post("/package_releases/create", {
-        package_id,
-        version,
-        is_latest,
-        commit_sha,
-        package_name_with_version,
-      })
+      let resolvedVersion = version
+      let resolvedPkgName = package_name_with_version
 
-      if (!newPackageRelease) {
-        throw new Error("Failed to create package release")
+      // Parse version from package_name_with_version if needed
+      if (package_name_with_version && !version) {
+        const [pkgName, parsedVersion] = package_name_with_version.split("@")
+        resolvedVersion = parsedVersion
+        resolvedPkgName = pkgName
+      } else if (package_name_with_version) {
+        const [pkgName] = package_name_with_version.split("@")
+        resolvedPkgName = pkgName
       }
 
-      return newPackageRelease
+      // Default version to 1.0.0 when it contains no digits
+      if (!resolvedVersion || !/[0-9]/.test(resolvedVersion)) {
+        resolvedVersion = "1.0.0"
+      }
+
+      const normalizedPackageNameWithVersion =
+        resolvedPkgName && `${resolvedPkgName}@${resolvedVersion}`
+
+      try {
+        const {
+          data: { package_release: newPackageRelease },
+        } = await axios.post("/package_releases/create", {
+          package_id,
+          version: resolvedVersion,
+          is_latest,
+          commit_sha,
+          package_name_with_version: normalizedPackageNameWithVersion,
+        })
+
+        if (!newPackageRelease) {
+          throw new Error("Failed to create package release")
+        }
+
+        return newPackageRelease
+      } catch (error: any) {
+        if (
+          error.status === 400 &&
+          error.data?.error?.error_code === "version_already_exists" &&
+          normalizedPackageNameWithVersion
+        ) {
+          // Update the existing release with the provided data
+          await axios.post("/package_releases/update", {
+            package_name_with_version: normalizedPackageNameWithVersion,
+            is_latest,
+            commit_sha,
+          })
+
+          const {
+            data: { package_release },
+          } = await axios.post("/package_releases/get", {
+            package_name_with_version: normalizedPackageNameWithVersion,
+          })
+
+          if (!package_release) {
+            throw new Error("Failed to update package release")
+          }
+
+          return package_release as PackageRelease
+        }
+
+        throw error
+      }
     },
     {
       onSuccess: (packageRelease: PackageRelease) => {


### PR DESCRIPTION
## Summary
- revert accidental API changes from previous commit
- update `useCreatePackageReleaseMutation` to default version to `1.0.0`
- update the hook to update an existing release if the version already exists

## Testing
- `bun test`


------
https://chatgpt.com/codex/tasks/task_b_68434af7877c832ebf43f7098e81f286