### PR TITLE
Add AI review endpoints

### DIFF
--- a/bun-tests/fake-snippets-api/routes/ai_reviews/create.test.ts
+++ b/bun-tests/fake-snippets-api/routes/ai_reviews/create.test.ts
@@ -1,0 +1,12 @@
+import { getTestServer } from "bun-tests/fake-snippets-api/fixtures/get-test-server"
+import { test, expect } from "bun:test"
+
+test("create ai review", async () => {
+  const { axios } = await getTestServer()
+
+  const response = await axios.post("/api/ai_reviews/create")
+
+  expect(response.status).toBe(200)
+  expect(response.data.ai_review.display_status).toBe("pending")
+  expect(response.data.ai_review.ai_review_text).toBeNull()
+})

--- a/bun-tests/fake-snippets-api/routes/ai_reviews/get.test.ts
+++ b/bun-tests/fake-snippets-api/routes/ai_reviews/get.test.ts
@@ -1,0 +1,16 @@
+import { getTestServer } from "bun-tests/fake-snippets-api/fixtures/get-test-server"
+import { test, expect } from "bun:test"
+
+test("get ai review", async () => {
+  const { axios } = await getTestServer()
+
+  const createRes = await axios.post("/api/ai_reviews/create")
+  const id = createRes.data.ai_review.ai_review_id
+
+  const getRes = await axios.get("/api/ai_reviews/get", {
+    params: { ai_review_id: id },
+  })
+
+  expect(getRes.status).toBe(200)
+  expect(getRes.data.ai_review.ai_review_id).toBe(id)
+})

--- a/bun-tests/fake-snippets-api/routes/ai_reviews/list.test.ts
+++ b/bun-tests/fake-snippets-api/routes/ai_reviews/list.test.ts
@@ -1,0 +1,14 @@
+import { getTestServer } from "bun-tests/fake-snippets-api/fixtures/get-test-server"
+import { test, expect } from "bun:test"
+
+test("list ai reviews", async () => {
+  const { axios } = await getTestServer()
+
+  await axios.post("/api/ai_reviews/create")
+  await axios.post("/api/ai_reviews/create")
+
+  const res = await axios.get("/api/ai_reviews/list")
+
+  expect(res.status).toBe(200)
+  expect(res.data.ai_reviews.length).toBe(2)
+})

--- a/bun-tests/fake-snippets-api/routes/ai_reviews/process_review.test.ts
+++ b/bun-tests/fake-snippets-api/routes/ai_reviews/process_review.test.ts
@@ -1,0 +1,16 @@
+import { getTestServer } from "bun-tests/fake-snippets-api/fixtures/get-test-server"
+import { test, expect } from "bun:test"
+
+test("process ai review", async () => {
+  const { axios } = await getTestServer()
+
+  const createRes = await axios.post("/api/ai_reviews/create")
+  const id = createRes.data.ai_review.ai_review_id
+
+  const processRes = await axios.post("/api/_fake/ai_reviews/process_review", {
+    ai_review_id: id,
+  })
+  expect(processRes.status).toBe(200)
+  expect(processRes.data.ai_review.display_status).toBe("completed")
+  expect(processRes.data.ai_review.ai_review_text).toBe("Placeholder AI Review")
+})

--- a/fake-snippets-api/lib/db/db-client.ts
+++ b/fake-snippets-api/lib/db/db-client.ts
@@ -16,6 +16,8 @@ import {
   type PackageFile,
   type PackageRelease,
   packageReleaseSchema,
+  type AiReview,
+  aiReviewSchema,
   type Session,
   type Snippet,
   databaseSchema,
@@ -1337,5 +1339,43 @@ const initializer = combine(databaseSchema.parse({}), (set, get) => ({
           : pkg,
       ),
     }))
+  },
+
+  addAiReview: (review: Omit<AiReview, "ai_review_id">): AiReview => {
+    const base = aiReviewSchema.omit({ ai_review_id: true }).parse(review)
+    const newReview = {
+      ai_review_id: crypto.randomUUID(),
+      ...base,
+    }
+    set((state) => ({
+      aiReviews: [...state.aiReviews, newReview],
+      idCounter: state.idCounter + 1,
+    }))
+    return newReview
+  },
+  updateAiReview: (
+    aiReviewId: string,
+    updates: Partial<AiReview>,
+  ): AiReview | undefined => {
+    let updated: AiReview | undefined
+    set((state) => {
+      const index = state.aiReviews.findIndex(
+        (ar) => ar.ai_review_id === aiReviewId,
+      )
+      if (index === -1) return state
+      const aiReviews = [...state.aiReviews]
+      aiReviews[index] = { ...aiReviews[index], ...updates }
+      updated = aiReviews[index]
+      return { ...state, aiReviews }
+    })
+    return updated
+  },
+  getAiReviewById: (aiReviewId: string): AiReview | undefined => {
+    const state = get()
+    return state.aiReviews.find((ar) => ar.ai_review_id === aiReviewId)
+  },
+  listAiReviews: (): AiReview[] => {
+    const state = get()
+    return state.aiReviews
   },
 }))

--- a/fake-snippets-api/lib/db/schema.ts
+++ b/fake-snippets-api/lib/db/schema.ts
@@ -138,6 +138,17 @@ export const orderQuoteSchema = z.object({
 })
 export type OrderQuote = z.infer<typeof orderQuoteSchema>
 
