### PR TITLE
Add ai_review_text support

### DIFF
--- a/fake-snippets-api/lib/db/db-client.ts
+++ b/fake-snippets-api/lib/db/db-client.ts
@@ -1195,6 +1195,7 @@ const initializer = combine(databaseSchema.parse({}), (set, get) => ({
     const newPackage = {
       package_id: `package_${timestamp}`,
       ..._package,
+      ai_review_text: _package.ai_review_text ?? null,
     }
     set((state) => ({
       packages: [...state.packages, newPackage as Package],
@@ -1247,6 +1248,7 @@ const initializer = combine(databaseSchema.parse({}), (set, get) => ({
     const parsed = packageReleaseSchema.parse({
       package_release_id: `package_release_${Date.now()}`,
       ...packageRelease,
+      ai_review_text: packageRelease.ai_review_text ?? null,
     })
     set((state) => ({
       packageReleases: [...state.packageReleases, parsed],

--- a/fake-snippets-api/lib/db/schema.ts
+++ b/fake-snippets-api/lib/db/schema.ts
@@ -201,6 +201,7 @@ export const packageReleaseSchema = z.object({
   circuit_json_build_completed_at: z.string().datetime().nullable().optional(),
   circuit_json_build_logs: z.array(z.any()).default([]),
   circuit_json_build_is_stale: z.boolean().default(false),
+  ai_review_text: z.string().nullable().optional(),
 })
 export type PackageRelease = z.infer<typeof packageReleaseSchema>
 
@@ -244,6 +245,7 @@ export const packageSchema = z.object({
   ai_description: z.string().nullable(),
   latest_license: z.string().nullable().optional(),
   ai_usage_instructions: z.string().nullable(),
+  ai_review_text: z.string().nullable(),
   latest_package_release_fs_sha: z.string().nullable().default(null),
   default_view: z
     .enum(["files", "3d", "pcb", "schematic"])

--- a/fake-snippets-api/lib/public-mapping/public-map-package.ts
+++ b/fake-snippets-api/lib/public-mapping/public-map-package.ts
@@ -18,6 +18,7 @@ export const publicMapPackage = (internalPackage: {
   created_at: string
   ai_description: string | null
   ai_usage_instructions: string | null
+  ai_review_text: string | null
   is_snippet: boolean
   is_board: boolean
   is_package: boolean

--- a/fake-snippets-api/routes/api/package_releases/create.ts
+++ b/fake-snippets-api/routes/api/package_releases/create.ts
@@ -99,6 +99,7 @@ export default withRouteSpec({
     ctx.db.updatePackage(package_id, {
       latest_package_release_id: newPackageRelease.package_release_id,
       latest_version: version,
+      ai_review_text: newPackageRelease.ai_review_text ?? null,
     })
   }
 

--- a/fake-snippets-api/routes/api/packages/create.ts
+++ b/fake-snippets-api/routes/api/packages/create.ts
@@ -56,6 +56,7 @@ export default withRouteSpec({
     is_public: is_private === true ? false : true,
     is_unlisted: is_private === true ? true : (is_unlisted ?? false),
     ai_usage_instructions: "placeholder ai usage instructions",
+    ai_review_text: "placeholder ai review text",
     default_view: "files",
   })
 

--- a/fake-snippets-api/routes/api/packages/fork.ts
+++ b/fake-snippets-api/routes/api/packages/fork.ts
@@ -116,6 +116,7 @@ export default withRouteSpec({
     is_public: !is_private,
     is_unlisted,
     ai_usage_instructions: "forked package usage",
+    ai_review_text: sourcePackage.ai_review_text || null,
     is_board: Boolean(sourcePackage.is_board),
     is_package: true,
     is_model: Boolean(sourcePackage.is_model),

--- a/fake-snippets-api/routes/api/packages/generate_from_jlcpcb.ts
+++ b/fake-snippets-api/routes/api/packages/generate_from_jlcpcb.ts
@@ -69,6 +69,7 @@ export default withRouteSpec({
       license: null,
       ai_description: "placeholder ai description",
       ai_usage_instructions: "placeholder ai usage instructions",
+      ai_review_text: "placeholder ai review text",
     }
 
     const createdPackage = ctx.db.addPackage(newPackage)

--- a/fake-snippets-api/routes/api/snippets/create.ts
+++ b/fake-snippets-api/routes/api/snippets/create.ts
@@ -92,6 +92,7 @@ export default withRouteSpec({
       is_unlisted: is_unlisted || false,
       latest_package_release_id: null,
       ai_usage_instructions: "placeholder ai usage instructions",
+      ai_review_text: null,
     })
 
     const newPackageRelease = ctx.db.addPackageRelease({

--- a/src/components/ViewPackagePage/components/important-files-view.tsx
+++ b/src/components/ViewPackagePage/components/important-files-view.tsx
@@ -44,7 +44,9 @@ export default function ImportantFilesView({
     setTimeout(() => setCopyState("copy"), 500)
   }
   // Determine if we have AI content
-  const hasAiContent = Boolean(aiDescription || aiUsageInstructions || aiReviewText)
+  const hasAiContent = Boolean(
+    aiDescription || aiUsageInstructions || aiReviewText,
+  )
 
   // Select the appropriate tab/file when content changes
   useEffect(() => {

--- a/src/components/ViewPackagePage/components/important-files-view.tsx
+++ b/src/components/ViewPackagePage/components/important-files-view.tsx
@@ -23,12 +23,14 @@ interface ImportantFilesViewProps {
 
   aiDescription?: string
   aiUsageInstructions?: string
+  aiReviewText?: string
 }
 
 export default function ImportantFilesView({
   importantFiles = [],
   aiDescription,
   aiUsageInstructions,
+  aiReviewText,
   isLoading = false,
   onEditClicked,
 }: ImportantFilesViewProps) {
@@ -42,7 +44,7 @@ export default function ImportantFilesView({
     setTimeout(() => setCopyState("copy"), 500)
   }
   // Determine if we have AI content
-  const hasAiContent = Boolean(aiDescription || aiUsageInstructions)
+  const hasAiContent = Boolean(aiDescription || aiUsageInstructions || aiReviewText)
 
   // Select the appropriate tab/file when content changes
   useEffect(() => {
@@ -100,6 +102,11 @@ export default function ImportantFilesView({
           <div>
             <h3 className="font-semibold text-lg mb-2">Instructions</h3>
             <MarkdownViewer markdownContent={aiUsageInstructions} />
+          </div>
+        )}
+        {aiReviewText && (
+          <div className="mt-6">
+            <MarkdownViewer markdownContent={aiReviewText} />
           </div>
         )}
       </div>

--- a/src/components/ViewPackagePage/components/repo-page-content.tsx
+++ b/src/components/ViewPackagePage/components/repo-page-content.tsx
@@ -198,6 +198,7 @@ export default function RepoPageContent({
               onEditClicked={onEditClicked}
               aiDescription={packageInfo?.ai_description ?? ""}
               aiUsageInstructions={packageInfo?.ai_usage_instructions ?? ""}
+              aiReviewText={packageInfo?.ai_review_text ?? ""}
             />
           </div>
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -22,6 +22,7 @@ export interface PackageInfo {
   description: string
   ai_description: string
   ai_usage_instructions: string
+  ai_review_text: string
   creator_account_id?: string
   owner_org_id?: string
   package_id: string


### PR DESCRIPTION
## Summary
- add `ai_review_text` to package_release and packages schema
- store review text when creating packages
- expose review text via package API
- show review text in ImportantFilesView

## Testing
- `bun test`

------
https://chatgpt.com/codex/tasks/task_b_6844d86e776c832eae455bd16d697fa0