### PR TITLE
Improve datasheet page layout, show capabilities in expandable text

### DIFF
--- a/src/components/ExpandableText.tsx
+++ b/src/components/ExpandableText.tsx
@@ -1,0 +1,29 @@
+import { useState } from "react"
+
+interface ExpandableTextProps {
+  text: string
+  maxChars?: number
+}
+
+const ExpandableText = ({ text, maxChars = 30 }: ExpandableTextProps) => {
+  const [expanded, setExpanded] = useState(false)
+
+  if (text.length <= maxChars) {
+    return <span>{text}</span>
+  }
+
+  return (
+    <span>
+      {expanded ? text : `${text.slice(0, maxChars)}...`}
+      <button
+        className="text-blue-600 underline ml-1"
+        type="button"
+        onClick={() => setExpanded((prev) => !prev)}
+      >
+        {expanded ? "Show less" : "Show more"}
+      </button>
+    </span>
+  )
+}
+
+export default ExpandableText

--- a/src/pages/datasheet.tsx
+++ b/src/pages/datasheet.tsx
@@ -3,6 +3,7 @@ import { useDatasheet } from "@/hooks/use-datasheet"
 import { useCreateDatasheet } from "@/hooks/use-create-datasheet"
 import Header from "@/components/Header"
 import Footer from "@/components/Footer"
+import ExpandableText from "@/components/ExpandableText"
 import type { Datasheet } from "fake-snippets-api/lib/db/schema"
 
 export const DatasheetPage = () => {
@@ -24,33 +25,14 @@ export const DatasheetPage = () => {
           <p>Loading...</p>
         ) : datasheetQuery.data ? (
           <div>
-            <h2 className="text-xl font-semibold mb-2">Pin Information</h2>
-            {datasheetQuery.data.pin_information ? (
-              <table className="table-auto border-collapse mb-6">
-                <thead>
-                  <tr>
-                    <th className="border px-2 py-1">Pin</th>
-                    <th className="border px-2 py-1">Name</th>
-                    <th className="border px-2 py-1">Description</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {datasheetQuery.data.pin_information.map((pin) => (
-                    <tr key={pin.pin_number}>
-                      <td className="border px-2 py-1">{pin.pin_number}</td>
-                      <td className="border px-2 py-1">{pin.name}</td>
-                      <td className="border px-2 py-1">{pin.description}</td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            ) : (
-              <p>No pin information available.</p>
-            )}
+            {!datasheetQuery.data.pin_information &&
+              !datasheetQuery.data.datasheet_pdf_urls && (
+                <p>Datasheet is processing. Please check back later.</p>
+              )}
 
             <h2 className="text-xl font-semibold mb-2">PDFs</h2>
             {datasheetQuery.data.datasheet_pdf_urls ? (
-              <ul className="list-disc pl-5">
+              <ul className="list-disc pl-5 mb-6">
                 {datasheetQuery.data.datasheet_pdf_urls.map((url) => (
                   <li key={url}>
                     <a href={url} className="text-blue-600 underline">
@@ -61,6 +43,37 @@ export const DatasheetPage = () => {
               </ul>
             ) : (
               <p>No datasheet PDFs available.</p>
+            )}
+
+            <h2 className="text-xl font-semibold mb-2">Pin Information</h2>
+            {datasheetQuery.data.pin_information ? (
+              <table className="table-auto border-collapse mb-6">
+                <thead>
+                  <tr>
+                    <th className="border px-2 py-1">Pin</th>
+                    <th className="border px-2 py-1">Name</th>
+                    <th className="border px-2 py-1">Description</th>
+                    <th className="border px-2 py-1">Capabilities</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {datasheetQuery.data.pin_information.map((pin) => (
+                    <tr key={pin.pin_number}>
+                      <td className="border px-2 py-1">{pin.pin_number}</td>
+                      <td className="border px-2 py-1">{pin.name}</td>
+                      <td className="border px-2 py-1">{pin.description}</td>
+                      <td className="border px-2 py-1">
+                        <ExpandableText
+                          text={pin.capabilities.join(", ")}
+                          maxChars={30}
+                        />
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            ) : (
+              <p>No pin information available.</p>
             )}
           </div>
         ) : datasheetQuery.error &&


### PR DESCRIPTION
## Summary
- show PDF URLs first on the datasheet page
- display a processing placeholder when the datasheet lacks information
- add capabilities column with expandable text

## Testing
- `bun test bun-tests/fake-snippets-api/routes/datasheets`
- `bun run format`

------
https://chatgpt.com/codex/tasks/task_b_6871f06ffe9c832eb155ba2582480e79