### PR TITLE
Add reload button for build logs

### DIFF
--- a/src/components/PackageBuildsPage/package-build-header.tsx
+++ b/src/components/PackageBuildsPage/package-build-header.tsx
@@ -1,4 +1,3 @@
-import { Github, RefreshCw, RotateCcw } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { useCurrentPackageRelease } from "@/hooks/use-current-package-release"
 import { useRebuildPackageReleaseMutation } from "@/hooks/use-rebuild-package-release-mutation"

--- a/src/components/PackageBuildsPage/package-build-header.tsx
+++ b/src/components/PackageBuildsPage/package-build-header.tsx
@@ -1,4 +1,4 @@
-import { Github, RefreshCw } from "lucide-react"
+import { Github, RefreshCw, RotateCcw } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { useParams } from "wouter"
 import { DownloadButtonAndMenu } from "../DownloadButtonAndMenu"
@@ -7,7 +7,9 @@ import { useRebuildPackageReleaseMutation } from "@/hooks/use-rebuild-package-re
 
 export function PackageBuildHeader() {
   const { author, packageName } = useParams()
-  const { packageRelease } = useCurrentPackageRelease()
+  const { packageRelease, refetch, isFetching } = useCurrentPackageRelease({
+    include_logs: true,
+  })
   const { mutate: rebuildPackage, isLoading } =
     useRebuildPackageReleaseMutation()
 
@@ -53,6 +55,16 @@ export function PackageBuildHeader() {
           >
             <RefreshCw className="w-3 h-3 sm:w-4 sm:h-4 mr-1 sm:mr-2" />
             {isLoading ? "Rebuilding..." : "Rebuild"}
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            className="border-gray-300 bg-white hover:bg-gray-50 text-xs sm:text-sm"
+            onClick={() => refetch()}
+            disabled={isFetching}
+          >
+            <RotateCcw className="w-3 h-3 sm:w-4 sm:h-4 mr-1 sm:mr-2" />
+            {isFetching ? "Reloading..." : "Reload"}
           </Button>
           <DownloadButtonAndMenu
             snippetUnscopedName={`${author}/${packageName}`}

--- a/src/components/PackageBuildsPage/package-build-header.tsx
+++ b/src/components/PackageBuildsPage/package-build-header.tsx
@@ -58,13 +58,13 @@ export function PackageBuildHeader() {
           </Button>
           <Button
             variant="outline"
-            size="sm"
-            className="border-gray-300 bg-white hover:bg-gray-50 text-xs sm:text-sm"
+            size="icon"
+            aria-label="Reload logs"
+            className="border-gray-300 bg-white hover:bg-gray-50"
             onClick={() => refetch()}
             disabled={isFetching}
           >
-            <RotateCcw className="w-3 h-3 sm:w-4 sm:h-4 mr-1 sm:mr-2" />
-            {isFetching ? "Reloading..." : "Reload"}
+            <RotateCcw className="w-3 h-3 sm:w-4 sm:h-4" />
           </Button>
           <DownloadButtonAndMenu
             snippetUnscopedName={`${author}/${packageName}`}


### PR DESCRIPTION
## Summary
- add `RotateCcw` button to reload build logs

## Testing
- `bun run lint`
- `npx playwright test` *(fails: 12 failed, 38 did not run)*

------
https://chatgpt.com/codex/tasks/task_b_6849ad53075c8327b13deb6556dbd89f