### PR TITLE
fix: ui of important file tabs overlapping

### DIFF
--- a/src/components/ViewPackagePage/components/important-files-view.tsx
+++ b/src/components/ViewPackagePage/components/important-files-view.tsx
@@ -173,7 +173,6 @@ export default function ImportantFilesView({
             <Skeleton className="h-6 w-24" />
             <Skeleton className="h-6 w-20" />
             <Skeleton className="h-6 w-28" />
-            ShiboSoftwareDev/cli#files
           </div>
           <div className="ml-auto flex items-center">
             <Skeleton className="h-4 w-4 mr-1" />

--- a/src/components/ViewPackagePage/components/important-files-view.tsx
+++ b/src/components/ViewPackagePage/components/important-files-view.tsx
@@ -173,6 +173,7 @@ export default function ImportantFilesView({
             <Skeleton className="h-6 w-24" />
             <Skeleton className="h-6 w-20" />
             <Skeleton className="h-6 w-28" />
+            ShiboSoftwareDev/cli#files
           </div>
           <div className="ml-auto flex items-center">
             <Skeleton className="h-4 w-4 mr-1" />
@@ -213,11 +214,11 @@ export default function ImportantFilesView({
   return (
     <div className="mt-4 border border-gray-200 dark:border-[#30363d] rounded-md overflow-hidden">
       <div className="flex items-center pl-2 pr-4 py-2 bg-gray-100 dark:bg-[#161b22] border-b border-gray-200 dark:border-[#30363d]">
-        <div className="flex items-center space-x-2 overflow-x-auto no-scrollbar">
+        <div className="flex items-center space-x-2 overflow-x-auto no-scrollbar flex-1 min-w-0">
           {/* AI Description Tab */}
           {hasAiContent && (
             <button
-              className={`flex items-center px-3 py-1.5 rounded-md text-xs ${
+              className={`flex items-center px-3 py-1.5 rounded-md text-xs flex-shrink-0 whitespace-nowrap ${
                 activeTab === "ai"
                   ? "bg-gray-200 dark:bg-[#30363d] font-medium"
                   : "text-gray-500 dark:text-[#8b949e] hover:bg-gray-200 dark:hover:bg-[#30363d]"
@@ -234,7 +235,7 @@ export default function ImportantFilesView({
 
           {/* AI Review Tab */}
           <button
-            className={`flex items-center px-3 py-1.5 rounded-md text-xs ${
+            className={`flex items-center px-3 py-1.5 rounded-md text-xs flex-shrink-0 whitespace-nowrap ${
               activeTab === "ai-review"
                 ? "bg-gray-200 dark:bg-[#30363d] font-medium"
                 : "text-gray-500 dark:text-[#8b949e] hover:bg-gray-200 dark:hover:bg-[#30363d]"
@@ -252,7 +253,7 @@ export default function ImportantFilesView({
           {importantFiles.map((file) => (
             <button
               key={file.package_file_id}
-              className={`flex items-center px-3 py-1.5 rounded-md text-xs ${
+              className={`flex items-center px-3 py-1.5 rounded-md text-xs flex-shrink-0 whitespace-nowrap ${
                 activeTab === "file" && activeFilePath === file.file_path
                   ? "bg-gray-200 dark:bg-[#30363d] font-medium"
                   : "text-gray-500 dark:text-[#8b949e] hover:bg-gray-200 dark:hover:bg-[#30363d]"

--- a/src/components/ViewPackagePage/utils/is-package-file-important.ts
+++ b/src/components/ViewPackagePage/utils/is-package-file-important.ts
@@ -36,10 +36,3 @@ export const scorePackageFileImportance = (filePath: string): number => {
   return 0
 }
 
-export const isPackageFileImportant = (filePath: string) => {
-  // Only allow root directory files
-  if (filePath.split("/").length > 1) {
-    return false
-  }
-  return scorePackageFileImportance(filePath) > 0
-}

--- a/src/components/ViewPackagePage/utils/is-package-file-important.ts
+++ b/src/components/ViewPackagePage/utils/is-package-file-important.ts
@@ -18,5 +18,9 @@ export const scorePackageFileImportance = (filePath: string) => {
 }
 
 export const isPackageFileImportant = (filePath: string) => {
+  // Only allow root directory files
+  if (filePath.split("/").length > 1) {
+    return false
+  }
   return scorePackageFileImportance(filePath) > 0
 }

--- a/src/components/ViewPackagePage/utils/is-package-file-important.ts
+++ b/src/components/ViewPackagePage/utils/is-package-file-important.ts
@@ -35,4 +35,3 @@ export const scorePackageFileImportance = (filePath: string): number => {
   }
   return 0
 }
-


### PR DESCRIPTION
# before

![image](https://github.com/user-attachments/assets/1a1d6eac-09c5-4c17-9f6c-88b14988c918)


# after (Scrollable)

![image](https://github.com/user-attachments/assets/705ed3d0-5c68-470a-8e76-3dbeb18babb8)
