### PR TITLE
Fix sidebar build links

### DIFF
--- a/src/components/ViewPackagePage/components/build-status.tsx
+++ b/src/components/ViewPackagePage/components/build-status.tsx
@@ -1,12 +1,5 @@
-import { useState } from "react"
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog"
-import { CheckCircle, XCircle, Check, X } from "lucide-react"
-import { cn } from "@/lib/utils"
+import { CheckCircle, XCircle } from "lucide-react"
+import { Link, useParams } from "wouter"
 
 export interface BuildStep {
   id: string
@@ -17,83 +10,23 @@ export interface BuildStep {
 
 export interface BuildStatusProps {
   step: BuildStep
+  packageReleaseId: string
 }
 
-export const BuildStatus = ({ step }: BuildStatusProps) => {
-  const [isDialogOpen, setIsDialogOpen] = useState(false)
+export const BuildStatus = ({ step, packageReleaseId }: BuildStatusProps) => {
+  const { author, packageName } = useParams()
+  const href = `/${author}/${packageName}/builds?package_release_id=${packageReleaseId}`
 
   return (
-    <>
-      <div
-        onClick={() => setIsDialogOpen(true)}
-        className={"flex items-center cursor-pointer"}
-      >
-        {step.status === "success" ? (
-          <CheckCircle className="h-4 w-4 mr-2 text-green-600 dark:text-[#8b949e]" />
-        ) : (
-          <XCircle className="h-4 w-4 mr-2 text-red-600 dark:text-[#8b949e]" />
-        )}
-        <span className="text-sm text-gray-500 dark:text-[#8b949e]">
-          {step.name}
-        </span>
-      </div>
-
-      <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
-        <DialogContent className="sm:max-w-md">
-          <DialogHeader>
-            <DialogTitle className="flex items-center gap-2">
-              {step.status === "success" ? (
-                <>
-                  <CheckCircle className="h-5 w-5 text-green-600" />
-                  <span>Build Status: Passing</span>
-                </>
-              ) : (
-                <>
-                  <XCircle className="h-5 w-5 text-red-600" />
-                  <span>Build Status: Failing</span>
-                </>
-              )}
-            </DialogTitle>
-          </DialogHeader>
-
-          <div className="space-y-4">
-            <div className="space-y-3">
-              <div
-                key={step.id}
-                className={cn(
-                  "flex items-start gap-3 rounded-md border p-3",
-                  step.status === "success"
-                    ? "bg-green-50 border-green-200"
-                    : "bg-red-50 border-red-200",
-                )}
-              >
-                <div
-                  className={cn(
-                    "rounded-full p-1 mt-0.5",
-                    step.status === "success"
-                      ? "bg-green-100 text-green-600"
-                      : "bg-red-100 text-red-600",
-                  )}
-                >
-                  {step.status === "success" ? (
-                    <Check className="h-4 w-4" />
-                  ) : (
-                    <X className="h-4 w-4" />
-                  )}
-                </div>
-                <div>
-                  <div className="font-medium">{step.name}</div>
-                  {step.message && (
-                    <div className="text-sm text-muted-foreground mt-1">
-                      {step.message}
-                    </div>
-                  )}
-                </div>
-              </div>
-            </div>
-          </div>
-        </DialogContent>
-      </Dialog>
-    </>
+    <Link href={href} className="flex items-center gap-2">
+      {step.status === "success" ? (
+        <CheckCircle className="h-4 w-4 text-green-600 dark:text-[#8b949e]" />
+      ) : (
+        <XCircle className="h-4 w-4 text-red-600 dark:text-[#8b949e]" />
+      )}
+      <span className="text-sm text-gray-500 dark:text-[#8b949e]">
+        {step.name}
+      </span>
+    </Link>
   )
 }

--- a/src/components/ViewPackagePage/components/sidebar-releases-section.tsx
+++ b/src/components/ViewPackagePage/components/sidebar-releases-section.tsx
@@ -56,7 +56,11 @@ export default function SidebarReleasesSection() {
           </span>
         </div>
         {buildSteps.map((step) => (
-          <BuildStatus key={step.id} step={step} />
+          <BuildStatus
+            key={step.id}
+            step={step}
+            packageReleaseId={packageRelease.package_release_id}
+          />
         ))}
       </div>
       {/* <a href="#" className="text-blue-600 dark:text-[#58a6ff] hover:underline text-sm">


### PR DESCRIPTION
## Summary
- remove modal behavior for build steps
- link to build details page from sidebar

## Testing
- `bun run lint`
- `bun run format`
- `bun run playwright` *(fails: bunx command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684748b7dbcc832e89c9f1f11d6c756b