### PR TITLE
patch: remvoe extra spacing in cmdkmenu

### DIFF
--- a/src/components/CmdKMenu.tsx
+++ b/src/components/CmdKMenu.tsx
@@ -309,10 +309,7 @@ const CmdKMenu = () => {
 
       const chars = text.split("")
       return chars.map((char, i) => (
-        <span
-          key={i}
-          className={item.matches.includes(i) ? "bg-blue-200 px-0.5" : ""}
-        >
+        <span key={i} className={item.matches.includes(i) ? "bg-blue-200" : ""}>
           {char}
         </span>
       ))


### PR DESCRIPTION

# before
![image](https://github.com/user-attachments/assets/3d09f392-1304-48ed-aac1-cb3ad88d046f)


# after

![image](https://github.com/user-attachments/assets/a24869f5-1d14-4aab-8a13-d59867118ebd)
