### PR TITLE
Improve TypeScript lib caching

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -3,9 +3,6 @@
   "workspaces": {
     "": {
       "name": "@tscircuit/fake-snippets",
-      "dependencies": {
-        "idb-keyval": "^6.2.2",
-      },
       "devDependencies": {
         "@anthropic-ai/sdk": "^0.27.3",
         "@babel/preset-react": "^7.25.9",
@@ -105,6 +102,7 @@
         "get-port": "^7.1.0",
         "globals": "^15.9.0",
         "he": "^1.2.0",
+        "idb-keyval": "^6.2.2",
         "immer": "^10.1.1",
         "input-otp": "^1.2.4",
         "javascript-time-ago": "^2.5.11",
@@ -114,6 +112,7 @@
         "kicad-converter": "^0.0.16",
         "ky": "^1.7.5",
         "lucide-react": "^0.488.0",
+        "lz-string": "^1.5.0",
         "md5": "^2.3.0",
         "ms": "^2.1.3",
         "next-themes": "^0.3.0",
@@ -1637,6 +1636,8 @@
     "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
     "lucide-react": ["lucide-react@0.488.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-ronlL0MyKut4CEzBY/ai2ZpKPxyWO4jUqdAkm2GNK5Zn3Rj+swDz+3lvyAUXN0PNqPKIX6XM9Xadwz/skLs/pQ=="],
+
+    "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
 
     "maath": ["maath@0.10.8", "", { "peerDependencies": { "@types/three": ">=0.134.0", "three": ">=0.134.0" } }, "sha512-tRvbDF0Pgqz+9XUa4jjfgAQ8/aPKmQdWXilFu2tMy4GWj4NOsx99HlULO4IeREfbO3a0sA145DZYyvXPkybm0g=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -3,6 +3,9 @@
   "workspaces": {
     "": {
       "name": "@tscircuit/fake-snippets",
+      "dependencies": {
+        "idb-keyval": "^6.2.2",
+      },
       "devDependencies": {
         "@anthropic-ai/sdk": "^0.27.3",
         "@babel/preset-react": "^7.25.9",
@@ -1426,6 +1429,8 @@
     "human-readable": ["human-readable@0.2.1", "", {}, "sha512-uFtz4WZlB1M5xI45MZ5AjyAzfrrgLOdty4363Jd0LQ5NGXa+UiKaD0EQXQeDfCinodrpePFk/vKjzBlDTZdZQQ=="],
 
     "humanize-ms": ["humanize-ms@1.2.1", "", { "dependencies": { "ms": "^2.0.0" } }, "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ=="],
+
+    "idb-keyval": ["idb-keyval@6.2.2", "", {}, "sha512-yjD9nARJ/jb1g+CvD0tlhUHOrJ9Sy0P8T9MF3YaLlHnSRpwPfpTX0XIvpmw3gAJUmEu3FiICLBDPXVwyEvrleg=="],
 
     "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
 

--- a/package.json
+++ b/package.json
@@ -131,6 +131,7 @@
     "get-port": "^7.1.0",
     "globals": "^15.9.0",
     "he": "^1.2.0",
+    "idb-keyval": "^6.2.2",
     "immer": "^10.1.1",
     "input-otp": "^1.2.4",
     "javascript-time-ago": "^2.5.11",
@@ -140,6 +141,7 @@
     "kicad-converter": "^0.0.16",
     "ky": "^1.7.5",
     "lucide-react": "^0.488.0",
+    "lz-string": "^1.5.0",
     "md5": "^2.3.0",
     "ms": "^2.1.3",
     "next-themes": "^0.3.0",
@@ -188,8 +190,5 @@
     "zod": "^3.23.8",
     "zustand": "^4.5.5",
     "zustand-hoist": "^2.0.1"
-  },
-  "dependencies": {
-    "idb-keyval": "^6.2.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -188,5 +188,8 @@
     "zod": "^3.23.8",
     "zustand": "^4.5.5",
     "zustand-hoist": "^2.0.1"
+  },
+  "dependencies": {
+    "idb-keyval": "^6.2.2"
   }
 }

--- a/src/components/package-port/CodeEditor.tsx
+++ b/src/components/package-port/CodeEditor.tsx
@@ -12,10 +12,10 @@ import { setupTypeAcquisition } from "@typescript/ata"
 import { linter } from "@codemirror/lint"
 import { TSCI_PACKAGE_PATTERN } from "@/lib/constants"
 import {
-  createDefaultMapFromCDN,
   createSystem,
   createVirtualTypeScriptEnvironment,
 } from "@typescript/vfs"
+import { loadDefaultLibMap } from "@/lib/ts-lib-cache"
 import { tsAutocomplete, tsFacet, tsSync } from "@valtown/codemirror-ts"
 import { getLints } from "@valtown/codemirror-ts"
 import { EditorView } from "codemirror"
@@ -141,12 +141,7 @@ export const CodeEditor = ({
     })
     ;(window as any).__DEBUG_CODE_EDITOR_FS_MAP = fsMap
 
-    createDefaultMapFromCDN(
-      { target: tsModule.ScriptTarget.ES2022 },
-      "5.6.3",
-      true,
-      tsModule,
-    ).then((defaultFsMap) => {
+    loadDefaultLibMap().then((defaultFsMap) => {
       defaultFsMap.forEach((content, filename) => {
         fsMap.set(filename, content)
       })

--- a/src/lib/ts-lib-cache.ts
+++ b/src/lib/ts-lib-cache.ts
@@ -1,0 +1,47 @@
+import {
+  createDefaultMapFromCDN,
+  knownLibFilesForCompilerOptions,
+} from "@typescript/vfs"
+import { get, set } from "idb-keyval"
+import { compressToUTF16, decompressFromUTF16 } from "lz-string"
+import ts from "typescript"
+
+const TS_LIB_VERSION = "5.6.3"
+const CACHE_PREFIX = `ts-lib-${TS_LIB_VERSION}-`
+
+export async function loadDefaultLibMap(): Promise<Map<string, string>> {
+  const fsMap = new Map<string, string>()
+  const libs = knownLibFilesForCompilerOptions(
+    { target: ts.ScriptTarget.ES2022 },
+    ts,
+  )
+  const missing: string[] = []
+
+  for (const lib of libs) {
+    const cached = await get(CACHE_PREFIX + lib)
+    if (cached) {
+      fsMap.set("/" + lib, decompressFromUTF16(cached as string))
+    } else {
+      missing.push(lib)
+    }
+  }
+
+  if (missing.length > 0) {
+    const fetched = await createDefaultMapFromCDN(
+      { target: ts.ScriptTarget.ES2022 },
+      TS_LIB_VERSION,
+      true,
+      ts,
+      { compressToUTF16, decompressFromUTF16 } as any,
+    )
+    for (const [filename, content] of fetched) {
+      fsMap.set(filename, content)
+      await set(
+        CACHE_PREFIX + filename.replace(/^\//, ""),
+        compressToUTF16(content),
+      )
+    }
+  }
+
+  return fsMap
+}


### PR DESCRIPTION
## Summary
- cache default TypeScript libs using IndexedDB
- load cached libs when the CodeEditor mounts

## Testing
- `bun test bun-tests`
- `bun run format`


------
https://chatgpt.com/codex/tasks/task_b_685488db2bdc832e8fc215e9f23896e6