### PR TITLE
Enable build rebuild action

### DIFF
--- a/src/components/PackageBuildsPage/package-build-header.tsx
+++ b/src/components/PackageBuildsPage/package-build-header.tsx
@@ -2,9 +2,14 @@ import { Github, RefreshCw } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { useParams } from "wouter"
 import { DownloadButtonAndMenu } from "../DownloadButtonAndMenu"
+import { useCurrentPackageRelease } from "@/hooks/use-current-package-release"
+import { useRebuildPackageReleaseMutation } from "@/hooks/use-rebuild-package-release-mutation"
 
 export function PackageBuildHeader() {
   const { author, packageName } = useParams()
+  const { packageRelease } = useCurrentPackageRelease()
+  const { mutate: rebuildPackage, isLoading } =
+    useRebuildPackageReleaseMutation()
 
   return (
     <div className="border-b border-gray-200 bg-white px-6 py-4">
@@ -38,9 +43,16 @@ export function PackageBuildHeader() {
             variant="outline"
             size="sm"
             className="border-gray-300 bg-white hover:bg-gray-50 text-xs sm:text-sm"
+            disabled={isLoading || !packageRelease}
+            onClick={() =>
+              packageRelease &&
+              rebuildPackage({
+                package_release_id: packageRelease.package_release_id,
+              })
+            }
           >
             <RefreshCw className="w-3 h-3 sm:w-4 sm:h-4 mr-1 sm:mr-2" />
-            Rebuild
+            {isLoading ? "Rebuilding..." : "Rebuild"}
           </Button>
           <DownloadButtonAndMenu
             snippetUnscopedName={`${author}/${packageName}`}

--- a/src/hooks/use-rebuild-package-release-mutation.ts
+++ b/src/hooks/use-rebuild-package-release-mutation.ts
@@ -1,0 +1,42 @@
+import { PackageRelease } from "fake-snippets-api/lib/db/schema"
+import { useMutation, useQueryClient } from "react-query"
+import { useAxios } from "./use-axios"
+import { useToast } from "./use-toast"
+
+export const useRebuildPackageReleaseMutation = ({
+  onSuccess,
+}: { onSuccess?: (packageRelease: PackageRelease) => void } = {}) => {
+  const axios = useAxios()
+  const { toast } = useToast()
+  const queryClient = useQueryClient()
+
+  return useMutation(
+    async ({ package_release_id }: { package_release_id: string }) => {
+      const { data } = await axios.post("/package_releases/rebuild", {
+        package_release_id,
+      })
+      if (!data?.ok) {
+        throw new Error("Failed to trigger rebuild")
+      }
+      return data.package_release as PackageRelease
+    },
+    {
+      onSuccess: (pkgRelease) => {
+        toast({
+          title: "Rebuild triggered",
+          description: "The package build has been queued for rebuild.",
+        })
+        queryClient.invalidateQueries(["packageRelease"])
+        onSuccess?.(pkgRelease)
+      },
+      onError: (error: any) => {
+        toast({
+          title: "Error",
+          description:
+            error?.data?.error?.message || "Failed to rebuild package.",
+          variant: "destructive",
+        })
+      },
+    },
+  )
+}


### PR DESCRIPTION
## Summary
- hook up the Rebuild button on the package builds page
- provide a hook to trigger a rebuild via `/package_releases/rebuild`

## Testing
- `bun run format`
- `bun run playwright` *(fails: bunx not found)*

------
https://chatgpt.com/codex/tasks/task_b_68445073866c8327952951b06cc7f31e