### PR TITLE
Hide file delete option for non-owners

### DIFF
--- a/src/components/FileSidebar.tsx
+++ b/src/components/FileSidebar.tsx
@@ -1,6 +1,13 @@
 import React, { useState } from "react"
 import { cn } from "@/lib/utils"
-import { File, Folder, MoreVertical, PanelRightOpen, Plus } from "lucide-react"
+import {
+  File,
+  Folder,
+  MoreVertical,
+  PanelRightOpen,
+  Plus,
+  Trash2,
+} from "lucide-react"
 import { TreeView, TreeDataItem } from "@/components/ui/tree-view"
 import { isHiddenFile } from "./ViewPackagePage/utils/is-hidden-file"
 import { Input } from "@/components/ui/input"
@@ -18,6 +25,8 @@ import type {
   IDeleteFileResult,
 } from "@/hooks/useFileManagement"
 import { useToast } from "@/hooks/use-toast"
+import { useGlobalStore } from "@/hooks/use-global-store"
+import type { Package } from "fake-snippets-api/lib/db/schema"
 type FileName = string
 
 interface FileSidebarProps {
@@ -28,6 +37,7 @@ interface FileSidebarProps {
   fileSidebarState: ReturnType<typeof useState<boolean>>
   handleCreateFile: (props: ICreateFileProps) => ICreateFileResult
   handleDeleteFile: (props: IDeleteFileProps) => IDeleteFileResult
+  pkg?: Package
 }
 
 const FileSidebar: React.FC<FileSidebarProps> = ({
@@ -38,12 +48,18 @@ const FileSidebar: React.FC<FileSidebarProps> = ({
   fileSidebarState,
   handleCreateFile,
   handleDeleteFile,
+  pkg,
 }) => {
   const [sidebarOpen, setSidebarOpen] = fileSidebarState
   const [newFileName, setNewFileName] = useState("")
   const [isCreatingFile, setIsCreatingFile] = useState(false)
   const [errorMessage, setErrorMessage] = useState("")
   const { toast } = useToast()
+  const session = useGlobalStore((s) => s.session)
+  const isLoggedIn = Boolean(session)
+  const canDeleteFiles =
+    isLoggedIn &&
+    (!pkg || pkg.owner_github_username === session?.github_username)
 
   const transformFilesToTreeData = (
     files: Record<FileName, string>,
@@ -85,7 +101,7 @@ const FileSidebar: React.FC<FileSidebarProps> = ({
             draggable: false,
             droppable: !isLeafNode,
             children: isLeafNode ? undefined : {},
-            actions: (
+            actions: canDeleteFiles ? (
               <>
                 <DropdownMenu key={itemId}>
                   <DropdownMenuTrigger asChild>
@@ -118,15 +134,16 @@ const FileSidebar: React.FC<FileSidebarProps> = ({
                             setErrorMessage("")
                           }
                         }}
-                        className="flex items-center px-4 py-1 text-sm text-gray-700 hover:bg-gray-100 cursor-pointer"
+                        className="flex items-center px-4 py-1 text-xs text-red-600 hover:bg-gray-100 cursor-pointer"
                       >
+                        <Trash2 className="mr-2 h-3 w-3" />
                         Delete
                       </DropdownMenuItem>
                     </DropdownMenuGroup>
                   </DropdownMenuContent>
                 </DropdownMenu>
               </>
-            ),
+            ) : undefined,
           }
         }
 

--- a/src/components/package-port/CodeAndPreview.tsx
+++ b/src/components/package-port/CodeAndPreview.tsx
@@ -16,6 +16,7 @@ import { toastManualEditConflicts } from "@/lib/utils/toastManualEditConflicts"
 import { ManualEditEvent } from "@tscircuit/props"
 import { useFileManagement } from "@/hooks/useFileManagement"
 import { DEFAULT_CODE } from "@/lib/utils/package-utils"
+import { useGlobalStore } from "@/hooks/use-global-store"
 
 interface Props {
   pkg?: Package
@@ -38,6 +39,7 @@ export interface CodeAndPreviewState {
 
 export function CodeAndPreview({ pkg, projectUrl }: Props) {
   const { toast } = useToast()
+  const session = useGlobalStore((s) => s.session)
   const urlParams = useUrlParams()
 
   const templateFromUrl = useMemo(
@@ -208,6 +210,7 @@ export function CodeAndPreview({ pkg, projectUrl }: Props) {
             isSaving={isSaving}
             handleCreateFile={createFile}
             handleDeleteFile={deleteFile}
+            pkg={pkg}
             currentFile={currentFile}
             onFileSelect={onFileSelect}
             files={localFiles}

--- a/src/components/package-port/CodeEditor.tsx
+++ b/src/components/package-port/CodeEditor.tsx
@@ -35,6 +35,7 @@ import CodeEditorHeader, {
 import FileSidebar from "../FileSidebar"
 import { findTargetFile } from "@/lib/utils/findTargetFile"
 import type { PackageFile } from "@/types/package"
+import type { Package } from "fake-snippets-api/lib/db/schema"
 import { useShikiHighlighter } from "@/hooks/use-shiki-highlighter"
 import QuickOpen from "./QuickOpen"
 import GlobalFindReplace from "./GlobalFindReplace"
@@ -67,12 +68,14 @@ export const CodeEditor = ({
   onFileSelect,
   handleCreateFile,
   handleDeleteFile,
+  pkg,
 }: {
   onCodeChange: (code: string, filename?: string) => void
   files: PackageFile[]
   isSaving?: boolean
   handleCreateFile: (props: ICreateFileProps) => ICreateFileResult
   handleDeleteFile: (props: IDeleteFileProps) => IDeleteFileResult
+  pkg?: Package
   readOnly?: boolean
   isStreaming?: boolean
   pkgFilesLoaded?: boolean
@@ -801,6 +804,7 @@ export const CodeEditor = ({
         onFileSelect={(path) => handleFileChange(path)}
         handleCreateFile={handleCreateFile}
         handleDeleteFile={handleDeleteFile}
+        pkg={pkg}
       />
       <div className="flex flex-col flex-1 w-full min-w-0 h-full">
         {showImportAndFormatButtons && (


### PR DESCRIPTION
## Summary
- show delete option only if current user owns the package
- remove `canDeleteFiles` prop and check ownership inside `FileSidebar`
- propagate `pkg` to `CodeEditor` so sidebar can access ownership info

## Testing
- `npm run format`
- `bun x playwright test` *(fails: browserType.launch executable missing)*

------
https://chatgpt.com/codex/tasks/task_b_687abc1de34483279a31b35e733e8132