### PR TITLE
Switch ai_reviews/create to JSON body

### DIFF
--- a/bun-tests/fake-snippets-api/routes/ai_reviews/create.test.ts
+++ b/bun-tests/fake-snippets-api/routes/ai_reviews/create.test.ts
@@ -4,8 +4,8 @@ import { test, expect } from "bun:test"
 test("create ai review", async () => {
   const { axios, seed, db } = await getTestServer()
 
-  const response = await axios.post("/api/ai_reviews/create", null, {
-    params: { package_release_id: seed.packageRelease.package_release_id },
+  const response = await axios.post("/api/ai_reviews/create", {
+    package_release_id: seed.packageRelease.package_release_id,
   })
 
   expect(response.status).toBe(200)

--- a/bun-tests/fake-snippets-api/routes/ai_reviews/get.test.ts
+++ b/bun-tests/fake-snippets-api/routes/ai_reviews/get.test.ts
@@ -4,7 +4,7 @@ import { test, expect } from "bun:test"
 test("get ai review", async () => {
   const { axios } = await getTestServer()
 
-  const createRes = await axios.post("/api/ai_reviews/create")
+  const createRes = await axios.post("/api/ai_reviews/create", {})
   const id = createRes.data.ai_review.ai_review_id
 
   const getRes = await axios.get("/api/ai_reviews/get", {

--- a/bun-tests/fake-snippets-api/routes/ai_reviews/list.test.ts
+++ b/bun-tests/fake-snippets-api/routes/ai_reviews/list.test.ts
@@ -4,8 +4,8 @@ import { test, expect } from "bun:test"
 test("list ai reviews", async () => {
   const { axios } = await getTestServer()
 
-  await axios.post("/api/ai_reviews/create")
-  await axios.post("/api/ai_reviews/create")
+  await axios.post("/api/ai_reviews/create", {})
+  await axios.post("/api/ai_reviews/create", {})
 
   const res = await axios.get("/api/ai_reviews/list")
 

--- a/bun-tests/fake-snippets-api/routes/ai_reviews/process_review.test.ts
+++ b/bun-tests/fake-snippets-api/routes/ai_reviews/process_review.test.ts
@@ -4,7 +4,7 @@ import { test, expect } from "bun:test"
 test("process ai review", async () => {
   const { axios } = await getTestServer()
 
-  const createRes = await axios.post("/api/ai_reviews/create")
+  const createRes = await axios.post("/api/ai_reviews/create", {})
   const id = createRes.data.ai_review.ai_review_id
 
   const processRes = await axios.post("/api/_fake/ai_reviews/process_review", {

--- a/bun-tests/fake-snippets-api/routes/package_releases/get.test.ts
+++ b/bun-tests/fake-snippets-api/routes/package_releases/get.test.ts
@@ -158,8 +158,8 @@ test("POST /api/package_releases/get?include_logs=true - should return include_l
 test("POST /api/package_releases/get?include_ai_review=true returns latest review", async () => {
   const { axios, seed } = await getTestServer()
 
-  const createRes = await axios.post("/api/ai_reviews/create", null, {
-    params: { package_release_id: seed.packageRelease.package_release_id },
+  const createRes = await axios.post("/api/ai_reviews/create", {
+    package_release_id: seed.packageRelease.package_release_id,
   })
   const aiReviewId = createRes.data.ai_review.ai_review_id
 

--- a/fake-snippets-api/routes/api/ai_reviews/create.ts
+++ b/fake-snippets-api/routes/api/ai_reviews/create.ts
@@ -5,14 +5,16 @@ import { aiReviewSchema } from "fake-snippets-api/lib/db/schema"
 export default withRouteSpec({
   methods: ["POST"],
   auth: "session",
-  queryParams: z.object({
-    package_release_id: z.string().optional(),
-  }),
+  jsonBody: z
+    .object({
+      package_release_id: z.string().optional(),
+    })
+    .optional(),
   jsonResponse: z.object({
     ai_review: aiReviewSchema,
   }),
 })(async (req, ctx) => {
-  const { package_release_id } = req.query
+  const { package_release_id } = req.jsonBody ?? {}
 
   if (package_release_id) {
     const release = ctx.db.getPackageReleaseById(package_release_id)

--- a/src/hooks/use-request-ai-review-mutation.ts
+++ b/src/hooks/use-request-ai-review-mutation.ts
@@ -12,8 +12,8 @@ export const useRequestAiReviewMutation = ({
 
   return useMutation(
     async ({ package_release_id }: { package_release_id: string }) => {
-      await axios.post("/ai_reviews/create", null, {
-        params: { package_release_id },
+      await axios.post("/ai_reviews/create", {
+        package_release_id,
       })
       const { data } = await axios.post(
         "/package_releases/get",


### PR DESCRIPTION
## Summary
- update `/ai_reviews/create` endpoint to read optional `package_release_id` from JSON body
- adjust hook `use-request-ai-review-mutation` to send JSON body
- update tests for new POST body behavior
- keep tests passing

## Testing
- `bun test bun-tests/fake-snippets-api/routes/ai_reviews`
- `bun test bun-tests/fake-snippets-api/routes/package_releases/get.test.ts`
- `bun run format`


------
https://chatgpt.com/codex/tasks/task_b_684cd04f7294832e8129c0af7254ccd1