### PR TITLE
Fix default README display

### DIFF
--- a/src/components/ViewPackagePage/components/important-files-view.tsx
+++ b/src/components/ViewPackagePage/components/important-files-view.tsx
@@ -56,6 +56,7 @@ export default function ImportantFilesView({
   // if no tab has been chosen yet.
   useEffect(() => {
     if (activeTab !== null) return
+    if (isLoading) return
 
     // First priority: README file if it exists
     const readmeFile = importantFiles.find(
@@ -87,6 +88,7 @@ export default function ImportantFilesView({
     hasAiReview,
     importantFiles,
     activeTab,
+    isLoading,
   ])
 
   // Get file name from path


### PR DESCRIPTION
## Summary
- ensure README is selected after package files load

## Testing
- `npm exec playwright test --list` *(fails: browsers missing)*

------
https://chatgpt.com/codex/tasks/task_b_6849bbba87e0832eb3ff675fbd2a670c