### PR TITLE
Fix tab switching on AI review request

### DIFF
--- a/src/components/ViewPackagePage/components/important-files-view.tsx
+++ b/src/components/ViewPackagePage/components/important-files-view.tsx
@@ -51,8 +51,12 @@ export default function ImportantFilesView({
   const hasAiContent = Boolean(aiDescription || aiUsageInstructions)
   const hasAiReview = Boolean(aiReviewText)
 
-  // Select the appropriate tab/file when content changes
+  // Select the appropriate tab/file when content changes. Once the user has
+  // interacted with the tabs we keep their selection and only run this logic
+  // if no tab has been chosen yet.
   useEffect(() => {
+    if (activeTab !== null) return
+
     // First priority: README file if it exists
     const readmeFile = importantFiles.find(
       (file) =>
@@ -82,6 +86,7 @@ export default function ImportantFilesView({
     hasAiContent,
     hasAiReview,
     importantFiles,
+    activeTab,
   ])
 
   // Get file name from path


### PR DESCRIPTION
## Summary
- preserve user-selected tab in ViewPackagePage when async updates occur

## Testing
- `bun run lint`
- `npx playwright test` *(fails: 24 failed, 26 skipped)*

------
https://chatgpt.com/codex/tasks/task_b_68474ccf30d0832eb6298b4f09a0fb0f