### PR TITLE
fix(CodeEditorHeader): pass correct component name to fetchEasyEDAComponent

### DIFF
--- a/src/components/package-port/CodeEditorHeader.tsx
+++ b/src/components/package-port/CodeEditorHeader.tsx
@@ -162,7 +162,8 @@ export const CodeEditorHeader: React.FC<CodeEditorHeaderProps> = ({
       if (!session?.token) {
         throw new Error("You need to be logged in to import jlcpcb component")
       }
-      const jlcpcbComponent = await fetchEasyEDAComponent("C1", {
+      console.log(component)
+      const jlcpcbComponent = await fetchEasyEDAComponent(component.name, {
         fetch: ((url, options: any) => {
           return fetch(`${API_BASE}/proxy`, {
             body: options.body,

--- a/src/components/package-port/CodeEditorHeader.tsx
+++ b/src/components/package-port/CodeEditorHeader.tsx
@@ -162,7 +162,6 @@ export const CodeEditorHeader: React.FC<CodeEditorHeaderProps> = ({
       if (!session?.token) {
         throw new Error("You need to be logged in to import jlcpcb component")
       }
-      console.log(component)
       const jlcpcbComponent = await fetchEasyEDAComponent(component.name, {
         fetch: ((url, options: any) => {
           return fetch(`${API_BASE}/proxy`, {


### PR DESCRIPTION
…

The component name was hardcoded as "C1" which caused incorrect component fetching. Now it uses the actual component.name from props.