### PR TITLE
Fix package page refetch on tab change

### DIFF
--- a/src/hooks/use-package-by-package-id.ts
+++ b/src/hooks/use-package-by-package-id.ts
@@ -18,6 +18,7 @@ export const usePackageById = (packageId: string | null) => {
     {
       retry: false,
       enabled: Boolean(packageId),
+      refetchOnWindowFocus: false,
     },
   )
 }

--- a/src/hooks/use-package-by-package-name.ts
+++ b/src/hooks/use-package-by-package-name.ts
@@ -18,6 +18,7 @@ export const usePackageByName = (packageName: string | null) => {
     {
       retry: false,
       enabled: Boolean(packageName),
+      refetchOnWindowFocus: false,
     },
   )
 }

--- a/src/hooks/use-package-files.ts
+++ b/src/hooks/use-package-files.ts
@@ -47,6 +47,7 @@ export const usePackageFile = (
     {
       retry: false,
       enabled: Boolean(query),
+      refetchOnWindowFocus: false,
       ...(opts as any),
     },
   )
@@ -112,6 +113,7 @@ export const usePackageFiles = (packageReleaseId?: string | null) => {
     },
     {
       enabled: Boolean(packageReleaseId),
+      refetchOnWindowFocus: false,
     },
   )
 }

--- a/src/hooks/use-package-release.ts
+++ b/src/hooks/use-package-release.ts
@@ -52,6 +52,7 @@ export const usePackageRelease = (
       retry: false,
       enabled: Boolean(query),
       refetchInterval: options?.refetchInterval,
+      refetchOnWindowFocus: false,
     },
   )
 }

--- a/src/hooks/use-package.ts
+++ b/src/hooks/use-package.ts
@@ -18,6 +18,7 @@ export const usePackage = (packageId: string | null) => {
     {
       enabled: Boolean(packageId),
       retry: false,
+      refetchOnWindowFocus: false,
     },
   )
 }

--- a/src/hooks/use-snippet.ts
+++ b/src/hooks/use-snippet.ts
@@ -18,6 +18,7 @@ export const useSnippet = (snippetId: string | null) => {
     {
       enabled: Boolean(snippetId),
       retry: false,
+      refetchOnWindowFocus: false,
     },
   )
 }


### PR DESCRIPTION
## Summary
- avoid refetching data when returning to the package page

## Testing
- `bun run lint`


------
https://chatgpt.com/codex/tasks/task_b_68509c715b508327948c7c2c33cc9ba7