### PR TITLE
Fix dashboard package list refresh

### DIFF
--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -34,8 +34,9 @@ export const DashboardPage = () => {
     data: myPackages,
     isLoading,
     error,
+    refetch: refetchUserPackages,
   } = useQuery<Package[]>(
-    "userPackages",
+    ["userPackages", currentUser],
     async () => {
       const response = await axios.post(`/packages/list`, {
         owner_github_username: currentUser,
@@ -195,6 +196,7 @@ export const DashboardPage = () => {
             packageId={packageToDelete.package_id}
             packageName={packageToDelete.unscoped_name}
             packageOwner={packageToDelete.owner_github_username ?? ""}
+            refetchUserPackages={refetchUserPackages}
           />
         )}
       </div>


### PR DESCRIPTION
## Summary
- refresh dashboard package list on delete by using a user-scoped query key
- ensure delete dialog triggers a refetch after deletion

## Testing
- `bun x playwright test` *(fails: 48 failed)*

------
https://chatgpt.com/codex/tasks/task_b_684890ae8e4083278f0d91b56320daf7