### PR TITLE
Import JLCPCB parts into package `imports` folder similar to the cli

### DIFF
--- a/src/components/package-port/CodeEditorHeader.tsx
+++ b/src/components/package-port/CodeEditorHeader.tsx
@@ -184,11 +184,13 @@ export const CodeEditorHeader: React.FC<CodeEditorHeaderProps> = ({
       )
       const tsxComponent = await convertRawEasyToTsx(jlcpcbComponent)
       let componentName = component.name.replace(/ /g, "-")
-      if (files[`${componentName}.tsx`] || files[`./${componentName}.tsx`]) {
+      let componentPath = `imports/${componentName}.tsx`
+      if (files[componentPath] || files[`./${componentPath}`]) {
         componentName = `${componentName}-1`
+        componentPath = `imports/${componentName}.tsx`
       }
       const createFileResult = createFile({
-        newFileName: `${componentName}.tsx`,
+        newFileName: componentPath,
         content: tsxComponent,
         onError: (error) => {
           throw error


### PR DESCRIPTION
## Summary
- import components from JLCPCB into `imports/` directory when using the CodeEditor import dialog

## Testing
- `bun run format`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_b_688b46b5902c8327b91a75e3a02f9f90