### PR TITLE
Fix datasheets list URL

### DIFF
--- a/src/pages/datasheets.tsx
+++ b/src/pages/datasheets.tsx
@@ -29,9 +29,7 @@ export const DatasheetsPage: React.FC = () => {
       } else {
         params.append("is_popular", "true")
       }
-      const { data } = await axios.get(
-        `/api/datasheets/list?${params.toString()}`,
-      )
+      const { data } = await axios.get(`/datasheets/list?${params.toString()}`)
       return data.datasheets as DatasheetSummary[]
     },
     { keepPreviousData: true },


### PR DESCRIPTION
## Summary
- fetch datasheet list from the correct registry path

## Testing
- `bun test bun-tests/fake-snippets-api/routes/datasheets/list.test.ts`
- `bun run format`

------
https://chatgpt.com/codex/tasks/task_b_6871eadb1a70832e96fec32f3ab179ee