### PR TITLE
Add AI description to datasheets

### DIFF
--- a/bun-tests/fake-snippets-api/routes/datasheets/create.test.ts
+++ b/bun-tests/fake-snippets-api/routes/datasheets/create.test.ts
@@ -12,4 +12,5 @@ test("create datasheet", async () => {
   expect(res.data.datasheet.chip_name).toBe("TestChip")
   expect(res.data.datasheet.pin_information).toBeNull()
   expect(res.data.datasheet.datasheet_pdf_urls).toBeNull()
+  expect(res.data.datasheet.ai_description).toBeNull()
 })

--- a/bun-tests/fake-snippets-api/routes/datasheets/process_all_datasheets.test.ts
+++ b/bun-tests/fake-snippets-api/routes/datasheets/process_all_datasheets.test.ts
@@ -18,4 +18,5 @@ test("process datasheets", async () => {
   })
   expect(res.data.datasheet.pin_information).not.toBeNull()
   expect(res.data.datasheet.datasheet_pdf_urls).not.toBeNull()
+  expect(res.data.datasheet.ai_description).not.toBeNull()
 })

--- a/bun-tests/fake-snippets-api/routes/datasheets/run_async_tasks.test.ts
+++ b/bun-tests/fake-snippets-api/routes/datasheets/run_async_tasks.test.ts
@@ -15,4 +15,5 @@ test("run async tasks processes datasheets", async () => {
     params: { datasheet_id: id },
   })
   expect(res.data.datasheet.pin_information).not.toBeNull()
+  expect(res.data.datasheet.ai_description).not.toBeNull()
 })

--- a/fake-snippets-api/lib/db/db-client.ts
+++ b/fake-snippets-api/lib/db/db-client.ts
@@ -1387,6 +1387,7 @@ const initializer = combine(databaseSchema.parse({}), (set, get) => ({
       created_at: new Date().toISOString(),
       pin_information: null,
       datasheet_pdf_urls: null,
+      ai_description: null,
     })
     set((state) => ({
       datasheets: [...state.datasheets, newDatasheet],

--- a/fake-snippets-api/lib/db/schema.ts
+++ b/fake-snippets-api/lib/db/schema.ts
@@ -163,6 +163,7 @@ export const datasheetSchema = z.object({
   created_at: z.string(),
   pin_information: datasheetPinInformationSchema.array().nullable(),
   datasheet_pdf_urls: z.array(z.string()).nullable(),
+  ai_description: z.string().nullable(),
 })
 export type Datasheet = z.infer<typeof datasheetSchema>
 

--- a/fake-snippets-api/routes/api/_fake/datasheets/process_all_datasheets.ts
+++ b/fake-snippets-api/routes/api/_fake/datasheets/process_all_datasheets.ts
@@ -5,7 +5,7 @@ import { z } from "zod"
 export const processAllDatasheets = (ctx: any) => {
   const processed = [] as z.infer<typeof datasheetSchema>[]
   ctx.db.datasheets.forEach((ds: any) => {
-    if (!ds.pin_information || !ds.datasheet_pdf_urls) {
+    if (!ds.pin_information || !ds.datasheet_pdf_urls || !ds.ai_description) {
       const updated = ctx.db.updateDatasheet(ds.datasheet_id, {
         pin_information: [
           {
@@ -16,6 +16,7 @@ export const processAllDatasheets = (ctx: any) => {
           },
         ],
         datasheet_pdf_urls: ["https://example.com/datasheet.pdf"],
+        ai_description: "Placeholder ai description",
       })
       processed.push(updated!)
     } else {


### PR DESCRIPTION
## Summary
- add `ai_description` field to datasheet schema and DB client
- include `ai_description` when populating fake datasheets
- update tests for new field

## Testing
- `bun test bun-tests/fake-snippets-api/routes/datasheets`


------
https://chatgpt.com/codex/tasks/task_b_68728f0aeb94832eb95b6c3361d83acb