### PR TITLE
Fix default tab selection in ImportFiles

### DIFF
--- a/src/components/ViewPackagePage/components/important-files-view.tsx
+++ b/src/components/ViewPackagePage/components/important-files-view.tsx
@@ -169,9 +169,11 @@ export default function ImportantFilesView({
     )
     if (readmeTab) return readmeTab
 
-    // Priority 2: AI content
-    const aiTab = availableTabs.find((tab) => tab.type === "ai")
-    if (aiTab) return aiTab
+    // Priority 2: Description once available
+    if (hasAiContent) {
+      const aiTab = availableTabs.find((tab) => tab.type === "ai")
+      if (aiTab) return aiTab
+    }
 
     // Priority 3: AI review
     const aiReviewTab = availableTabs.find((tab) => tab.type === "ai-review")
@@ -182,7 +184,7 @@ export default function ImportantFilesView({
     if (firstFileTab) return firstFileTab
 
     return null
-  }, [isLoading, availableTabs, isReadmeFile])
+  }, [isLoading, availableTabs, isReadmeFile, hasAiContent])
 
   // Handle copy functionality
   const handleCopy = useCallback(() => {


### PR DESCRIPTION
## Summary
- prefer Description tab once loaded when computing the default tab
- revert useEffect to simply set default tab when none selected

## Testing
- `bun test`
- `bun run format`


------
https://chatgpt.com/codex/tasks/task_b_68879b2538bc83278d45d091235a1f06