### PR TITLE
Add datasheets landing page and case-insensitive query

### DIFF
--- a/api/generated-index.js
+++ b/api/generated-index.js
@@ -301,11 +301,14 @@ export default async function handler(req, res) {
     console.warn(e)
   }
 
-  try {
-    await handleDatasheetPage(req, res)
-    return
-  } catch (e) {
-    console.warn(e)
+  const pathParts = req.url.split("?")[0].split("/")
+  if (pathParts[1] === "datasheets" && pathParts[2]) {
+    try {
+      await handleDatasheetPage(req, res)
+      return
+    } catch (e) {
+      console.warn(e)
+    }
   }
 
   try {

--- a/api/generated-index.js
+++ b/api/generated-index.js
@@ -153,11 +153,33 @@ export async function handleUserProfile(req, res) {
   res.status(200).send(html)
 }
 
+async function handleDatasheetPage(req, res) {
+  const parts = req.url.split("?")[0].split("/")
+  if (parts[1] !== "datasheets" || !parts[2]) {
+    throw new Error("Not a datasheet page")
+  }
+  const chipName = parts[2]
+
+  const html = getHtmlWithModifiedSeoTags({
+    title: `${chipName} Datasheet - tscircuit`,
+    description: `View the ${chipName} datasheet on tscircuit.`,
+    canonicalUrl: `${BASE_URL}/datasheets/${he.encode(chipName)}`,
+  })
+
+  res.setHeader("Content-Type", "text/html; charset=utf-8")
+  res.setHeader("Cache-Control", cacheControlHeader)
+  res.setHeader("Vary", "Accept-Encoding")
+  res.status(200).send(html)
+}
+
 async function handleCustomPackageHtml(req, res) {
   // Get the author and package name
   const [_, author, unscopedPackageName] = req.url.split("?")[0].split("/")
   if (!author || !unscopedPackageName) {
     throw new Error("Invalid author/package URL")
+  }
+  if (author === "datasheets") {
+    throw new Error("Datasheet route")
   }
 
   const packageNotFoundHtml = getHtmlWithModifiedSeoTags({
@@ -274,6 +296,13 @@ async function handleCustomPage(req, res) {
 export default async function handler(req, res) {
   try {
     await handleCustomPackageHtml(req, res)
+    return
+  } catch (e) {
+    console.warn(e)
+  }
+
+  try {
+    await handleDatasheetPage(req, res)
     return
   } catch (e) {
     console.warn(e)

--- a/bun-tests/fake-snippets-api/routes/datasheets/get.test.ts
+++ b/bun-tests/fake-snippets-api/routes/datasheets/get.test.ts
@@ -40,3 +40,15 @@ test("get datasheet by chip name 404", async () => {
   })
   expect(res.status).toBe(404)
 })
+
+test("get datasheet by chip name case insensitive", async () => {
+  const { axios } = await getTestServer()
+  await axios.post("/api/datasheets/create", { chip_name: "ChipCase" })
+
+  const res = await axios.get("/api/datasheets/get", {
+    params: { chip_name: "chipcase" },
+  })
+
+  expect(res.status).toBe(200)
+  expect(res.data.datasheet.chip_name).toBe("ChipCase")
+})

--- a/fake-snippets-api/lib/db/db-client.ts
+++ b/fake-snippets-api/lib/db/db-client.ts
@@ -1399,7 +1399,9 @@ const initializer = combine(databaseSchema.parse({}), (set, get) => ({
   },
   getDatasheetByChipName: (chipName: string): Datasheet | undefined => {
     const state = get()
-    return state.datasheets.find((d) => d.chip_name === chipName)
+    return state.datasheets.find(
+      (d) => d.chip_name.toLowerCase() === chipName.toLowerCase(),
+    )
   },
   listDatasheets: ({
     chip_name,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -69,6 +69,7 @@ const ViewPackagePage = lazyImport(() => import("@/pages/view-package"))
 const PackageBuildsPage = lazyImport(() => import("@/pages/package-builds"))
 const TrendingPage = lazyImport(() => import("@/pages/trending"))
 const DatasheetPage = lazyImport(() => import("@/pages/datasheet"))
+const DatasheetsPage = lazyImport(() => import("@/pages/datasheets"))
 const PackageEditorPage = lazyImport(async () => {
   const [editorModule] = await Promise.all([
     import("@/pages/package-editor"),
@@ -181,6 +182,7 @@ function App() {
             <Route path="/settings" component={SettingsPage} />
             <Route path="/search" component={SearchPage} />
             <Route path="/trending" component={TrendingPage} />
+            <Route path="/datasheets" component={DatasheetsPage} />
             <Route path="/datasheets/:chipName" component={DatasheetPage} />
             <Route path="/authorize" component={AuthenticatePage} />
             <Route path="/my-orders" component={MyOrdersPage} />

--- a/src/pages/datasheets.tsx
+++ b/src/pages/datasheets.tsx
@@ -1,0 +1,78 @@
+import React, { useState } from "react"
+import { useQuery } from "react-query"
+import { useAxios } from "@/hooks/use-axios"
+import Header from "@/components/Header"
+import Footer from "@/components/Footer"
+import { Input } from "@/components/ui/input"
+import { Search } from "lucide-react"
+import { Link } from "wouter"
+
+interface DatasheetSummary {
+  datasheet_id: string
+  chip_name: string
+}
+
+export const DatasheetsPage: React.FC = () => {
+  const axios = useAxios()
+  const [searchQuery, setSearchQuery] = useState("")
+
+  const {
+    data: datasheets,
+    isLoading,
+    error,
+  } = useQuery(
+    ["datasheetList", searchQuery],
+    async () => {
+      const params = new URLSearchParams()
+      if (searchQuery) {
+        params.append("chip_name", searchQuery)
+      } else {
+        params.append("is_popular", "true")
+      }
+      const { data } = await axios.get(`/datasheets/list?${params.toString()}`)
+      return data.datasheets as DatasheetSummary[]
+    },
+    { keepPreviousData: true },
+  )
+
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Header />
+      <main className="container mx-auto flex-1 px-4 py-8">
+        <h1 className="text-3xl font-bold mb-6">Datasheets</h1>
+        <div className="max-w-md mb-6">
+          <div className="relative">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 h-4 w-4" />
+            <Input
+              type="search"
+              placeholder="Search datasheets..."
+              className="pl-10"
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              aria-label="Search datasheets"
+              role="searchbox"
+            />
+          </div>
+        </div>
+        {isLoading ? (
+          <p>Loading...</p>
+        ) : error ? (
+          <p>Error loading datasheets.</p>
+        ) : datasheets && datasheets.length > 0 ? (
+          <ul className="list-disc pl-5 space-y-2">
+            {datasheets.map((ds) => (
+              <li key={ds.datasheet_id}>
+                <Link href={`/datasheets/${ds.chip_name}`}>{ds.chip_name}</Link>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p>No datasheets found.</p>
+        )}
+      </main>
+      <Footer />
+    </div>
+  )
+}
+
+export default DatasheetsPage

--- a/src/pages/datasheets.tsx
+++ b/src/pages/datasheets.tsx
@@ -29,7 +29,9 @@ export const DatasheetsPage: React.FC = () => {
       } else {
         params.append("is_popular", "true")
       }
-      const { data } = await axios.get(`/datasheets/list?${params.toString()}`)
+      const { data } = await axios.get(
+        `/api/datasheets/list?${params.toString()}`,
+      )
       return data.datasheets as DatasheetSummary[]
     },
     { keepPreviousData: true },


### PR DESCRIPTION
## Summary
- lookup datasheets case-insensitively
- test datasheet GET with different casing
- expose `/datasheets` page
- show SEO for `/datasheets/<chip>` pages

## Testing
- `bun test bun-tests/fake-snippets-api/routes/datasheets`
- `bun run format`

------
https://chatgpt.com/codex/tasks/task_b_6871b35c50a8832e8890cd7a71f585d5