### PR TITLE
Fix: file sidebar on creation of new file, selects new file

### DIFF
--- a/src/hooks/useFileManagement.ts
+++ b/src/hooks/useFileManagement.ts
@@ -193,7 +193,8 @@ export function useFileManagement({
       { path: newFileName, content: "" },
     ]
     setLocalFiles(updatedFiles)
-    onFileSelect(newFileName)
+    // immediately select the newly created file
+    setCurrentFile(newFileName)
     return {
       newFileCreated: true,
     }


### PR DESCRIPTION
## Summary
- select new file immediately after creating in file sidebar

## Testing
- `bun run lint`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_b_684aca8a592883278d27e055ab72035c