### PR TITLE
Add datasheets links to headers

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -81,6 +81,9 @@ export default function Header() {
                 </HeaderButton>
               </li>
               <li>
+                <HeaderButton href="/datasheets">Datasheets</HeaderButton>
+              </li>
+              <li>
                 <a href="https://chat.tscircuit.com">
                   <Button variant="ghost">AI</Button>
                 </a>
@@ -150,6 +153,14 @@ export default function Header() {
                   alsoHighlightForUrl="/editor"
                 >
                   Editor
+                </HeaderButton>
+              </li>
+              <li>
+                <HeaderButton
+                  className="w-full justify-start"
+                  href="/datasheets"
+                >
+                  Datasheets
                 </HeaderButton>
               </li>
               <li>

--- a/src/components/Header2.tsx
+++ b/src/components/Header2.tsx
@@ -88,6 +88,12 @@ export const Header2 = () => {
             >
               Editor
             </PrefetchPageLink>
+            <PrefetchPageLink
+              className="text-sm font-medium hover:underline underline-offset-4"
+              href="/datasheets"
+            >
+              Datasheets
+            </PrefetchPageLink>
             {/* <a
             className="text-sm font-medium hover:underline underline-offset-4"
             href="https://github.com/tscircuit/tscircuit"


### PR DESCRIPTION
## Summary
- add "Datasheets" link to standard header
- add the same link on the landing page header

## Testing
- `bun test bun-tests`
- `bun run format`


------
https://chatgpt.com/codex/tasks/task_b_6871e88de7e0832ea45a1531325b0f28