### PR TITLE
Shorten package build status polling

### DIFF
--- a/src/components/PackageBuildsPage/PackageBuildDetailsPage.tsx
+++ b/src/components/PackageBuildsPage/PackageBuildDetailsPage.tsx
@@ -1,13 +1,13 @@
 "use client"
 
+import { useCurrentPackageRelease } from "@/hooks/use-current-package-release"
+import { PackageRelease } from "fake-snippets-api/lib/db/schema"
 import { useState } from "react"
+import { LogContent } from "./LogContent"
 import { BuildPreviewContent } from "./build-preview-content"
+import { CollapsibleSection } from "./collapsible-section"
 import { PackageBuildDetailsPanel } from "./package-build-details-panel"
 import { PackageBuildHeader } from "./package-build-header"
-import { CollapsibleSection } from "./collapsible-section"
-import { useCurrentPackageRelease } from "@/hooks/use-current-package-release"
-import { LogContent } from "./LogContent"
-import { PackageRelease } from "fake-snippets-api/lib/db/schema"
 
 function computeDuration(
   startedAt: string | null | undefined,
@@ -18,7 +18,10 @@ function computeDuration(
 }
 
 export const PackageBuildDetailsPage = () => {
-  const { packageRelease } = useCurrentPackageRelease({ include_logs: true })
+  const { packageRelease } = useCurrentPackageRelease({
+    include_logs: true,
+    refetchInterval: 2000,
+  })
   const [openSections, setOpenSections] = useState<Record<string, boolean>>({})
 
   const {

--- a/src/components/PackageBuildsPage/build-preview-content.tsx
+++ b/src/components/PackageBuildsPage/build-preview-content.tsx
@@ -2,7 +2,7 @@ import { useCurrentPackageInfo } from "@/hooks/use-current-package-info"
 import { useCurrentPackageRelease } from "@/hooks/use-current-package-release"
 
 export function BuildPreviewContent() {
-  const { packageRelease } = useCurrentPackageRelease()
+  const { packageRelease } = useCurrentPackageRelease({ refetchInterval: 2000 })
   const { packageInfo } = useCurrentPackageInfo()
 
   if (!packageRelease) {

--- a/src/components/PackageBuildsPage/package-build-details-panel.tsx
+++ b/src/components/PackageBuildsPage/package-build-details-panel.tsx
@@ -1,9 +1,9 @@
-import { Globe, GitBranch, GitCommit, Clock } from "lucide-react"
 import { useCurrentPackageRelease } from "@/hooks/use-current-package-release"
-import { useParams } from "wouter"
-import { timeAgo } from "@/lib/utils/timeAgo"
 import { useNow } from "@/hooks/use-now"
+import { timeAgo } from "@/lib/utils/timeAgo"
 import { PackageRelease } from "fake-snippets-api/lib/db/schema"
+import { Clock, GitBranch, GitCommit, Globe } from "lucide-react"
+import { useParams } from "wouter"
 
 const capitalCase = (str: string) => {
   return str.charAt(0).toUpperCase() + str.slice(1)
@@ -25,7 +25,7 @@ function getColorFromDisplayStatus(
 }
 
 export function PackageBuildDetailsPanel() {
-  const { packageRelease } = useCurrentPackageRelease()
+  const { packageRelease } = useCurrentPackageRelease({ refetchInterval: 2000 })
   const { author } = useParams() // TODO use packageRelease.author_account_id when it's added by backed
   const now = useNow(1000)
 

--- a/src/components/PackageBuildsPage/package-build-header.tsx
+++ b/src/components/PackageBuildsPage/package-build-header.tsx
@@ -1,13 +1,13 @@
-import { Github, RefreshCw } from "lucide-react"
 import { Button } from "@/components/ui/button"
-import { useParams } from "wouter"
-import { DownloadButtonAndMenu } from "../DownloadButtonAndMenu"
 import { useCurrentPackageRelease } from "@/hooks/use-current-package-release"
 import { useRebuildPackageReleaseMutation } from "@/hooks/use-rebuild-package-release-mutation"
+import { Github, RefreshCw } from "lucide-react"
+import { useParams } from "wouter"
+import { DownloadButtonAndMenu } from "../DownloadButtonAndMenu"
 
 export function PackageBuildHeader() {
   const { author, packageName } = useParams()
-  const { packageRelease } = useCurrentPackageRelease()
+  const { packageRelease } = useCurrentPackageRelease({ refetchInterval: 2000 })
   const { mutate: rebuildPackage, isLoading } =
     useRebuildPackageReleaseMutation()
 

--- a/src/hooks/use-current-package-release.ts
+++ b/src/hooks/use-current-package-release.ts
@@ -1,10 +1,11 @@
 import { useParams } from "wouter"
 import { useCurrentPackageId } from "./use-current-package-id"
-import { useUrlParams } from "./use-url-params"
 import { usePackageRelease } from "./use-package-release"
+import { useUrlParams } from "./use-url-params"
 
 export const useCurrentPackageRelease = (options?: {
-  include_logs: boolean
+  include_logs?: boolean
+  refetchInterval?: number
 }) => {
   const { packageId } = useCurrentPackageId()
   const urlParams = useUrlParams()
@@ -27,6 +28,7 @@ export const useCurrentPackageRelease = (options?: {
 
   const { data: packageRelease, ...rest } = usePackageRelease(query, {
     include_logs: options?.include_logs ?? false,
+    refetchInterval: options?.refetchInterval,
   })
   return { packageRelease, ...rest }
 }

--- a/src/hooks/use-package-release.ts
+++ b/src/hooks/use-package-release.ts
@@ -1,5 +1,5 @@
 import type { PackageRelease } from "fake-snippets-api/lib/db/schema"
-import { useQuery } from "react-query"
+import { type UseQueryOptions, useQuery } from "react-query"
 import { useAxios } from "./use-axios"
 
 type PackageReleaseQuery =
@@ -20,7 +20,7 @@ type PackageReleaseQuery =
 
 export const usePackageRelease = (
   query: PackageReleaseQuery | null,
-  options?: { include_logs: boolean },
+  options?: { include_logs?: boolean; refetchInterval?: number },
 ) => {
   const axios = useAxios()
 
@@ -50,6 +50,7 @@ export const usePackageRelease = (
     {
       retry: false,
       enabled: Boolean(query),
+      refetchInterval: options?.refetchInterval,
     },
   )
 }


### PR DESCRIPTION
## Summary
- poll package release queries every 2 seconds
- expose `refetchInterval` option in hooks

## Testing
- `bun x biome check src/hooks/use-package-release.ts src/hooks/use-current-package-release.ts src/components/PackageBuildsPage/PackageBuildDetailsPage.tsx src/components/PackageBuildsPage/package-build-header.tsx src/components/PackageBuildsPage/build-preview-content.tsx src/components/PackageBuildsPage/package-build-details-panel.tsx`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_b_6849bc49d5d4832e8da9c20bf1b3fbb2