### PR TITLE
Implement client build version checking

### DIFF
--- a/src/ContextProviders.tsx
+++ b/src/ContextProviders.tsx
@@ -4,6 +4,7 @@ import { useEffect } from "react"
 import { useGlobalStore } from "./hooks/use-global-store"
 import { posthog } from "./lib/posthog"
 import { Toaster } from "react-hot-toast"
+import { Toaster as SonnerToaster } from "@/components/ui/sonner"
 import { populateQueryCacheWithSSRData } from "./lib/populate-query-cache-with-ssr-data"
 
 const staffGithubUsernames = [
@@ -65,6 +66,7 @@ export const ContextProviders = ({ children }: any) => {
         <PostHogIdentifier />
         {children}
         <Toaster position="bottom-right" />
+        <SonnerToaster position="bottom-left" />
       </HelmetProvider>
     </QueryClientProvider>
   )

--- a/src/build-watcher.ts
+++ b/src/build-watcher.ts
@@ -1,3 +1,5 @@
+import { toast } from "sonner"
+
 export function setupBuildWatcher() {
   const meta = document.querySelector<HTMLMetaElement>(
     'meta[name="tscircuit-build"]',
@@ -19,12 +21,24 @@ export function setupBuildWatcher() {
     }
   }
 
+  let updateToastShown = false
+
   async function checkForUpdate() {
     const serverId = await fetchBuildId()
-    if (serverId && serverId !== (window as any).TSC_BUILD_ID) {
-      if (confirm("A new version of tscircuit.com is available. Reload?")) {
-        window.location.reload()
-      }
+    if (
+      serverId &&
+      serverId !== (window as any).TSC_BUILD_ID &&
+      !updateToastShown
+    ) {
+      updateToastShown = true
+      toast("A new version of tscircuit.com is available.", {
+        action: {
+          label: "Reload",
+          onClick: () => window.location.reload(),
+        },
+        duration: Infinity,
+        position: "bottom-left",
+      })
     }
   }
 

--- a/src/build-watcher.ts
+++ b/src/build-watcher.ts
@@ -1,0 +1,38 @@
+export function setupBuildWatcher() {
+  const meta = document.querySelector<HTMLMetaElement>(
+    'meta[name="tscircuit-build"]',
+  )
+  const currentId = meta?.content || ""
+  ;(window as any).TSC_BUILD_ID = currentId
+
+  async function fetchBuildId(): Promise<string | null> {
+    try {
+      const res = await fetch("/api/generated-index", { cache: "no-store" })
+      const text = await res.text()
+      const match = text.match(
+        /<meta name="tscircuit-build" content="([^"]+)"/i,
+      )
+      return match ? match[1] : null
+    } catch (err) {
+      console.error("Failed to fetch build identifier", err)
+      return null
+    }
+  }
+
+  async function checkForUpdate() {
+    const serverId = await fetchBuildId()
+    if (serverId && serverId !== (window as any).TSC_BUILD_ID) {
+      if (confirm("A new version of tscircuit.com is available. Reload?")) {
+        window.location.reload()
+      }
+    }
+  }
+
+  document.addEventListener("visibilitychange", () => {
+    if (document.visibilityState === "visible") {
+      checkForUpdate()
+    }
+  })
+
+  setInterval(checkForUpdate, 5 * 60 * 1000)
+}

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,0 +1,3 @@
+interface Window {
+  TSC_BUILD_ID?: string
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,9 @@ import { StrictMode } from "react"
 import { createRoot } from "react-dom/client"
 import App from "./App.tsx"
 import "./index.css"
+import { setupBuildWatcher } from "./build-watcher"
+
+setupBuildWatcher()
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>


### PR DESCRIPTION
Demo (use 2x playback speed, build takes some time 😅 ):

https://github.com/user-attachments/assets/10571dbc-0244-4580-807f-c6ff7458566a

## Summary
- inject build ID meta tag during Vite build
- watch for build changes in browser and reload when needed
- register the watcher in the client entry
- define global type for build ID

## Testing
- `bun run format`
- `bun run lint`
- `npx tsc -b`
- `bun x playwright test --list`

------
https://chatgpt.com/codex/tasks/task_b_68529ff44178832cb56273e4636f367c