### PR TITLE
Handle dynamic import errors

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -78,18 +78,34 @@ const PackageEditorPage = lazyImport(async () => {
 
 class ErrorBoundary extends React.Component<
   { children: React.ReactNode },
-  { hasError: boolean }
+  { hasError: boolean; reloading: boolean }
 > {
   constructor(props: { children: React.ReactNode }) {
     super(props)
-    this.state = { hasError: false }
+    this.state = { hasError: false, reloading: false }
   }
 
   static getDerivedStateFromError() {
-    return { hasError: true }
+    return { hasError: true, reloading: false }
+  }
+
+  componentDidCatch(error: Error) {
+    console.error("ErrorBoundary caught", error)
+    const message = error.message || ""
+    if (
+      /(Loading chunk|ChunkLoadError|dynamically imported module)/i.test(
+        message,
+      )
+    ) {
+      this.setState({ reloading: true })
+      window.location.reload()
+    }
   }
 
   render() {
+    if (this.state.reloading) {
+      return <div>There was a problem loading this page. Reloading…</div>
+    }
     if (this.state.hasError) {
       return <div>Something went wrong loading the page.</div>
     }


### PR DESCRIPTION
## Summary
- reload the page when lazy-loaded chunks fail
- catch various dynamic import error messages

## Testing
- `bun run lint`
- `bun x tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_b_685143f649f8832c82a3524487cf1f36