### PR TITLE
Fix CodeEditor losing focus when empty

### DIFF
--- a/src/components/package-port/CodeEditor.tsx
+++ b/src/components/package-port/CodeEditor.tsx
@@ -644,6 +644,12 @@ export const CodeEditor = ({
     })
 
     viewRef.current = view
+    // Ensure the editor retains focus after reinitialization so that undo
+    // shortcuts like Cmd+Z work even when the document becomes empty.
+    view.focus()
+    if (view.state.doc.length === 0) {
+      view.dispatch({ selection: { anchor: 0 } })
+    }
 
     if (currentFile?.endsWith(".tsx") || currentFile?.endsWith(".ts")) {
       ata(`${defaultImports}${code}`)


### PR DESCRIPTION
## Summary
- ensure CodeEditor keeps focus when its document is cleared

## Testing
- `bun run lint`
- `bun run playwright` *(fails: browserType.launch executable doesn't exist)*

------
https://chatgpt.com/codex/tasks/task_b_688b43b5eb28832785e3e2985015c84e