### PR TITLE
Disable refetch on focus for user profile queries

### DIFF
--- a/src/pages/user-profile.tsx
+++ b/src/pages/user-profile.tsx
@@ -48,7 +48,10 @@ export const UserProfilePage = () => {
       })
       return response.data
     },
-    { retry: false },
+    {
+      retry: false,
+      refetchOnWindowFocus: false,
+    },
   )
 
   // use the username stored in the database so the correct case is displayed
@@ -71,7 +74,10 @@ export const UserProfilePage = () => {
       })
       return response.data.packages
     },
-    { enabled: Boolean(githubUsername) },
+    {
+      enabled: Boolean(githubUsername),
+      refetchOnWindowFocus: false,
+    },
   )
 
   const { data: starredPackages, isLoading: isLoadingStarredPackages } =
@@ -85,6 +91,7 @@ export const UserProfilePage = () => {
       },
       {
         enabled: activeTab === "starred" && Boolean(githubUsername),
+        refetchOnWindowFocus: false,
       },
     )
 


### PR DESCRIPTION
## Summary
- stop react-query refetching account and packages on window focus in user profile page

## Testing
- `bun run format`
- `npx playwright test` *(fails: 48 failing)*

------
https://chatgpt.com/codex/tasks/task_b_68488ab8aeb48327921d4a016cbabdef