### PR TITLE
Fix generated index route

### DIFF
--- a/api/generated-index.js
+++ b/api/generated-index.js
@@ -255,6 +255,14 @@ async function handleCustomPage(req, res) {
 }
 
 export default async function handler(req, res) {
+  const urlPath = req.url.split("?")[0]
+  if (urlPath === "/api/generated-index") {
+    res.setHeader("Content-Type", "text/html; charset=utf-8")
+    res.setHeader("Cache-Control", cacheControlHeader)
+    res.setHeader("Vary", "Accept-Encoding")
+    res.status(200).send(htmlContent)
+    return
+  }
   try {
     await handleCustomPackageHtml(req, res)
     return


### PR DESCRIPTION
## Summary
- avoid treating `/api/generated-index` as a package request
- no behavioral changes for normal user package routes

## Testing
- `bun test`

------
https://chatgpt.com/codex/tasks/task_b_686e8d29dba8832cbd5becfa2a4696a3