### PR TITLE
Fix AI review polling

### DIFF
--- a/src/hooks/use-current-package-release.ts
+++ b/src/hooks/use-current-package-release.ts
@@ -2,11 +2,15 @@ import { useParams } from "wouter"
 import { useCurrentPackageId } from "./use-current-package-id"
 import { usePackageRelease } from "./use-package-release"
 import { useUrlParams } from "./use-url-params"
+import type { PackageRelease } from "fake-snippets-api/lib/db/schema"
 
 export const useCurrentPackageRelease = (options?: {
   include_ai_review?: boolean
   include_logs?: boolean
-  refetchInterval?: number
+  refetchInterval?:
+    | number
+    | false
+    | ((data: PackageRelease | undefined) => number | false)
 }) => {
   const { packageId } = useCurrentPackageId()
   const urlParams = useUrlParams()

--- a/src/hooks/use-package-release.ts
+++ b/src/hooks/use-package-release.ts
@@ -25,7 +25,10 @@ type PackageReleaseQuery = (
 export const usePackageRelease = (
   query: PackageReleaseQuery | null,
   options?: {
-    refetchInterval?: number
+    refetchInterval?:
+      | number
+      | false
+      | ((data: PackageRelease | undefined) => number | false)
   },
 ) => {
   const axios = useAxios()

--- a/src/pages/view-package.tsx
+++ b/src/pages/view-package.tsx
@@ -21,11 +21,17 @@ export const ViewPackagePage = () => {
     data: packageRelease,
     error: packageReleaseError,
     isLoading: isLoadingPackageRelease,
-  } = usePackageRelease({
-    is_latest: true,
-    package_name: `${author}/${packageName}`,
-    include_ai_review: true,
-  })
+  } = usePackageRelease(
+    {
+      is_latest: true,
+      package_name: `${author}/${packageName}`,
+      include_ai_review: true,
+    },
+    {
+      refetchInterval: (data) =>
+        data?.ai_review_requested && !data.ai_review_text ? 2000 : false,
+    },
+  )
 
   const { data: packageFiles } = usePackageFiles(
     packageRelease?.package_release_id,


### PR DESCRIPTION
## Summary
- allow `usePackageRelease` and `useCurrentPackageRelease` to accept dynamic `refetchInterval`
- start polling package release when AI review is requested

## Testing
- `bun test bun-tests/fake-snippets-api`


------
https://chatgpt.com/codex/tasks/task_b_685987eab80c832ea5d10afcfd172682