### PR TITLE
Redirect to new datasheet after creation

### DIFF
--- a/src/pages/datasheets.tsx
+++ b/src/pages/datasheets.tsx
@@ -6,7 +6,7 @@ import Header from "@/components/Header"
 import Footer from "@/components/Footer"
 import { Input } from "@/components/ui/input"
 import { Search } from "lucide-react"
-import { Link } from "wouter"
+import { Link, useLocation } from "wouter"
 
 interface DatasheetSummary {
   datasheet_id: string
@@ -15,7 +15,10 @@ interface DatasheetSummary {
 
 export const DatasheetsPage: React.FC = () => {
   const axios = useAxios()
-  const createDatasheet = useCreateDatasheet()
+  const [, navigate] = useLocation()
+  const createDatasheet = useCreateDatasheet({
+    onSuccess: (datasheet) => navigate(`/datasheets/${datasheet.chip_name}`),
+  })
   const [searchQuery, setSearchQuery] = useState("")
 
   const {


### PR DESCRIPTION
## Summary
- redirect to created datasheet when pressing **Create Datasheet** on the search page

## Testing
- `bun test bun-tests/fake-snippets-api/routes/datasheets/create.test.ts`
- `bun run format`


------
https://chatgpt.com/codex/tasks/task_b_6872fceb6ea4832eaa6f60e5c077ea8f