### PR TITLE
feat: Restrict AI review generation to package owners

### DIFF
--- a/src/components/ViewPackagePage/components/repo-page-content.tsx
+++ b/src/components/ViewPackagePage/components/repo-page-content.tsx
@@ -237,6 +237,7 @@ export default function RepoPageContent({
               importantFiles={importantFiles}
               isLoading={!packageFiles}
               onEditClicked={onEditClicked}
+              packageAuthorOwner={packageInfo?.owner_github_username}
               aiDescription={packageInfo?.ai_description ?? ""}
               aiUsageInstructions={packageInfo?.ai_usage_instructions ?? ""}
               aiReviewText={packageRelease?.ai_review_text ?? null}


### PR DESCRIPTION
This pull request introduces a security enhancement that limits the ability to generate or re-generate AI reviews to only the package owner. Previously, any authenticated user had access to this functionality.

---

### 🔒 Changes Implemented

#### `src/components/ViewPackagePage/components/important-files-view.tsx`

* Added a `packageAuthorId` prop to the component.
* Replaced the `useUser` hook with `useGlobalStore` to retrieve the currently logged-in user's session info.
* Conditionally render the **"Request AI Review"** and **"Re-request AI Review"** buttons only when the logged-in user's `github_username` matches the `packageAuthorId`.

#### `src/components/ViewPackagePage/components/repo-page-content.tsx`

* Passed the `packageAuthorOwner` (sourced from `packageInfo.owner_github_username`) as a prop to the `ImportantFilesView` component.