### PR TITLE
Fix new file input closing behavior

### DIFF
--- a/src/components/FileSidebar.tsx
+++ b/src/components/FileSidebar.tsx
@@ -167,6 +167,16 @@ const FileSidebar: React.FC<FileSidebarProps> = ({
     }
   }
 
+  const handleCreateFileBlur = () => {
+    if (newFileName.trim() === "") {
+      setIsCreatingFile(false)
+      setNewFileName("")
+      setErrorMessage("")
+      return
+    }
+    handleCreateFileInline()
+  }
+
   const toggleSidebar = () => {
     setSidebarOpen(!sidebarOpen)
     setErrorMessage("")
@@ -204,7 +214,7 @@ const FileSidebar: React.FC<FileSidebarProps> = ({
             value={newFileName}
             spellCheck={false}
             onChange={(e) => setNewFileName(e.target.value)}
-            onBlur={handleCreateFileInline}
+            onBlur={handleCreateFileBlur}
             onKeyDown={(e) => {
               if (e.key === "Enter") {
                 handleCreateFileInline()


### PR DESCRIPTION
## Summary
- ensure empty new-file input doesn't trigger error

## Testing
- `bun test`
- `bun run lint`
- `bun run format`


------
https://chatgpt.com/codex/tasks/task_b_6859d0cdfdc08327aa817039c7c86dca