### PR TITLE
Implement ai review polling

### DIFF
--- a/src/hooks/use-ai-review.ts
+++ b/src/hooks/use-ai-review.ts
@@ -1,0 +1,31 @@
+import type { AiReview } from "fake-snippets-api/lib/db/schema"
+import { useQuery } from "react-query"
+import { useAxios } from "./use-axios"
+
+export const useAiReview = (
+  aiReviewId: string | null,
+  options?: {
+    refetchInterval?:
+      | number
+      | false
+      | ((data: AiReview | undefined) => number | false)
+  },
+) => {
+  const axios = useAxios()
+
+  return useQuery<AiReview, Error & { status: number }>(
+    ["aiReview", aiReviewId],
+    async () => {
+      if (!aiReviewId) throw new Error("aiReviewId is required")
+      const { data } = await axios.get("/ai_reviews/get", {
+        params: { ai_review_id: aiReviewId },
+      })
+      return data.ai_review as AiReview
+    },
+    {
+      enabled: Boolean(aiReviewId),
+      refetchInterval: options?.refetchInterval,
+      refetchOnWindowFocus: false,
+    },
+  )
+}


### PR DESCRIPTION
## Summary
- fetch AI reviews with new `useAiReview` hook
- return AI review ID from the request mutation
- poll for AI review completion in the package view page

## Testing
- `bun test`

------
https://chatgpt.com/codex/tasks/task_b_6859ce278c3883278bd82fff38b8b393