### PR TITLE
Add package_name support for package_release creation

### DIFF
--- a/bun-tests/fake-snippets-api/routes/package_releases/create.test.ts
+++ b/bun-tests/fake-snippets-api/routes/package_releases/create.test.ts
@@ -56,6 +56,31 @@ test("create package release using package_name_with_version", async () => {
   expect(releaseResponse.data.package_release.is_latest).toBe(true)
 })
 
+test("create package release using package_name and version", async () => {
+  const { axios } = await getTestServer()
+
+  const packageResponse = await axios.post("/api/packages/create", {
+    name: "testuser/test-package-name-version",
+    description: "Test Description",
+  })
+  expect(packageResponse.status).toBe(200)
+  const createdPackage = packageResponse.data.package
+
+  const releaseResponse = await axios.post("/api/package_releases/create", {
+    package_name: createdPackage.name,
+    version: "3.0.0",
+  })
+
+  expect(releaseResponse.status).toBe(200)
+  expect(releaseResponse.data.ok).toBe(true)
+  expect(releaseResponse.data.package_release).toBeDefined()
+  expect(releaseResponse.data.package_release.package_id).toBe(
+    createdPackage.package_id,
+  )
+  expect(releaseResponse.data.package_release.version).toBe("3.0.0")
+  expect(releaseResponse.data.package_release.is_latest).toBe(true)
+})
+
 test("create package release - version already exists", async () => {
   const { axios } = await getTestServer()
 

--- a/fake-snippets-api/routes/api/package_releases/create.ts
+++ b/fake-snippets-api/routes/api/package_releases/create.ts
@@ -8,6 +8,7 @@ export default withRouteSpec({
   auth: "none",
   jsonBody: z.object({
     package_id: z.string().optional(),
+    package_name: z.string().optional(),
     version: z.string().optional(),
     is_latest: z.boolean().optional(),
     commit_sha: z.string().optional(),
@@ -20,6 +21,7 @@ export default withRouteSpec({
 })(async (req, ctx) => {
   let {
     package_id,
+    package_name,
     is_latest = true,
     version,
     commit_sha,
@@ -41,10 +43,21 @@ export default withRouteSpec({
     version = parsedVersion
   }
 
+  if (!package_id && package_name) {
+    const pkg = ctx.db.packages.find((p) => p.name === package_name)
+    if (!pkg) {
+      return ctx.error(404, {
+        error_code: "package_not_found",
+        message: `Package not found: ${package_name}`,
+      })
+    }
+    package_id = pkg.package_id
+  }
+
   if (!package_id || !version) {
     return ctx.error(400, {
       error_code: "missing_options",
-      message: "package_id and version are required",
+      message: "package_id or package_name and version are required",
     })
   }
 


### PR DESCRIPTION
## Summary
- allow using `{ package_name, version }` in package release creation
- test new create path with package_name

## Testing
- `bun test`

------
https://chatgpt.com/codex/tasks/task_b_684359d9e4ac832e916fcba94c05ff65