### PR TITLE
Fix line comment shortcut

### DIFF
--- a/src/components/package-port/CodeEditor.tsx
+++ b/src/components/package-port/CodeEditor.tsx
@@ -6,6 +6,7 @@ import { javascript } from "@codemirror/lang-javascript"
 import { json } from "@codemirror/lang-json"
 import { EditorState } from "@codemirror/state"
 import { Decoration, hoverTooltip, keymap } from "@codemirror/view"
+import { toggleSlashComment } from "@/lib/codemirror/toggle-slash-comment"
 import { getImportsFromCode } from "@tscircuit/prompt-benchmarks/code-runner-utils"
 import type { ATABootstrapConfig } from "@typescript/ata"
 import { setupTypeAcquisition } from "@typescript/ata"
@@ -238,6 +239,7 @@ export const CodeEditor = ({
         ? json()
         : javascript({ typescript: true, jsx: true }),
       keymap.of([indentWithTab]),
+      keymap.of([{ key: "Mod-/", run: toggleSlashComment }]),
       EditorState.readOnly.of(readOnly || isSaving),
       EditorView.updateListener.of((update) => {
         if (update.docChanged) {

--- a/src/lib/codemirror/toggle-slash-comment.ts
+++ b/src/lib/codemirror/toggle-slash-comment.ts
@@ -1,0 +1,51 @@
+import type { StateCommand } from "@codemirror/state"
+import { EditorState } from "@codemirror/state"
+
+/**
+ * Toggle line comments using // regardless of language configuration.
+ */
+export const toggleSlashComment: StateCommand = ({ state, dispatch }) => {
+  if (state.readOnly) return false
+
+  const ranges = state.selection.ranges
+  let commentAll = true
+
+  for (const { from, to } of ranges) {
+    for (let pos = from; pos <= to; ) {
+      const line = state.doc.lineAt(pos)
+      const indent = /^\s*/.exec(line.text)?.[0].length || 0
+      if (!line.text.slice(indent).startsWith("//")) {
+        commentAll = false
+        break
+      }
+      pos = line.to + 1
+    }
+    if (!commentAll) break
+  }
+
+  const changes = []
+  for (const { from, to } of ranges) {
+    for (let pos = from; pos <= to; ) {
+      const line = state.doc.lineAt(pos)
+      const indent = /^\s*/.exec(line.text)?.[0].length || 0
+      const lineStart = line.from + indent
+      if (commentAll) {
+        if (line.text.slice(indent).startsWith("//")) {
+          let end = lineStart + 2
+          if (line.text.slice(indent + 2, indent + 3) === " ") end++
+          changes.push({ from: lineStart, to: end })
+        }
+      } else {
+        if (line.text.trim().length) {
+          changes.push({ from: lineStart, insert: "// " })
+        }
+      }
+      pos = line.to + 1
+    }
+  }
+
+  if (!changes.length) return false
+
+  dispatch(state.update({ changes, scrollIntoView: true }))
+  return true
+}


### PR DESCRIPTION
## Summary
- add a helper to force line comments
- hook custom command into editor keymap

## Testing
- `bun run format`
- `bun run lint`


------
https://chatgpt.com/codex/tasks/task_b_6843e6ed0d5c8327afe5af21a5569280