### PR TITLE
feat(download): Add SPICE netlist download option

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -3,6 +3,9 @@
   "workspaces": {
     "": {
       "name": "@tscircuit/fake-snippets",
+      "dependencies": {
+        "circuit-json-to-spice": "^0.0.6",
+      },
       "devDependencies": {
         "@anthropic-ai/sdk": "^0.27.3",
         "@babel/preset-react": "^7.25.9",
@@ -1036,6 +1039,8 @@
     "circuit-json-to-readable-netlist": ["circuit-json-to-readable-netlist@0.0.13", "", { "peerDependencies": { "@tscircuit/circuit-json-util": "*", "circuit-json": "*", "circuit-json-to-connectivity-map": "*", "typescript": "^5.0.0" } }, "sha512-Wwk/PdEuqKTQM8HRNVzohgcVpicSRkfcUW+eeycb4ZUaJNunGFEEpBkGHPguIcuG9RJBQrGp3XfBVoBUXeBmWQ=="],
 
     "circuit-json-to-simple-3d": ["circuit-json-to-simple-3d@0.0.2", "", { "peerDependencies": { "typescript": "^5" } }, "sha512-Zyqhf4NcbU3roIR5a8eLA7/YpoRsV2li5hZ3g4jC2F8Dhu+lYirznsS1PofGANVWj8y5XcqUuTQWzhsQel69cg=="],
+
+    "circuit-json-to-spice": ["circuit-json-to-spice@0.0.6", "", { "peerDependencies": { "typescript": "^5.0.0" } }, "sha512-rrjXZbbh3FFFJvExnJMJuVXEJZo3AuiQRaabBdonAEIccd05PTxmTvRCLNCrTTph71+NC4Q87mCgL7WFWBdtEw=="],
 
     "circuit-json-to-tscircuit": ["circuit-json-to-tscircuit@0.0.4", "", { "peerDependencies": { "typescript": "^5.0.0" } }, "sha512-LpHbOwdPE4+CooWPAPoKXWs4vxTrjJgu/avnxE3AqGwCD9r0ZnT73mEAB9oQi6T1i7T53zdkSR6y+zpsyCSE7g=="],
 

--- a/package.json
+++ b/package.json
@@ -187,6 +187,7 @@
     "wouter": "^3.3.5",
     "zod": "^3.23.8",
     "zustand": "^4.5.5",
-    "zustand-hoist": "^2.0.1"
+    "zustand-hoist": "^2.0.1",
+    "circuit-json-to-spice": "^0.0.6"
   }
 }

--- a/src/components/DownloadButtonAndMenu.tsx
+++ b/src/components/DownloadButtonAndMenu.tsx
@@ -12,6 +12,7 @@ import { downloadDsnFile } from "@/lib/download-fns/download-dsn-file-fn"
 import { downloadFabricationFiles } from "@/lib/download-fns/download-fabrication-files"
 import { downloadSchematicSvg } from "@/lib/download-fns/download-schematic-svg"
 import { downloadReadableNetlist } from "@/lib/download-fns/download-readable-netlist"
+import { downloadSpiceFile } from "@/lib/download-fns/download-spice-file"
 import { downloadAssemblySvg } from "@/lib/download-fns/download-assembly-svg"
 import { usePcbDownloadDialog } from "@/components/dialogs/pcb-download-dialog"
 import { downloadKicadFiles } from "@/lib/download-fns/download-kicad-files"
@@ -212,6 +213,18 @@ export function DownloadButtonAndMenu({
             <span className="flex-grow mr-6">Readable Netlist</span>
             <span className="text-[0.6rem] opacity-80 bg-blue-500 text-white font-mono rounded-md px-1 text-center py-0.5 mr-1">
               txt
+            </span>
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            className="text-xs"
+            onSelect={() => {
+              downloadSpiceFile(circuitJson, unscopedName || "circuit")
+            }}
+          >
+            <Download className="mr-1 h-3 w-3" />
+            <span className="flex-grow mr-6">SPICE Netlist</span>
+            <span className="text-[0.6rem] opacity-80 bg-blue-500 text-white font-mono rounded-md px-1 text-center py-0.5 mr-1">
+              spice
             </span>
           </DropdownMenuItem>
           <DropdownMenuItem

--- a/src/lib/download-fns/download-spice-file.ts
+++ b/src/lib/download-fns/download-spice-file.ts
@@ -1,0 +1,13 @@
+import { AnyCircuitElement } from "circuit-json"
+import { saveAs } from "file-saver"
+import { circuitJsonToSpice } from "circuit-json-to-spice"
+
+export const downloadSpiceFile = (
+  circuitJson: AnyCircuitElement[],
+  fileName: string,
+) => {
+  const spiceNetlist = circuitJsonToSpice(circuitJson)
+  const spiceString = spiceNetlist.toSpiceString()
+  const blob = new Blob([spiceString], { type: "text/plain" })
+  saveAs(blob, fileName + ".cir")
+}


### PR DESCRIPTION
This PR introduces the capability to download a SPICE netlist for a given circuit.                                                

It utilizes the circuit-json-to-spice package to convert the circuit's JSON representation into a SPICE-compatible format. A      
"SPICE Netlist" option has been added to the download menu.