### PR TITLE
feat(view-package): add license file click handler and auto-view

### DIFF
--- a/src/components/ViewPackagePage/components/important-files-view.tsx
+++ b/src/components/ViewPackagePage/components/important-files-view.tsx
@@ -36,6 +36,7 @@ interface ImportantFilesViewProps {
   aiReviewText?: string | null
   aiReviewRequested?: boolean
   onRequestAiReview?: () => void
+  onLicenseFileRequested?: boolean
 }
 
 export default function ImportantFilesView({
@@ -48,6 +49,7 @@ export default function ImportantFilesView({
   isLoading = false,
   onEditClicked,
   packageAuthorOwner,
+  onLicenseFileRequested,
 }: ImportantFilesViewProps) {
   const [activeFilePath, setActiveFilePath] = useState<string | null>(null)
   const [activeTab, setActiveTab] = useState<string | null>(null)
@@ -69,9 +71,24 @@ export default function ImportantFilesView({
   const hasAiContent = Boolean(aiDescription || aiUsageInstructions)
   const hasAiReview = Boolean(aiReviewText)
 
-  // Select the appropriate tab/file when content changes. Once the user has
-  // interacted with the tabs we keep their selection and only run this logic
-  // if no tab has been chosen yet.
+  useEffect(() => {
+    if (onLicenseFileRequested && importantFiles.length > 0) {
+      const licenseFile = importantFiles.find(
+        (file) =>
+          file.file_path.toLowerCase() === "license" ||
+          file.file_path.toLowerCase().endsWith("/license") ||
+          file.file_path.toLowerCase() === "license.txt" ||
+          file.file_path.toLowerCase().endsWith("/license.txt") ||
+          file.file_path.toLowerCase() === "license.md" ||
+          file.file_path.toLowerCase().endsWith("/license.md"),
+      )
+
+      if (licenseFile) {
+        setActiveFilePath(licenseFile.file_path)
+        setActiveTab("file")
+      }
+    }
+  }, [onLicenseFileRequested, importantFiles])
   useEffect(() => {
     if (activeTab !== null) return
     if (isLoading) return

--- a/src/components/ViewPackagePage/components/repo-page-content.tsx
+++ b/src/components/ViewPackagePage/components/repo-page-content.tsx
@@ -57,6 +57,8 @@ export default function RepoPageContent({
   const [pendingAiReviewId, setPendingAiReviewId] = useState<string | null>(
     null,
   )
+  const [licenseFileRequested, setLicenseFileRequested] =
+    useState<boolean>(false)
   const queryClient = useQueryClient()
   const { data: aiReview } = useAiReview(pendingAiReviewId, {
     refetchInterval: (data) => (data && !data.ai_review_text ? 2000 : false),
@@ -81,6 +83,11 @@ export default function RepoPageContent({
     Boolean(packageRelease?.ai_review_requested) ||
     Boolean(pendingAiReviewId) ||
     isRequestingAiReview
+
+  const handleLicenseFileRequest = () => {
+    setLicenseFileRequested(true)
+    setTimeout(() => setLicenseFileRequested(false), 100)
+  }
 
   // Handle initial view selection and hash-based view changes
   useEffect(() => {
@@ -222,6 +229,7 @@ export default function RepoPageContent({
                   })
                 }
               }}
+              onLicenseFileRequested={licenseFileRequested}
             />
           </div>
 
@@ -235,6 +243,7 @@ export default function RepoPageContent({
                 // Update URL hash when view changes
                 window.location.hash = view
               }}
+              onLicenseClick={handleLicenseFileRequest}
             />
           </div>
           {/* Releases section - Only visible on small screens */}

--- a/src/components/ViewPackagePage/components/sidebar-about-section.tsx
+++ b/src/components/ViewPackagePage/components/sidebar-about-section.tsx
@@ -13,9 +13,12 @@ import { PackageInfo } from "@/lib/types"
 interface SidebarAboutSectionProps {
   packageInfo?: PackageInfo
   isLoading?: boolean
+  onLicenseClick?: () => void
 }
 
-export default function SidebarAboutSection() {
+export default function SidebarAboutSection({
+  onLicenseClick,
+}: SidebarAboutSectionProps = {}) {
   const { packageInfo, refetch: refetchPackageInfo } = useCurrentPackageInfo()
   const { data: packageRelease } = usePackageReleaseById(
     packageInfo?.latest_package_release_id,
@@ -137,7 +140,11 @@ export default function SidebarAboutSection() {
           ))}
         </div>
         <div className="space-y-2 text-sm">
-          <div className="flex items-center">
+          <button
+            className="flex items-center hover:underline hover:underline-offset-2 cursor-pointer hover:decoration-gray-500"
+            onClick={onLicenseClick}
+            disabled={!onLicenseClick}
+          >
             <svg
               className="h-4 w-4 mr-2 text-gray-500 dark:text-[#8b949e]"
               viewBox="0 0 16 16"
@@ -146,7 +153,7 @@ export default function SidebarAboutSection() {
               <path d="M8.75.75V2h.985c.304 0 .603.08.867.231l1.29.736c.038.022.08.033.124.033h2.234a.75.75 0 0 1 0 1.5h-.427l2.111 4.692a.75.75 0 0 1-.154.838l-.53-.53.53.53-.001.002-.002.002-.006.006-.006.005-.01.01-.045.04c-.21.176-.441.327-.686.45C14.556 10.78 13.88 11 13 11a4.498 4.498 0 0 1-2.023-.454 3.544 3.544 0 0 1-.686-.45l-.045-.04-.016-.015-.006-.006-.004-.004v-.001a.75.75 0 0 1-.154-.838L12.178 4.5h-.162c-.305 0-.604-.079-.868-.231l-1.29-.736a.245.245 0 0 0-.124-.033H8.75V13h2.5a.75.75 0 0 1 0 1.5h-6.5a.75.75 0 0 1 0-1.5h2.5V3.5h-.984a.245.245 0 0 0-.124.033l-1.29.736c-.264.152-.563.231-.868.231h-.162l2.112 4.692a.75.75 0 0 1-.154.838l-.53-.53.53.53-.001.002-.002.002-.006.006-.016.015-.045.04c-.21.176-.441.327-.686.45C4.556 10.78 3.88 11 3 11a4.498 4.498 0 0 1-2.023-.454 3.544 3.544 0 0 1-.686-.45l-.045-.04-.016-.015-.006-.006-.004-.004v-.001a.75.75 0 0 1-.154-.838L2.178 4.5H1.75a.75.75 0 0 1 0-1.5h2.234a.249.249 0 0 0 .125-.033l1.29-.736c.263-.15.561-.231.865-.231H7.25V.75a.75.75 0 0 1 1.5 0Zm2.945 8.477c.285.135.718.273 1.305.273s1.02-.138 1.305-.273L13 6.327Zm-10 0c.285.135.718.273 1.305.273s1.02-.138 1.305-.273L3 6.327Z"></path>
             </svg>
             <span>{currentLicense ?? "Unset"} license</span>
-          </div>
+          </button>
 
           <div className="flex items-center">
             <Star className="h-4 w-4 mr-2 text-gray-500 dark:text-[#8b949e]" />

--- a/src/components/ViewPackagePage/components/sidebar.tsx
+++ b/src/components/ViewPackagePage/components/sidebar.tsx
@@ -9,16 +9,18 @@ interface SidebarProps {
   packageInfo?: Package
   isLoading?: boolean
   onViewChange?: (view: "3d" | "pcb" | "schematic") => void
+  onLicenseClick?: () => void
 }
 
 export default function Sidebar({
   packageInfo,
   isLoading = false,
   onViewChange,
+  onLicenseClick,
 }: SidebarProps) {
   return (
     <div className="h-full p-4 bg-white dark:bg-[#0d1117] overflow-y-auto">
-      <SidebarAboutSection />
+      <SidebarAboutSection onLicenseClick={onLicenseClick} />
       <PreviewImageSquares
         packageInfo={packageInfo}
         onViewChange={onViewChange}


### PR DESCRIPTION
Add onLicenseClick handler to sidebar and implement automatic license file viewing when clicked. The license section in sidebar is now clickable and will automatically find and display the license file in the important files view.