### PR TITLE
Fix landing page demo link

### DIFF
--- a/src/pages/landing.tsx
+++ b/src/pages/landing.tsx
@@ -73,7 +73,7 @@ export function LandingPage() {
                       </Button>
                     </a>
                     <PrefetchPageLink
-                      href="/seveibar/usb-c-flashlight#3d"
+                      href="/seveibar/led-water-accelerometer#3d"
                       className="w-[70vw] min-[500px]:w-auto"
                     >
                       <Button


### PR DESCRIPTION
## Summary
- update Open Online Example link on landing page

## Testing
- `bun test`
- `bun run format`


------
https://chatgpt.com/codex/tasks/task_b_688a488916f4832ebe5df49f32d34bb9