### PR TITLE
Add resizable panels for the split CodeEditor and preview view

### DIFF
--- a/src/components/package-port/CodeAndPreview.tsx
+++ b/src/components/package-port/CodeAndPreview.tsx
@@ -306,33 +306,31 @@ export function CodeAndPreview({ pkg, projectUrl }: Props) {
           )}
         </>
       ) : (
-        !isMobile && (
-          <div className="hidden md:flex w-full">
-            <div className="flex flex-col w-full border-r border-gray-200 bg-gray-50">
-              <CodeEditor
-                isSaving={isSaving}
-                handleCreateFile={createFile}
-                handleDeleteFile={deleteFile}
-                handleRenameFile={renameFile}
-                pkg={pkg}
-                currentFile={currentFile}
-                onFileSelect={onFileSelect}
-                files={localFiles}
-                onCodeChange={(newCode, filename) => {
-                  const targetFilename = filename ?? currentFile
-                  setLocalFiles((prev) =>
-                    prev.map((file) =>
-                      file.path === targetFilename
-                        ? { ...file, content: newCode }
-                        : file,
-                    ),
-                  )
-                }}
-                pkgFilesLoaded={!isLoading}
-              />
-            </div>
+        <div className="flex w-full">
+          <div className="flex flex-col w-full border-r border-gray-200 bg-gray-50">
+            <CodeEditor
+              isSaving={isSaving}
+              handleCreateFile={createFile}
+              handleDeleteFile={deleteFile}
+              handleRenameFile={renameFile}
+              pkg={pkg}
+              currentFile={currentFile}
+              onFileSelect={onFileSelect}
+              files={localFiles}
+              onCodeChange={(newCode, filename) => {
+                const targetFilename = filename ?? currentFile
+                setLocalFiles((prev) =>
+                  prev.map((file) =>
+                    file.path === targetFilename
+                      ? { ...file, content: newCode }
+                      : file,
+                  ),
+                )
+              }}
+              pkgFilesLoaded={!isLoading}
+            />
           </div>
-        )
+        </div>
       )}
       <NewPackageSaveDialog initialIsPrivate={false} onSave={savePackage} />
       <DiscardChangesDialog onConfirm={handleDiscardChanges} />

--- a/src/components/package-port/CodeAndPreview.tsx
+++ b/src/components/package-port/CodeAndPreview.tsx
@@ -208,36 +208,34 @@ export function CodeAndPreview({ pkg, projectUrl }: Props) {
       />
       {state.showPreview ? (
         <>
-          {/* Mobile layout: show preview only */}
-          <div className="flex md:hidden">
-            <div
-              className={cn(
-                "flex p-0 flex-col min-h-[640px] w-full",
-                state.fullScreen &&
-                  "fixed inset-0 z-50 bg-white p-4 overflow-hidden",
-              )}
-            >
-              <SuspenseRunFrame
-                showRunButton
-                forceLatestEvalVersion
-                onRenderStarted={() =>
-                  setState((prev) => ({
-                    ...prev,
-                    lastRunCode: currentFileCode,
-                  }))
-                }
-                onRenderFinished={({ circuitJson }) => {
-                  setState((prev) => ({ ...prev, circuitJson }))
-                  toastManualEditConflicts(circuitJson, toast)
-                }}
-                mainComponentPath={mainComponentPath}
-                onEditEvent={(event) => {
-                  handleEditEvent(event)
-                }}
-                fsMap={fsMap ?? {}}
-                projectUrl={projectUrl}
-              />
-            </div>
+          {/* Mobile preview only */}
+          <div
+            className={cn(
+              "flex p-0 flex-col min-h-[640px] w-full md:hidden",
+              state.fullScreen &&
+                "fixed inset-0 z-50 bg-white p-4 overflow-hidden",
+            )}
+          >
+            <SuspenseRunFrame
+              showRunButton
+              forceLatestEvalVersion
+              onRenderStarted={() =>
+                setState((prev) => ({
+                  ...prev,
+                  lastRunCode: currentFileCode,
+                }))
+              }
+              onRenderFinished={({ circuitJson }) => {
+                setState((prev) => ({ ...prev, circuitJson }))
+                toastManualEditConflicts(circuitJson, toast)
+              }}
+              mainComponentPath={mainComponentPath}
+              onEditEvent={(event) => {
+                handleEditEvent(event)
+              }}
+              fsMap={fsMap ?? {}}
+              projectUrl={projectUrl}
+            />
           </div>
           {/* Desktop layout with resizable panels */}
           <ResizablePanelGroup
@@ -305,7 +303,7 @@ export function CodeAndPreview({ pkg, projectUrl }: Props) {
           </ResizablePanelGroup>
         </>
       ) : (
-        <div className="flex">
+        <div className="hidden md:flex w-full">
           <div className="flex flex-col w-full border-r border-gray-200 bg-gray-50">
             <CodeEditor
               isSaving={isSaving}


### PR DESCRIPTION
## Summary
- import resizable panel components
- wrap editor and preview with `ResizablePanelGroup`
- hide preview on mobile and keep editor full width when preview is hidden

## Testing
- `npm run lint`
- `npm run playwright -- --list`
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_b_688b252ce5f083279909a3a1ddfd7803