+export const aiReviewSchema = z.object({
+  ai_review_id: z.string().uuid(),
+  ai_review_text: z.string().nullable(),
+  start_processing_at: z.string().datetime().nullable(),
+  finished_processing_at: z.string().datetime().nullable(),
+  processing_error: z.any().nullable(),
+  created_at: z.string().datetime(),
+  display_status: z.enum(["pending", "completed", "failed"]),
+})
+export type AiReview = z.infer<typeof aiReviewSchema>
+
 // TODO: Remove this schema after migration to accountPackages is complete
 export const accountSnippetSchema = z.object({
   account_id: z.string(),
@@ -314,5 +325,6 @@ export const databaseSchema = z.object({
   jlcpcbOrderState: z.array(jlcpcbOrderStateSchema).default([]),
   jlcpcbOrderStepRuns: z.array(jlcpcbOrderStepRunSchema).default([]),
   orderQuotes: z.array(orderQuoteSchema).default([]),
+  aiReviews: z.array(aiReviewSchema).default([]),
 })
 export type DatabaseSchema = z.infer<typeof databaseSchema>

--- a/fake-snippets-api/routes/api/_fake/ai_reviews/process_review.ts
+++ b/fake-snippets-api/routes/api/_fake/ai_reviews/process_review.ts
@@ -1,0 +1,31 @@
+import { withRouteSpec } from "fake-snippets-api/lib/middleware/with-winter-spec"
+import { z } from "zod"
+import { aiReviewSchema } from "fake-snippets-api/lib/db/schema"
+
+export default withRouteSpec({
+  methods: ["POST"],
+  auth: "session",
+  jsonBody: z.object({
+    ai_review_id: z.string(),
+  }),
+  jsonResponse: z.object({
+    ai_review: aiReviewSchema,
+  }),
+})(async (req, ctx) => {
+  const { ai_review_id } = req.jsonBody
+  const existing = ctx.db.getAiReviewById(ai_review_id)
+  if (!existing) {
+    return ctx.error(404, {
+      error_code: "ai_review_not_found",
+      message: "AI review not found",
+    })
+  }
+  const now = new Date().toISOString()
+  const updated = ctx.db.updateAiReview(ai_review_id, {
+    ai_review_text: "Placeholder AI Review",
+    start_processing_at: existing.start_processing_at ?? now,
+    finished_processing_at: now,
+    display_status: "completed",
+  })!
+  return ctx.json({ ai_review: updated })
+})

--- a/fake-snippets-api/routes/api/ai_reviews/create.ts
+++ b/fake-snippets-api/routes/api/ai_reviews/create.ts
@@ -1,0 +1,22 @@
+import { withRouteSpec } from "fake-snippets-api/lib/middleware/with-winter-spec"
+import { z } from "zod"
+import { aiReviewSchema } from "fake-snippets-api/lib/db/schema"
+
+export default withRouteSpec({
+  methods: ["POST"],
+  auth: "session",
+  jsonResponse: z.object({
+    ai_review: aiReviewSchema,
+  }),
+})(async (req, ctx) => {
+  const ai_review = ctx.db.addAiReview({
+    ai_review_text: null,
+    start_processing_at: null,
+    finished_processing_at: null,
+    processing_error: null,
+    created_at: new Date().toISOString(),
+    display_status: "pending",
+  })
+
+  return ctx.json({ ai_review })
+})

--- a/fake-snippets-api/routes/api/ai_reviews/get.ts
+++ b/fake-snippets-api/routes/api/ai_reviews/get.ts
@@ -1,0 +1,24 @@
+import { withRouteSpec } from "fake-snippets-api/lib/middleware/with-winter-spec"
+import { z } from "zod"
+import { aiReviewSchema } from "fake-snippets-api/lib/db/schema"
+
+export default withRouteSpec({
+  methods: ["GET"],
+  auth: "session",
+  queryParams: z.object({
+    ai_review_id: z.string(),
+  }),
+  jsonResponse: z.object({
+    ai_review: aiReviewSchema,
+  }),
+})(async (req, ctx) => {
+  const { ai_review_id } = req.query
+  const ai_review = ctx.db.getAiReviewById(ai_review_id)
+  if (!ai_review) {
+    return ctx.error(404, {
+      error_code: "ai_review_not_found",
+      message: "AI review not found",
+    })
+  }
+  return ctx.json({ ai_review })
+})

--- a/fake-snippets-api/routes/api/ai_reviews/list.ts
+++ b/fake-snippets-api/routes/api/ai_reviews/list.ts
@@ -1,0 +1,14 @@
+import { withRouteSpec } from "fake-snippets-api/lib/middleware/with-winter-spec"
+import { z } from "zod"
+import { aiReviewSchema } from "fake-snippets-api/lib/db/schema"
+
+export default withRouteSpec({
+  methods: ["GET"],
+  auth: "session",
+  jsonResponse: z.object({
+    ai_reviews: z.array(aiReviewSchema),
+  }),
+})(async (req, ctx) => {
+  const ai_reviews = ctx.db.listAiReviews()
+  return ctx.json({ ai_reviews })
+})


### PR DESCRIPTION
## Summary
- implement `aiReviewSchema` and database storage
- add DB helpers for AI review CRUD
- expose new routes for AI review create/get/list
- fake endpoint to process an AI review
- unit tests for new functionality

## Testing
- `bun run format`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_b_684c737b8cbc832ea16a3c4243691de2