### PR TITLE
Use ai_reviews create and map latest review

### DIFF
--- a/bun-tests/fake-snippets-api/routes/ai_reviews/create.test.ts
+++ b/bun-tests/fake-snippets-api/routes/ai_reviews/create.test.ts
@@ -2,11 +2,20 @@ import { getTestServer } from "bun-tests/fake-snippets-api/fixtures/get-test-ser
 import { test, expect } from "bun:test"
 
 test("create ai review", async () => {
-  const { axios } = await getTestServer()
+  const { axios, seed, db } = await getTestServer()
 
-  const response = await axios.post("/api/ai_reviews/create")
+  const response = await axios.post("/api/ai_reviews/create", null, {
+    params: { package_release_id: seed.packageRelease.package_release_id },
+  })
 
   expect(response.status).toBe(200)
   expect(response.data.ai_review.display_status).toBe("pending")
   expect(response.data.ai_review.ai_review_text).toBeNull()
+  expect(response.data.ai_review.package_release_id).toBe(
+    seed.packageRelease.package_release_id,
+  )
+  const updated = db.getPackageReleaseById(
+    seed.packageRelease.package_release_id,
+  )
+  expect(updated?.ai_review_requested).toBe(true)
 })

--- a/fake-snippets-api/lib/db/schema.ts
+++ b/fake-snippets-api/lib/db/schema.ts
@@ -140,6 +140,7 @@ export type OrderQuote = z.infer<typeof orderQuoteSchema>
 
 export const aiReviewSchema = z.object({
   ai_review_id: z.string().uuid(),
+  package_release_id: z.string().optional(),
   ai_review_text: z.string().nullable(),
   start_processing_at: z.string().datetime().nullable(),
   finished_processing_at: z.string().datetime().nullable(),

--- a/fake-snippets-api/routes/api/ai_reviews/create.ts
+++ b/fake-snippets-api/routes/api/ai_reviews/create.ts
@@ -5,11 +5,31 @@ import { aiReviewSchema } from "fake-snippets-api/lib/db/schema"
 export default withRouteSpec({
   methods: ["POST"],
   auth: "session",
+  queryParams: z.object({
+    package_release_id: z.string().optional(),
+  }),
   jsonResponse: z.object({
     ai_review: aiReviewSchema,
   }),
 })(async (req, ctx) => {
+  const { package_release_id } = req.query
+
+  if (package_release_id) {
+    const release = ctx.db.getPackageReleaseById(package_release_id)
+    if (!release) {
+      return ctx.error(404, {
+        error_code: "package_release_not_found",
+        message: "Package release not found",
+      })
+    }
+    ctx.db.updatePackageRelease({
+      ...release,
+      ai_review_requested: true,
+    })
+  }
+
   const ai_review = ctx.db.addAiReview({
+    package_release_id: package_release_id,
     ai_review_text: null,
     start_processing_at: null,
     finished_processing_at: null,

--- a/fake-snippets-api/routes/api/package_releases/create.ts
+++ b/fake-snippets-api/routes/api/package_releases/create.ts
@@ -104,6 +104,6 @@ export default withRouteSpec({
 
   return ctx.json({
     ok: true,
-    package_release: publicMapPackageRelease(newPackageRelease),
+    package_release: publicMapPackageRelease(newPackageRelease, { db: ctx.db }),
   })
 })

--- a/fake-snippets-api/routes/api/package_releases/get.ts
+++ b/fake-snippets-api/routes/api/package_releases/get.ts
@@ -61,6 +61,7 @@ export default withRouteSpec({
       ok: true,
       package_release: publicMapPackageRelease(packageReleases[0], {
         include_ai_review: req.commonParams?.include_ai_review,
+        db: ctx.db,
       }),
     })
   }
@@ -87,6 +88,7 @@ export default withRouteSpec({
       ok: true,
       package_release: publicMapPackageRelease(packageReleases[0], {
         include_ai_review: req.commonParams?.include_ai_review,
+        db: ctx.db,
       }),
     })
   }
@@ -109,6 +111,7 @@ export default withRouteSpec({
       ok: true,
       package_release: publicMapPackageRelease(pkgRelease, {
         include_ai_review: req.commonParams?.include_ai_review,
+        db: ctx.db,
       }),
     })
   }
@@ -128,6 +131,7 @@ export default withRouteSpec({
     package_release: publicMapPackageRelease(foundRelease, {
       include_logs: req.commonParams?.include_logs,
       include_ai_review: req.commonParams?.include_ai_review,
+      db: ctx.db,
     }),
   })
 })

--- a/fake-snippets-api/routes/api/package_releases/list.ts
+++ b/fake-snippets-api/routes/api/package_releases/list.ts
@@ -78,6 +78,7 @@ export default withRouteSpec({
     package_releases: releases.map((pr) =>
       publicMapPackageRelease(pr, {
         include_ai_review: req.commonParams?.include_ai_review,
+        db: ctx.db,
       }),
     ),
   })

--- a/src/hooks/use-request-ai-review-mutation.ts
+++ b/src/hooks/use-request-ai-review-mutation.ts
@@ -12,13 +12,14 @@ export const useRequestAiReviewMutation = ({
 
   return useMutation(
     async ({ package_release_id }: { package_release_id: string }) => {
-      await axios.post("/package_releases/update", {
-        package_release_id,
-        ai_review_requested: true,
+      await axios.post("/ai_reviews/create", null, {
+        params: { package_release_id },
       })
-      const { data } = await axios.post("/package_releases/get", {
-        package_release_id,
-      })
+      const { data } = await axios.post(
+        "/package_releases/get",
+        { package_release_id },
+        { params: { include_ai_review: true } },
+      )
       return data.package_release as PackageRelease
     },
     {


### PR DESCRIPTION
## Summary
- create ai reviews using the `/ai_reviews/create` endpoint
- update fake snippets API to associate AI reviews with package releases
- surface latest AI review data on package releases
- adjust tests for new AI review flow

## Testing
- `bun test bun-tests/fake-snippets-api/routes/ai_reviews/create.test.ts`
- `bun test bun-tests/fake-snippets-api/routes/package_releases/get.test.ts`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_b_684cbcedfc74832e9eaae15c384d0047