### PR TITLE
Add AI review support

### DIFF
--- a/bun-tests/fake-snippets-api/routes/package_releases/create.test.ts
+++ b/bun-tests/fake-snippets-api/routes/package_releases/create.test.ts
@@ -28,6 +28,8 @@ test("create package release", async () => {
   expect(releaseResponse.data.package_release.version).toBe("1.0.0")
   expect(releaseResponse.data.package_release.is_latest).toBe(true)
   expect(releaseResponse.data.package_release.is_locked).toBe(false)
+  expect(releaseResponse.data.package_release.ai_review_requested).toBe(false)
+  expect(releaseResponse.data.package_release.ai_review_text).toBeNull()
 })
 
 test("create package release using package_name_with_version", async () => {
@@ -54,6 +56,8 @@ test("create package release using package_name_with_version", async () => {
   )
   expect(releaseResponse.data.package_release.version).toBe("2.0.0")
   expect(releaseResponse.data.package_release.is_latest).toBe(true)
+  expect(releaseResponse.data.package_release.ai_review_requested).toBe(false)
+  expect(releaseResponse.data.package_release.ai_review_text).toBeNull()
 })
 
 test("create package release using package_name and version", async () => {
@@ -79,6 +83,8 @@ test("create package release using package_name and version", async () => {
   )
   expect(releaseResponse.data.package_release.version).toBe("3.0.0")
   expect(releaseResponse.data.package_release.is_latest).toBe(true)
+  expect(releaseResponse.data.package_release.ai_review_requested).toBe(false)
+  expect(releaseResponse.data.package_release.ai_review_text).toBeNull()
 })
 
 test("create package release - version already exists", async () => {

--- a/bun-tests/fake-snippets-api/routes/package_releases/update.test.ts
+++ b/bun-tests/fake-snippets-api/routes/package_releases/update.test.ts
@@ -24,6 +24,7 @@ test("update package release", async () => {
     package_release_id: release.package_release_id,
     is_locked: true,
     license: "MIT",
+    ai_review_requested: true,
   })
 
   expect(response.status).toBe(200)
@@ -35,6 +36,8 @@ test("update package release", async () => {
   )
   expect(updatedRelease?.is_locked).toBe(true)
   expect(updatedRelease?.license).toBe("MIT")
+  expect(updatedRelease?.ai_review_requested).toBe(true)
+  expect(updatedRelease?.ai_review_text).toBe("Placeholder AI Review Text")
 })
 
 test("update package release using package_name_with_version", async () => {

--- a/fake-snippets-api/lib/db/schema.ts
+++ b/fake-snippets-api/lib/db/schema.ts
@@ -201,6 +201,10 @@ export const packageReleaseSchema = z.object({
   circuit_json_build_completed_at: z.string().datetime().nullable().optional(),
   circuit_json_build_logs: z.array(z.any()).default([]),
   circuit_json_build_is_stale: z.boolean().default(false),
+
+  // AI Review
+  ai_review_text: z.string().nullable().default(null),
+  ai_review_requested: z.boolean().default(false),
 })
 export type PackageRelease = z.infer<typeof packageReleaseSchema>
 

--- a/fake-snippets-api/routes/api/package_releases/update.ts
+++ b/fake-snippets-api/routes/api/package_releases/update.ts
@@ -12,6 +12,7 @@ export default withRouteSpec({
     license: z.string().optional(),
     fs_sha: z.string().optional(),
     ready_to_build: z.boolean().optional(),
+    ai_review_requested: z.boolean().optional(),
   }),
   jsonResponse: z.object({
     ok: z.boolean(),
@@ -25,6 +26,7 @@ export default withRouteSpec({
     license,
     fs_sha,
     ready_to_build,
+    ai_review_requested,
   } = req.jsonBody
   let releaseId = package_release_id
 
@@ -49,7 +51,14 @@ export default withRouteSpec({
     })
   }
 
-  const delta = { is_locked, is_latest, license, fs_sha, ready_to_build }
+  const delta = {
+    is_locked,
+    is_latest,
+    license,
+    fs_sha,
+    ready_to_build,
+    ai_review_requested,
+  }
   if (
     Object.keys(delta).filter(
       (k) => delta[k as keyof typeof delta] !== undefined,
@@ -79,6 +88,10 @@ export default withRouteSpec({
     ...(license !== undefined && { license }),
     ...(fs_sha !== undefined && { fs_sha }),
     ...(ready_to_build !== undefined && { ready_to_build }),
+    ...(ai_review_requested !== undefined && { ai_review_requested }),
+    ...(ai_review_requested === true && {
+      ai_review_text: "Placeholder AI Review Text",
+    }),
   }
 
   // Handle is_latest updates atomically

--- a/src/components/ViewPackagePage/components/repo-page-content.tsx
+++ b/src/components/ViewPackagePage/components/repo-page-content.tsx
@@ -20,6 +20,7 @@ import { useGlobalStore } from "@/hooks/use-global-store"
 import { useLocation } from "wouter"
 import { Package } from "fake-snippets-api/lib/db/schema"
 import { useCurrentPackageCircuitJson } from "../hooks/use-current-package-circuit-json"
+import { useRequestAiReviewMutation } from "@/hooks/use-request-ai-review-mutation"
 
 interface PackageFile {
   package_file_id: string
@@ -34,6 +35,7 @@ interface RepoPageContentProps {
   packageFiles?: PackageFile[]
   importantFilePaths?: string[]
   packageInfo?: Package
+  packageRelease?: import("fake-snippets-api/lib/db/schema").PackageRelease
   onFileClicked?: (file: PackageFile) => void
   onEditClicked?: () => void
 }
@@ -41,6 +43,7 @@ interface RepoPageContentProps {
 export default function RepoPageContent({
   packageFiles,
   packageInfo,
+  packageRelease,
   onFileClicked,
   onEditClicked,
 }: RepoPageContentProps) {
@@ -48,6 +51,7 @@ export default function RepoPageContent({
   const session = useGlobalStore((s) => s.session)
   const { circuitJson, isLoading: isCircuitJsonLoading } =
     useCurrentPackageCircuitJson()
+  const { mutate: requestAiReview } = useRequestAiReviewMutation()
 
   // Handle initial view selection and hash-based view changes
   useEffect(() => {
@@ -198,6 +202,15 @@ export default function RepoPageContent({
               onEditClicked={onEditClicked}
               aiDescription={packageInfo?.ai_description ?? ""}
               aiUsageInstructions={packageInfo?.ai_usage_instructions ?? ""}
+              aiReviewText={packageRelease?.ai_review_text ?? null}
+              aiReviewRequested={packageRelease?.ai_review_requested ?? false}
+              onRequestAiReview={() => {
+                if (packageRelease) {
+                  requestAiReview({
+                    package_release_id: packageRelease.package_release_id,
+                  })
+                }
+              }}
             />
           </div>
 

--- a/src/hooks/use-request-ai-review-mutation.ts
+++ b/src/hooks/use-request-ai-review-mutation.ts
@@ -1,0 +1,45 @@
+import { useMutation, useQueryClient } from "react-query"
+import { useAxios } from "./use-axios"
+import { useToast } from "./use-toast"
+import type { PackageRelease } from "fake-snippets-api/lib/db/schema"
+
+export const useRequestAiReviewMutation = ({
+  onSuccess,
+}: { onSuccess?: (packageRelease: PackageRelease) => void } = {}) => {
+  const axios = useAxios()
+  const { toast } = useToast()
+  const queryClient = useQueryClient()
+
+  return useMutation(
+    async ({ package_release_id }: { package_release_id: string }) => {
+      await axios.post("/package_releases/update", {
+        package_release_id,
+        ai_review_requested: true,
+      })
+      const { data } = await axios.post("/package_releases/get", {
+        package_release_id,
+      })
+      return data.package_release as PackageRelease
+    },
+    {
+      onSuccess: (packageRelease) => {
+        toast({
+          title: "AI review requested",
+          description: "An AI review has been generated.",
+        })
+        queryClient.invalidateQueries(["packageRelease"])
+        onSuccess?.(packageRelease)
+      },
+      onError: (error: any) => {
+        toast({
+          title: "Error",
+          description:
+            error?.response?.data?.message ||
+            error?.data?.message ||
+            "Failed to request AI review.",
+          variant: "destructive",
+        })
+      },
+    },
+  )
+}

--- a/src/pages/view-package.tsx
+++ b/src/pages/view-package.tsx
@@ -46,6 +46,7 @@ export const ViewPackagePage = () => {
       <RepoPageContent
         packageFiles={packageFiles as any}
         packageInfo={packageInfo as any}
+        packageRelease={packageRelease as any}
         importantFilePaths={["README.md", "LICENSE", "package.json"]}
         onFileClicked={(file) => {
           setLocation(


### PR DESCRIPTION
## Summary
- extend package releases with `ai_review_text` and `ai_review_requested`
- allow requesting AI review via `/package_releases/update`
- expose AI Review tab and request button in Important Files
- request AI review from UI using new mutation
- cover new fields in tests

## Testing
- `bun run format`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_b_684666b68a90832e8197f111e49abff7