### PR TITLE
Add datasheet support to fake api

### DIFF
--- a/bun-tests/fake-snippets-api/routes/datasheets/create.test.ts
+++ b/bun-tests/fake-snippets-api/routes/datasheets/create.test.ts
@@ -4,7 +4,9 @@ import { test, expect } from "bun:test"
 test("create datasheet", async () => {
   const { axios } = await getTestServer()
 
-  const res = await axios.post("/api/datasheets/create", { chip_name: "TestChip" })
+  const res = await axios.post("/api/datasheets/create", {
+    chip_name: "TestChip",
+  })
 
   expect(res.status).toBe(200)
   expect(res.data.datasheet.chip_name).toBe("TestChip")

--- a/bun-tests/fake-snippets-api/routes/datasheets/create.test.ts
+++ b/bun-tests/fake-snippets-api/routes/datasheets/create.test.ts
@@ -1,0 +1,13 @@
+import { getTestServer } from "bun-tests/fake-snippets-api/fixtures/get-test-server"
+import { test, expect } from "bun:test"
+
+test("create datasheet", async () => {
+  const { axios } = await getTestServer()
+
+  const res = await axios.post("/api/datasheets/create", { chip_name: "TestChip" })
+
+  expect(res.status).toBe(200)
+  expect(res.data.datasheet.chip_name).toBe("TestChip")
+  expect(res.data.datasheet.pin_information).toBeNull()
+  expect(res.data.datasheet.datasheet_pdf_urls).toBeNull()
+})

--- a/bun-tests/fake-snippets-api/routes/datasheets/get.test.ts
+++ b/bun-tests/fake-snippets-api/routes/datasheets/get.test.ts
@@ -3,10 +3,14 @@ import { test, expect } from "bun:test"
 
 test("get datasheet", async () => {
   const { axios } = await getTestServer()
-  const create = await axios.post("/api/datasheets/create", { chip_name: "Chip" })
+  const create = await axios.post("/api/datasheets/create", {
+    chip_name: "Chip",
+  })
   const id = create.data.datasheet.datasheet_id
 
-  const res = await axios.get("/api/datasheets/get", { params: { datasheet_id: id } })
+  const res = await axios.get("/api/datasheets/get", {
+    params: { datasheet_id: id },
+  })
 
   expect(res.status).toBe(200)
   expect(res.data.datasheet.datasheet_id).toBe(id)

--- a/bun-tests/fake-snippets-api/routes/datasheets/get.test.ts
+++ b/bun-tests/fake-snippets-api/routes/datasheets/get.test.ts
@@ -1,0 +1,13 @@
+import { getTestServer } from "bun-tests/fake-snippets-api/fixtures/get-test-server"
+import { test, expect } from "bun:test"
+
+test("get datasheet", async () => {
+  const { axios } = await getTestServer()
+  const create = await axios.post("/api/datasheets/create", { chip_name: "Chip" })
+  const id = create.data.datasheet.datasheet_id
+
+  const res = await axios.get("/api/datasheets/get", { params: { datasheet_id: id } })
+
+  expect(res.status).toBe(200)
+  expect(res.data.datasheet.datasheet_id).toBe(id)
+})

--- a/bun-tests/fake-snippets-api/routes/datasheets/process_all_datasheets.test.ts
+++ b/bun-tests/fake-snippets-api/routes/datasheets/process_all_datasheets.test.ts
@@ -1,0 +1,15 @@
+import { getTestServer } from "bun-tests/fake-snippets-api/fixtures/get-test-server"
+import { test, expect } from "bun:test"
+
+test("process datasheets", async () => {
+  const { axios } = await getTestServer()
+  const create = await axios.post("/api/datasheets/create", { chip_name: "Chip" })
+  const id = create.data.datasheet.datasheet_id
+
+  const processRes = await axios.post("/api/_fake/datasheets/process_all_datasheets")
+  expect(processRes.status).toBe(200)
+
+  const res = await axios.get("/api/datasheets/get", { params: { datasheet_id: id } })
+  expect(res.data.datasheet.pin_information).not.toBeNull()
+  expect(res.data.datasheet.datasheet_pdf_urls).not.toBeNull()
+})

--- a/bun-tests/fake-snippets-api/routes/datasheets/process_all_datasheets.test.ts
+++ b/bun-tests/fake-snippets-api/routes/datasheets/process_all_datasheets.test.ts
@@ -3,13 +3,19 @@ import { test, expect } from "bun:test"
 
 test("process datasheets", async () => {
   const { axios } = await getTestServer()
-  const create = await axios.post("/api/datasheets/create", { chip_name: "Chip" })
+  const create = await axios.post("/api/datasheets/create", {
+    chip_name: "Chip",
+  })
   const id = create.data.datasheet.datasheet_id
 
-  const processRes = await axios.post("/api/_fake/datasheets/process_all_datasheets")
+  const processRes = await axios.post(
+    "/api/_fake/datasheets/process_all_datasheets",
+  )
   expect(processRes.status).toBe(200)
 
-  const res = await axios.get("/api/datasheets/get", { params: { datasheet_id: id } })
+  const res = await axios.get("/api/datasheets/get", {
+    params: { datasheet_id: id },
+  })
   expect(res.data.datasheet.pin_information).not.toBeNull()
   expect(res.data.datasheet.datasheet_pdf_urls).not.toBeNull()
 })

--- a/bun-tests/fake-snippets-api/routes/datasheets/run_async_tasks.test.ts
+++ b/bun-tests/fake-snippets-api/routes/datasheets/run_async_tasks.test.ts
@@ -1,0 +1,14 @@
+import { getTestServer } from "bun-tests/fake-snippets-api/fixtures/get-test-server"
+import { test, expect } from "bun:test"
+
+test("run async tasks processes datasheets", async () => {
+  const { axios } = await getTestServer()
+  const create = await axios.post("/api/datasheets/create", { chip_name: "Chip" })
+  const id = create.data.datasheet.datasheet_id
+
+  const runRes = await axios.get("/api/_fake/run_async_tasks")
+  expect(runRes.status).toBe(200)
+
+  const res = await axios.get("/api/datasheets/get", { params: { datasheet_id: id } })
+  expect(res.data.datasheet.pin_information).not.toBeNull()
+})

--- a/bun-tests/fake-snippets-api/routes/datasheets/run_async_tasks.test.ts
+++ b/bun-tests/fake-snippets-api/routes/datasheets/run_async_tasks.test.ts
@@ -3,12 +3,16 @@ import { test, expect } from "bun:test"
 
 test("run async tasks processes datasheets", async () => {
   const { axios } = await getTestServer()
-  const create = await axios.post("/api/datasheets/create", { chip_name: "Chip" })
+  const create = await axios.post("/api/datasheets/create", {
+    chip_name: "Chip",
+  })
   const id = create.data.datasheet.datasheet_id
 
   const runRes = await axios.get("/api/_fake/run_async_tasks")
   expect(runRes.status).toBe(200)
 
-  const res = await axios.get("/api/datasheets/get", { params: { datasheet_id: id } })
+  const res = await axios.get("/api/datasheets/get", {
+    params: { datasheet_id: id },
+  })
   expect(res.data.datasheet.pin_information).not.toBeNull()
 })

--- a/fake-snippets-api/lib/db/db-client.ts
+++ b/fake-snippets-api/lib/db/db-client.ts
@@ -18,6 +18,8 @@ import {
   packageReleaseSchema,
   type AiReview,
   aiReviewSchema,
+  type Datasheet,
+  datasheetSchema,
   type Session,
   type Snippet,
   databaseSchema,
@@ -1377,5 +1379,39 @@ const initializer = combine(databaseSchema.parse({}), (set, get) => ({
   listAiReviews: (): AiReview[] => {
     const state = get()
     return state.aiReviews
+  },
+  addDatasheet: ({ chip_name }: { chip_name: string }): Datasheet => {
+    const newDatasheet = datasheetSchema.parse({
+      datasheet_id: `datasheet_${Date.now()}`,
+      chip_name,
+      created_at: new Date().toISOString(),
+      pin_information: null,
+      datasheet_pdf_urls: null,
+    })
+    set((state) => ({
+      datasheets: [...state.datasheets, newDatasheet],
+    }))
+    return newDatasheet
+  },
+  getDatasheetById: (datasheetId: string): Datasheet | undefined => {
+    const state = get()
+    return state.datasheets.find((d) => d.datasheet_id === datasheetId)
+  },
+  updateDatasheet: (
+    datasheetId: string,
+    updates: Partial<Datasheet>,
+  ): Datasheet | undefined => {
+    let updated: Datasheet | undefined
+    set((state) => {
+      const index = state.datasheets.findIndex(
+        (d) => d.datasheet_id === datasheetId,
+      )
+      if (index === -1) return state
+      const datasheets = [...state.datasheets]
+      datasheets[index] = { ...datasheets[index], ...updates }
+      updated = datasheets[index]
+      return { ...state, datasheets }
+    })
+    return updated
   },
 }))

--- a/fake-snippets-api/lib/db/schema.ts
+++ b/fake-snippets-api/lib/db/schema.ts
@@ -149,6 +149,22 @@ export const aiReviewSchema = z.object({
 })
 export type AiReview = z.infer<typeof aiReviewSchema>
 
+export const datasheetPinInformationSchema = z.object({
+  pin_number: z.string(),
+  name: z.string(),
+  description: z.string(),
+  capabilities: z.array(z.string()),
+})
+
+export const datasheetSchema = z.object({
+  datasheet_id: z.string(),
+  chip_name: z.string(),
+  created_at: z.string(),
+  pin_information: datasheetPinInformationSchema.array().nullable(),
+  datasheet_pdf_urls: z.array(z.string()).nullable(),
+})
+export type Datasheet = z.infer<typeof datasheetSchema>
+
 // TODO: Remove this schema after migration to accountPackages is complete
 export const accountSnippetSchema = z.object({
   account_id: z.string(),
@@ -326,5 +342,6 @@ export const databaseSchema = z.object({
   jlcpcbOrderStepRuns: z.array(jlcpcbOrderStepRunSchema).default([]),
   orderQuotes: z.array(orderQuoteSchema).default([]),
   aiReviews: z.array(aiReviewSchema).default([]),
+  datasheets: z.array(datasheetSchema).default([]),
 })
 export type DatabaseSchema = z.infer<typeof databaseSchema>

--- a/fake-snippets-api/routes/api/_fake/datasheets/process_all_datasheets.ts
+++ b/fake-snippets-api/routes/api/_fake/datasheets/process_all_datasheets.ts
@@ -1,0 +1,37 @@
+import { datasheetSchema } from "fake-snippets-api/lib/db/schema"
+import { withRouteSpec } from "fake-snippets-api/lib/middleware/with-winter-spec"
+import { z } from "zod"
+
+export const processAllDatasheets = (ctx: any) => {
+  const processed = [] as z.infer<typeof datasheetSchema>[]
+  ctx.db.datasheets.forEach((ds: any) => {
+    if (!ds.pin_information || !ds.datasheet_pdf_urls) {
+      const updated = ctx.db.updateDatasheet(ds.datasheet_id, {
+        pin_information: [
+          {
+            pin_number: "1",
+            name: "PIN1",
+            description: "Placeholder pin",
+            capabilities: ["digital"],
+          },
+        ],
+        datasheet_pdf_urls: ["https://example.com/datasheet.pdf"],
+      })
+      processed.push(updated!)
+    } else {
+      processed.push(ds)
+    }
+  })
+  return processed
+}
+
+export default withRouteSpec({
+  methods: ["POST"],
+  auth: "none",
+  jsonResponse: z.object({
+    datasheets: datasheetSchema.array(),
+  }),
+})(async (req, ctx) => {
+  const datasheets = processAllDatasheets(ctx)
+  return ctx.json({ datasheets })
+})

--- a/fake-snippets-api/routes/api/_fake/run_async_tasks.ts
+++ b/fake-snippets-api/routes/api/_fake/run_async_tasks.ts
@@ -1,0 +1,12 @@
+import { withRouteSpec } from "fake-snippets-api/lib/middleware/with-winter-spec"
+import { z } from "zod"
+import { processAllDatasheets } from "./datasheets/process_all_datasheets"
+
+export default withRouteSpec({
+  methods: ["GET"],
+  auth: "none",
+  jsonResponse: z.object({ ok: z.boolean() }),
+})(async (req, ctx) => {
+  processAllDatasheets(ctx)
+  return ctx.json({ ok: true })
+})

--- a/fake-snippets-api/routes/api/datasheets/create.ts
+++ b/fake-snippets-api/routes/api/datasheets/create.ts
@@ -1,0 +1,18 @@
+import { datasheetSchema } from "fake-snippets-api/lib/db/schema"
+import { withRouteSpec } from "fake-snippets-api/lib/middleware/with-winter-spec"
+import { z } from "zod"
+
+export default withRouteSpec({
+  methods: ["POST"],
+  auth: "session",
+  jsonBody: z.object({
+    chip_name: z.string(),
+  }),
+  jsonResponse: z.object({
+    datasheet: datasheetSchema,
+  }),
+})(async (req, ctx) => {
+  const { chip_name } = req.jsonBody
+  const datasheet = ctx.db.addDatasheet({ chip_name })
+  return ctx.json({ datasheet })
+})

--- a/fake-snippets-api/routes/api/datasheets/get.ts
+++ b/fake-snippets-api/routes/api/datasheets/get.ts
@@ -1,0 +1,25 @@
+import { datasheetSchema } from "fake-snippets-api/lib/db/schema"
+import { withRouteSpec } from "fake-snippets-api/lib/middleware/with-winter-spec"
+import { z } from "zod"
+
+export default withRouteSpec({
+  methods: ["GET", "POST"],
+  auth: "session",
+  queryParams: z.object({
+    datasheet_id: z.string(),
+  }),
+  jsonBody: z.any().optional(),
+  jsonResponse: z.object({
+    datasheet: datasheetSchema,
+  }),
+})(async (req, ctx) => {
+  const { datasheet_id } = req.query
+  const datasheet = ctx.db.getDatasheetById(datasheet_id)
+  if (!datasheet) {
+    return ctx.error(404, {
+      error_code: "datasheet_not_found",
+      message: "Datasheet not found",
+    })
+  }
+  return ctx.json({ datasheet })
+})


### PR DESCRIPTION
## Summary
- define datasheet schema in the DB
- expose add/get/update helpers for datasheets
- add `/datasheets/create` and `/datasheets/get` routes
- implement fake processing route and hook it into `/_fake/run_async_tasks`
- cover new features with Bun tests

## Testing
- `bun test`

------
https://chatgpt.com/codex/tasks/task_b_684ca0b621f4832e8641525611b8a03e