### PR TITLE
Fix newline on cmd+enter in CodeEditor

### DIFF
--- a/src/components/package-port/CodeEditor.tsx
+++ b/src/components/package-port/CodeEditor.tsx
@@ -4,7 +4,7 @@ import { autocompletion } from "@codemirror/autocomplete"
 import { indentWithTab } from "@codemirror/commands"
 import { javascript } from "@codemirror/lang-javascript"
 import { json } from "@codemirror/lang-json"
-import { EditorState } from "@codemirror/state"
+import { EditorState, Prec } from "@codemirror/state"
 import { Decoration, hoverTooltip, keymap } from "@codemirror/view"
 import { getImportsFromCode } from "@tscircuit/prompt-benchmarks/code-runner-utils"
 import type { ATABootstrapConfig } from "@typescript/ata"
@@ -237,13 +237,15 @@ export const CodeEditor = ({
       currentFile?.endsWith(".json")
         ? json()
         : javascript({ typescript: true, jsx: true }),
-      keymap.of([
-        indentWithTab,
-        {
-          key: "Mod-Enter",
-          run: () => true,
-        },
-      ]),
+      Prec.high(
+        keymap.of([
+          {
+            key: "Mod-Enter",
+            run: () => true,
+          },
+        ]),
+      ),
+      keymap.of([indentWithTab]),
       EditorState.readOnly.of(readOnly || isSaving),
       EditorView.updateListener.of((update) => {
         if (update.docChanged) {

--- a/src/components/package-port/CodeEditor.tsx
+++ b/src/components/package-port/CodeEditor.tsx
@@ -237,7 +237,13 @@ export const CodeEditor = ({
       currentFile?.endsWith(".json")
         ? json()
         : javascript({ typescript: true, jsx: true }),
-      keymap.of([indentWithTab]),
+      keymap.of([
+        indentWithTab,
+        {
+          key: "Mod-Enter",
+          run: () => true,
+        },
+      ]),
       EditorState.readOnly.of(readOnly || isSaving),
       EditorView.updateListener.of((update) => {
         if (update.docChanged) {


### PR DESCRIPTION
## Summary
- ensure `Mod-Enter` doesn't insert a newline in `CodeEditor`

## Testing
- `bun run lint`
- `bun run format`
- `bun run playwright` *(fails: `bunx` not found)*

------
https://chatgpt.com/codex/tasks/task_b_68470ab029bc832eb089c06a77ad2a32