### PR TITLE
Add datasheets list endpoint

### DIFF
--- a/bun-tests/fake-snippets-api/routes/datasheets/list.test.ts
+++ b/bun-tests/fake-snippets-api/routes/datasheets/list.test.ts
@@ -1,0 +1,49 @@
+import { getTestServer } from "bun-tests/fake-snippets-api/fixtures/get-test-server"
+import { test, expect } from "bun:test"
+
+// Test listing datasheets by chip name
+
+test("list datasheets", async () => {
+  const { axios } = await getTestServer()
+
+  await axios.post("/api/datasheets/create", { chip_name: "Chip" })
+  await axios.post("/api/datasheets/create", { chip_name: "Chip" })
+  await axios.post("/api/datasheets/create", { chip_name: "Other" })
+
+  const res = await axios.get("/api/datasheets/list", {
+    params: { chip_name: "Chip" },
+  })
+
+  expect(res.status).toBe(200)
+  expect(res.data.datasheets).toHaveLength(2)
+  expect(res.data.datasheets.every((d: any) => d.chip_name === "Chip")).toBe(
+    true,
+  )
+})
+
+test("list datasheets is_popular returns all", async () => {
+  const { axios } = await getTestServer()
+
+  await axios.post("/api/datasheets/create", { chip_name: "Chip" })
+  await axios.post("/api/datasheets/create", { chip_name: "Other" })
+
+  const res = await axios.get("/api/datasheets/list", {
+    params: { is_popular: true },
+  })
+
+  expect(res.status).toBe(200)
+  expect(res.data.datasheets).toHaveLength(2)
+})
+
+test("list datasheets empty", async () => {
+  const { axios } = await getTestServer()
+
+  await axios.post("/api/datasheets/create", { chip_name: "Other" })
+
+  const res = await axios.get("/api/datasheets/list", {
+    params: { chip_name: "Chip" },
+  })
+
+  expect(res.status).toBe(200)
+  expect(res.data.datasheets).toHaveLength(0)
+})

--- a/fake-snippets-api/lib/db/db-client.ts
+++ b/fake-snippets-api/lib/db/db-client.ts
@@ -1382,7 +1382,7 @@ const initializer = combine(databaseSchema.parse({}), (set, get) => ({
   },
   addDatasheet: ({ chip_name }: { chip_name: string }): Datasheet => {
     const newDatasheet = datasheetSchema.parse({
-      datasheet_id: `datasheet_${Date.now()}`,
+      datasheet_id: crypto.randomUUID(),
       chip_name,
       created_at: new Date().toISOString(),
       pin_information: null,
@@ -1396,6 +1396,23 @@ const initializer = combine(databaseSchema.parse({}), (set, get) => ({
   getDatasheetById: (datasheetId: string): Datasheet | undefined => {
     const state = get()
     return state.datasheets.find((d) => d.datasheet_id === datasheetId)
+  },
+  listDatasheets: ({
+    chip_name,
+    is_popular,
+  }: { chip_name?: string; is_popular?: boolean } = {}): Datasheet[] => {
+    const state = get()
+    if (is_popular) {
+      return state.datasheets
+    }
+
+    if (chip_name) {
+      return state.datasheets.filter(
+        (d) => d.chip_name.toLowerCase() === chip_name.toLowerCase(),
+      )
+    }
+
+    return state.datasheets
   },
   updateDatasheet: (
     datasheetId: string,

--- a/fake-snippets-api/routes/api/datasheets/list.ts
+++ b/fake-snippets-api/routes/api/datasheets/list.ts
@@ -1,0 +1,29 @@
+import { withRouteSpec } from "fake-snippets-api/lib/middleware/with-winter-spec"
+import { z } from "zod"
+
+export default withRouteSpec({
+  methods: ["GET", "POST"],
+  auth: "none",
+  commonParams: z.object({
+    chip_name: z.string().optional(),
+    is_popular: z.boolean().optional(),
+  }),
+  jsonResponse: z.object({
+    datasheets: z.array(
+      z.object({
+        datasheet_id: z.string().uuid(),
+        chip_name: z.string(),
+      }),
+    ),
+  }),
+})(async (req, ctx) => {
+  const { chip_name, is_popular } = req.commonParams
+  const datasheets = ctx.db
+    .listDatasheets({ chip_name, is_popular })
+    .map((ds) => ({
+      datasheet_id: ds.datasheet_id,
+      chip_name: ds.chip_name,
+    }))
+
+  return ctx.json({ datasheets })
+})


### PR DESCRIPTION
## Summary
- add `/datasheets/list` to the fake API
- support filtering datasheets by `chip_name`
- expose new `listDatasheets` helper in the DB client
- generate UUIDs when creating datasheets
- support `is_popular` flag to return all datasheets
- test datasheets list

## Testing
- `bun test bun-tests/fake-snippets-api/routes/datasheets`

------
https://chatgpt.com/codex/tasks/task_b_6871a2c8c79c832e9bffa198a476bd12