### PR TITLE
Improve sidebar build status

### DIFF
--- a/src/components/ViewPackagePage/components/build-status.tsx
+++ b/src/components/ViewPackagePage/components/build-status.tsx
@@ -1,11 +1,10 @@
-import { CheckCircle, XCircle } from "lucide-react"
+import { CheckCircle, XCircle, Clock, Loader2 } from "lucide-react"
 import { Link, useParams } from "wouter"
 
 export interface BuildStep {
   id: string
   name: string
-  status: "success" | "failed"
-  message?: string
+  status: "pending" | "running" | "success" | "error"
 }
 
 export interface BuildStatusProps {
@@ -19,10 +18,17 @@ export const BuildStatus = ({ step, packageReleaseId }: BuildStatusProps) => {
 
   return (
     <Link href={href} className="flex items-center gap-2">
-      {step.status === "success" ? (
+      {step.status === "success" && (
         <CheckCircle className="h-4 w-4 text-green-600 dark:text-[#8b949e]" />
-      ) : (
+      )}
+      {step.status === "error" && (
         <XCircle className="h-4 w-4 text-red-600 dark:text-[#8b949e]" />
+      )}
+      {step.status === "running" && (
+        <Loader2 className="h-4 w-4 text-blue-600 animate-spin dark:text-[#8b949e]" />
+      )}
+      {step.status === "pending" && (
+        <Clock className="h-4 w-4 text-yellow-600 dark:text-[#8b949e]" />
       )}
       <span className="text-sm text-gray-500 dark:text-[#8b949e]">
         {step.name}

--- a/src/components/ViewPackagePage/components/sidebar-releases-section.tsx
+++ b/src/components/ViewPackagePage/components/sidebar-releases-section.tsx
@@ -4,6 +4,27 @@ import { useCurrentPackageInfo } from "@/hooks/use-current-package-info"
 import { usePackageReleaseById } from "@/hooks/use-package-release"
 import { timeAgo } from "@/lib/utils/timeAgo"
 import { BuildStatus, BuildStep } from "./build-status"
+import type { PackageRelease } from "fake-snippets-api/lib/db/schema"
+
+function getTranspilationStatus(
+  pr?: PackageRelease | null,
+): BuildStep["status"] {
+  if (!pr) return "pending"
+  if (pr.transpilation_error) return "error"
+  if (pr.transpilation_in_progress) return "running"
+  if (pr.transpilation_completed_at) return "success"
+  if (pr.transpilation_started_at) return "running"
+  return "pending"
+}
+
+function getCircuitJsonStatus(pr?: PackageRelease | null): BuildStep["status"] {
+  if (!pr) return "pending"
+  if (pr.circuit_json_build_error) return "error"
+  if (pr.circuit_json_build_in_progress) return "running"
+  if (pr.circuit_json_build_completed_at) return "success"
+  if (pr.circuit_json_build_started_at) return "running"
+  return "pending"
+}
 
 export default function SidebarReleasesSection() {
   const { packageInfo } = useCurrentPackageInfo()
@@ -15,14 +36,12 @@ export default function SidebarReleasesSection() {
     {
       id: "package_transpilation",
       name: "Package Transpilation",
-      status: packageRelease?.has_transpiled ? "success" : "failed",
-      message: packageRelease?.transpilation_error || undefined,
+      status: getTranspilationStatus(packageRelease),
     },
     {
       id: "circuit_json_build",
       name: "Circuit JSON Build",
-      status: packageRelease?.circuit_json_build_error ? "failed" : "success",
-      message: packageRelease?.circuit_json_build_error || undefined,
+      status: getCircuitJsonStatus(packageRelease),
     },
   ]
 


### PR DESCRIPTION
## Summary
- extend build status handling to show pending, running, and error states
- compute transpilation and circuit JSON build statuses using build metadata

## Testing
- `bun run format`
- `bun run lint`


------
https://chatgpt.com/codex/tasks/task_b_68474e124768832e9ba810d2a823d891