### PR TITLE
Remove refresh button from build page

### DIFF
--- a/src/components/PackageBuildsPage/package-build-header.tsx
+++ b/src/components/PackageBuildsPage/package-build-header.tsx
@@ -1,13 +1,13 @@
 import { Button } from "@/components/ui/button"
 import { useCurrentPackageRelease } from "@/hooks/use-current-package-release"
 import { useRebuildPackageReleaseMutation } from "@/hooks/use-rebuild-package-release-mutation"
-import { Github, RefreshCw, RotateCcw } from "lucide-react"
+import { Github, RefreshCw } from "lucide-react"
 import { useParams } from "wouter"
 import { DownloadButtonAndMenu } from "../DownloadButtonAndMenu"
 
 export function PackageBuildHeader() {
   const { author, packageName } = useParams()
-  const { packageRelease, refetch, isFetching } = useCurrentPackageRelease({
+  const { packageRelease } = useCurrentPackageRelease({
     include_logs: true,
   })
   const { mutate: rebuildPackage, isLoading } =
@@ -58,16 +58,6 @@ export function PackageBuildHeader() {
           >
             <RefreshCw className="w-3 h-3 sm:w-4 sm:h-4 mr-1 sm:mr-2" />
             {isLoading ? "Rebuilding..." : "Rebuild"}
-          </Button>
-          <Button
-            variant="outline"
-            size="icon"
-            aria-label="Reload logs"
-            className="border-gray-300 bg-white hover:bg-gray-50"
-            onClick={() => refetch()}
-            disabled={isFetching}
-          >
-            <RotateCcw className="w-3 h-3 sm:w-4 sm:h-4" />
           </Button>
           <DownloadButtonAndMenu unscopedName={packageName} author={author} />
         </div>


### PR DESCRIPTION
## Summary
- remove the refresh logs button from the build header

## Testing
- `bun run lint`
- `bun run format`


------
https://chatgpt.com/codex/tasks/task_b_686bae9cad348327bfd26ed4a0d55bdd