### PR TITLE
Limit latest packages to 10 on dashboard

### DIFF
--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -71,7 +71,11 @@ export const DashboardPage = () => {
   const { data: latestPackages } = useQuery<Package[]>(
     "latestPackages",
     async () => {
-      const response = await axios.get("/packages/list_latest")
+      const response = await axios.get("/packages/list_latest", {
+        params: {
+          limit: 10,
+        },
+      })
       return response.data.packages
     },
     {


### PR DESCRIPTION
## Summary
- limit latest package query to 10 results on dashboard

## Testing
- `bun test`
- `bun run lint`


------
https://chatgpt.com/codex/tasks/task_b_6870fe5365248327a532c4a3eb54b4b2