### PR TITLE
Add datasheets pages and header link

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -68,6 +68,8 @@ const DevLoginPage = lazyImport(() => import("@/pages/dev-login"))
 const ViewPackagePage = lazyImport(() => import("@/pages/view-package"))
 const PackageBuildsPage = lazyImport(() => import("@/pages/package-builds"))
 const TrendingPage = lazyImport(() => import("@/pages/trending"))
+const DatasheetsPage = lazyImport(() => import("@/pages/datasheets"))
+const DatasheetPage = lazyImport(() => import("@/pages/datasheet"))
 const PackageEditorPage = lazyImport(async () => {
   const [editorModule] = await Promise.all([
     import("@/pages/package-editor"),
@@ -135,6 +137,8 @@ function App() {
             <Route path="/settings" component={SettingsPage} />
             <Route path="/search" component={SearchPage} />
             <Route path="/trending" component={TrendingPage} />
+            <Route path="/datasheets" component={DatasheetsPage} />
+            <Route path="/datasheets/:chipName" component={DatasheetPage} />
             <Route path="/authorize" component={AuthenticatePage} />
             <Route path="/my-orders" component={MyOrdersPage} />
             <Route path="/dev-login" component={DevLoginPage} />

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -81,6 +81,9 @@ export default function Header() {
                 </HeaderButton>
               </li>
               <li>
+                <HeaderButton href="/datasheets">Datasheets</HeaderButton>
+              </li>
+              <li>
                 <a href="https://chat.tscircuit.com">
                   <Button variant="ghost">AI</Button>
                 </a>
@@ -150,6 +153,14 @@ export default function Header() {
                   alsoHighlightForUrl="/editor"
                 >
                   Editor
+                </HeaderButton>
+              </li>
+              <li>
+                <HeaderButton
+                  className="w-full justify-start"
+                  href="/datasheets"
+                >
+                  Datasheets
                 </HeaderButton>
               </li>
               <li>

--- a/src/components/Header2.tsx
+++ b/src/components/Header2.tsx
@@ -74,6 +74,12 @@ export const Header2 = () => {
                 Dashboard
               </Link>
             )}
+            <Link
+              className="text-sm font-medium hover:underline underline-offset-4 ml-4"
+              href="/datasheets"
+            >
+              Datasheets
+            </Link>
           </nav>
           <nav className="hidden md:flex gap-6">
             <PrefetchPageLink
@@ -87,6 +93,12 @@ export const Header2 = () => {
               href="/quickstart"
             >
               Editor
+            </PrefetchPageLink>
+            <PrefetchPageLink
+              className="text-sm font-medium hover:underline underline-offset-4"
+              href="/datasheets"
+            >
+              Datasheets
             </PrefetchPageLink>
             {/* <a
             className="text-sm font-medium hover:underline underline-offset-4"

--- a/src/hooks/use-datasheet.ts
+++ b/src/hooks/use-datasheet.ts
@@ -1,0 +1,22 @@
+import { useQuery } from "react-query"
+import { useAxios } from "./use-axios"
+import type { Datasheet } from "fake-snippets-api/lib/db/schema"
+
+export const useDatasheet = (chipName: string | null) => {
+  const axios = useAxios()
+  return useQuery<Datasheet, Error & { status: number }>(
+    ["datasheet", chipName],
+    async () => {
+      if (!chipName) throw new Error("chip name required")
+      const { data } = await axios.get("/datasheets/get", {
+        params: { datasheet_id: chipName },
+      })
+      return data.datasheet
+    },
+    {
+      enabled: Boolean(chipName),
+      retry: false,
+      refetchOnWindowFocus: false,
+    },
+  )
+}

--- a/src/pages/datasheet.tsx
+++ b/src/pages/datasheet.tsx
@@ -1,0 +1,66 @@
+import Header from "@/components/Header"
+import Footer from "@/components/Footer"
+import { useParams } from "wouter"
+import { useDatasheet } from "@/hooks/use-datasheet"
+
+export const DatasheetPage = () => {
+  const { chipName } = useParams()
+  const { data: datasheet, error, isLoading } = useDatasheet(chipName)
+
+  return (
+    <div className="min-h-screen flex flex-col bg-gray-50">
+      <Header />
+      <main className="flex-1 container mx-auto px-4 py-8">
+        {isLoading && <p>Loading…</p>}
+        {error && <p>Failed to load datasheet.</p>}
+        {datasheet && (
+          <div className="space-y-6">
+            <h1 className="text-3xl font-bold">{datasheet.chip_name}</h1>
+            {datasheet.datasheet_pdf_urls && (
+              <div>
+                <h2 className="text-xl font-semibold mb-2">PDFs</h2>
+                <ul className="list-disc list-inside space-y-1">
+                  {datasheet.datasheet_pdf_urls.map((url, i) => (
+                    <li key={i}>
+                      <a className="text-blue-600 hover:underline" href={url}>
+                        {url}
+                      </a>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+            {datasheet.pin_information && (
+              <div>
+                <h2 className="text-xl font-semibold mb-2">Pins</h2>
+                <table className="min-w-full border text-sm">
+                  <thead>
+                    <tr>
+                      <th className="border px-2 py-1 text-left">#</th>
+                      <th className="border px-2 py-1 text-left">Name</th>
+                      <th className="border px-2 py-1 text-left">
+                        Description
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {datasheet.pin_information.map((pin, idx) => (
+                      <tr key={idx}>
+                        <td className="border px-2 py-1">{pin.pin_number}</td>
+                        <td className="border px-2 py-1">{pin.name}</td>
+                        <td className="border px-2 py-1">{pin.description}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </div>
+        )}
+      </main>
+      <Footer />
+    </div>
+  )
+}
+
+export default DatasheetPage

--- a/src/pages/datasheets.tsx
+++ b/src/pages/datasheets.tsx
@@ -1,0 +1,38 @@
+import Header from "@/components/Header"
+import Footer from "@/components/Footer"
+import { Input } from "@/components/ui/input"
+import { Button } from "@/components/ui/button"
+import { useState } from "react"
+import { navigate } from "wouter/use-browser-location"
+
+export const DatasheetsPage = () => {
+  const [chip, setChip] = useState("")
+
+  return (
+    <div className="min-h-screen flex flex-col bg-gray-50">
+      <Header />
+      <main className="flex-1 container mx-auto px-4 py-8">
+        <h1 className="text-3xl font-bold mb-4">Datasheets</h1>
+        <div className="flex gap-2 max-w-md">
+          <Input
+            placeholder="Chip name"
+            value={chip}
+            onChange={(e) => setChip(e.target.value)}
+          />
+          <Button
+            onClick={() => {
+              if (chip.trim()) {
+                navigate(`/datasheets/${encodeURIComponent(chip.trim())}`)
+              }
+            }}
+          >
+            View
+          </Button>
+        </div>
+      </main>
+      <Footer />
+    </div>
+  )
+}
+
+export default DatasheetsPage


### PR DESCRIPTION
## Summary
- add `/datasheets` landing page with chip search
- show datasheet details at `/datasheets/:chipName`
- add datasheets navigation link in both header components
- wire datasheet routes in App router
- expose `useDatasheet` hook for API access

## Testing
- `bun test bun-tests`
- `bun run format`


------
https://chatgpt.com/codex/tasks/task_b_685f68e58af0832e968ef69361f29bb8