### PR TITLE
feat(pr-previews): add support for PR previews in package settings

### DIFF
--- a/fake-snippets-api/lib/db/schema.ts
+++ b/fake-snippets-api/lib/db/schema.ts
@@ -251,6 +251,10 @@ export const packageReleaseSchema = z.object({
   ai_review_error: z.any().optional().nullable(),
   ai_review_logs: z.array(z.any()).optional().nullable(),
   ai_review_requested: z.boolean().default(false),
+
+  // Preview
+  is_pr_preview: z.boolean().default(false),
+  github_pr_number: z.number().nullable().optional(),
 })
 export type PackageRelease = z.infer<typeof packageReleaseSchema>
 
@@ -300,6 +304,7 @@ export const packageSchema = z.object({
     .enum(["files", "3d", "pcb", "schematic"])
     .default("files")
     .optional(),
+  allow_pr_previews: z.boolean().default(false).optional(),
 })
 export type Package = z.infer<typeof packageSchema>
 

--- a/fake-snippets-api/lib/public-mapping/public-map-package-release.ts
+++ b/fake-snippets-api/lib/public-mapping/public-map-package-release.ts
@@ -24,6 +24,8 @@ export const publicMapPackageRelease = (
     circuit_json_build_logs: options.include_logs
       ? internal_package_release.circuit_json_build_logs
       : [],
+    is_pr_preview: Boolean(internal_package_release.is_pr_preview),
+    github_pr_number: internal_package_release.github_pr_number,
   }
 
   if (options.include_ai_review && options.db) {

--- a/fake-snippets-api/lib/public-mapping/public-map-package.ts
+++ b/fake-snippets-api/lib/public-mapping/public-map-package.ts
@@ -27,6 +27,7 @@ export const publicMapPackage = (internalPackage: {
   is_unlisted: boolean | null
   latest_package_release_fs_sha: string | null
   github_repo_full_name?: string | null
+  allow_pr_previews?: boolean
 }): zt.Package => {
   return {
     ...internalPackage,
@@ -45,5 +46,6 @@ export const publicMapPackage = (internalPackage: {
       internalPackage.is_private === true
         ? true
         : (internalPackage.is_unlisted ?? false),
+    allow_pr_previews: Boolean(internalPackage.allow_pr_previews),
   }
 }

--- a/fake-snippets-api/routes/api/packages/update.ts
+++ b/fake-snippets-api/routes/api/packages/update.ts
@@ -22,6 +22,7 @@ export default withRouteSpec({
       is_private: z.boolean().optional(),
       is_unlisted: z.boolean().optional(),
       default_view: z.enum(["files", "3d", "pcb", "schematic"]).optional(),
+      allow_pr_previews: z.boolean().optional(),
     })
     .transform((data) => ({
       ...data,
@@ -41,6 +42,7 @@ export default withRouteSpec({
     is_unlisted,
     github_repo_full_name,
     default_view,
+    allow_pr_previews,
   } = req.jsonBody
 
   const packageIndex = ctx.db.packages.findIndex(
@@ -93,6 +95,7 @@ export default withRouteSpec({
     is_unlisted: is_unlisted ?? existingPackage.is_unlisted,
     default_view: default_view ?? existingPackage.default_view,
     updated_at: new Date().toISOString(),
+    allow_pr_previews: allow_pr_previews ?? existingPackage.allow_pr_previews,
   })
 
   if (!updatedPackage) {

--- a/src/components/ViewPackagePage/components/mobile-sidebar.tsx
+++ b/src/components/ViewPackagePage/components/mobile-sidebar.tsx
@@ -200,6 +200,7 @@ const MobileSidebar = ({
       </div>
       {packageInfo && (
         <EditPackageDetailsDialog
+          currentAllowPrPreviews={packageInfo.allow_pr_previews}
           packageReleaseId={packageInfo.latest_package_release_id}
           packageId={packageInfo.package_id}
           currentDescription={

--- a/src/components/ViewPackagePage/components/sidebar-about-section.tsx
+++ b/src/components/ViewPackagePage/components/sidebar-about-section.tsx
@@ -193,6 +193,7 @@ export default function SidebarAboutSection({
           onUpdate={handlePackageUpdate}
           packageName={packageInfo.name}
           currentDefaultView={packageInfo.default_view}
+          currentAllowPrPreviews={packageInfo.allow_pr_previews}
         />
       )}
     </>

--- a/src/components/dialogs/GitHubRepositorySelector.tsx
+++ b/src/components/dialogs/GitHubRepositorySelector.tsx
@@ -19,9 +19,8 @@ interface GitHubRepositorySelectorProps {
   setSelectedRepository?: (value: string | null) => void
   disabled?: boolean
   open?: boolean
-  addFormContent?: (data: {
-    enablePrPreview?: boolean
-    privateBuild?: boolean
+  addFormContent?: (props: {
+    allowPrPreviews?: boolean
   }) => void
   formData?: any
 }
@@ -137,28 +136,6 @@ export const GitHubRepositorySelector = ({
 
       {initialValue && selectedRepository !== "unlink//repo" && (
         <div className="space-y-4 mt-4 p-4 border rounded-lg bg-gray-50">
-          <h4 className="text-sm font-medium text-gray-900">
-            Repository Settings
-          </h4>
-
-          <div className="flex items-center justify-between">
-            <div className="space-y-0.5">
-              <Label className="text-sm font-medium">Private Build</Label>
-              <p className="text-xs text-gray-500">
-                Keep build previews private
-              </p>
-            </div>
-            <Switch
-              checked={formData?.privateBuild}
-              onCheckedChange={(checked) =>
-                addFormContent?.({
-                  privateBuild: checked,
-                })
-              }
-              disabled={disabled}
-            />
-          </div>
-
           <div className="flex items-center justify-between">
             <div className="space-y-0.5">
               <Label className="text-sm font-medium">Enable PR Preview</Label>
@@ -167,10 +144,10 @@ export const GitHubRepositorySelector = ({
               </p>
             </div>
             <Switch
-              checked={formData?.enablePrPreview}
+              checked={formData?.allowPrPreviews}
               onCheckedChange={(checked) =>
                 addFormContent?.({
-                  enablePrPreview: checked,
+                  allowPrPreviews: checked,
                 })
               }
               disabled={disabled}

--- a/src/components/dialogs/edit-package-details-dialog.tsx
+++ b/src/components/dialogs/edit-package-details-dialog.tsx
@@ -90,7 +90,7 @@ export const EditPackageDetailsDialog = ({
     initialVisibility: isPrivate ? "private" : "public",
     initialAllowPrPreviews: currentAllowPrPreviews,
   })
-  console.log(60, currentAllowPrPreviews)
+
   const [showConfirmDelete, setShowConfirmDelete] = useState(false)
   const [dangerOpen, setDangerOpen] = useState(false)
   const [, setLocation] = useLocation()

--- a/src/components/dialogs/edit-package-details-dialog.tsx
+++ b/src/components/dialogs/edit-package-details-dialog.tsx
@@ -48,7 +48,9 @@ interface EditPackageDetailsDialogProps {
     newWebsite: string,
     newLicense: string | null,
     newDefaultView: string,
+    newAllowPrPreviews?: boolean,
   ) => void
+  currentAllowPrPreviews?: boolean
 }
 
 export const EditPackageDetailsDialog = ({
@@ -64,6 +66,7 @@ export const EditPackageDetailsDialog = ({
   unscopedPackageName,
   packageReleaseId,
   packageAuthor,
+  currentAllowPrPreviews,
   onUpdate,
 }: EditPackageDetailsDialogProps) => {
   const axios = useAxios()
@@ -85,8 +88,9 @@ export const EditPackageDetailsDialog = ({
     initialUnscopedPackageName: unscopedPackageName,
     isDialogOpen: open,
     initialVisibility: isPrivate ? "private" : "public",
+    initialAllowPrPreviews: currentAllowPrPreviews,
   })
-
+  console.log(60, currentAllowPrPreviews)
   const [showConfirmDelete, setShowConfirmDelete] = useState(false)
   const [dangerOpen, setDangerOpen] = useState(false)
   const [, setLocation] = useLocation()
@@ -117,6 +121,7 @@ export const EditPackageDetailsDialog = ({
         website: formData.website.trim(),
         is_private: formData.visibility == "private",
         default_view: formData.defaultView,
+        allow_pr_previews: formData.allowPrPreviews,
         github_repo_full_name:
           formData.githubRepoFullName === "unlink//repo"
             ? null

--- a/src/hooks/use-package-details-form.ts
+++ b/src/hooks/use-package-details-form.ts
@@ -18,6 +18,7 @@ interface PackageDetailsForm {
   defaultView: string
   githubRepoFullName: string | null
   unscopedPackageName: string
+  allowPrPreviews?: boolean
 }
 
 interface UsePackageDetailsFormProps {
@@ -29,6 +30,7 @@ interface UsePackageDetailsFormProps {
   initialUnscopedPackageName: string
   initialGithubRepoFullName: string | null
   isDialogOpen: boolean
+  initialAllowPrPreviews?: boolean
 }
 
 export const usePackageDetailsForm = ({
@@ -40,6 +42,7 @@ export const usePackageDetailsForm = ({
   initialUnscopedPackageName,
   initialGithubRepoFullName,
   isDialogOpen,
+  initialAllowPrPreviews,
 }: UsePackageDetailsFormProps) => {
   const [formData, setFormData] = useState<PackageDetailsForm>({
     description: initialDescription,
@@ -62,6 +65,7 @@ export const usePackageDetailsForm = ({
         githubRepoFullName: initialGithubRepoFullName,
         defaultView: initialDefaultView,
         unscopedPackageName: initialUnscopedPackageName,
+        allowPrPreviews: initialAllowPrPreviews,
       })
       setWebsiteError(null)
     }
@@ -98,6 +102,11 @@ export const usePackageDetailsForm = ({
     [formData.defaultView, initialDefaultView],
   )
 
+  const hasAllowPrPreviewsChanged = useMemo(
+    () => formData.allowPrPreviews !== initialAllowPrPreviews,
+    [formData.allowPrPreviews, initialAllowPrPreviews],
+  )
+
   const hasChanges = useMemo(
     () =>
       formData.description !== initialDescription ||
@@ -106,7 +115,8 @@ export const usePackageDetailsForm = ({
       formData.visibility !== initialVisibility ||
       formData.defaultView !== initialDefaultView ||
       formData.githubRepoFullName !== initialGithubRepoFullName ||
-      formData.unscopedPackageName !== initialUnscopedPackageName,
+      formData.unscopedPackageName !== initialUnscopedPackageName ||
+      formData.allowPrPreviews !== initialAllowPrPreviews,
     [
       formData,
       initialDescription,
@@ -116,6 +126,7 @@ export const usePackageDetailsForm = ({
       initialDefaultView,
       initialGithubRepoFullName,
       initialUnscopedPackageName,
+      initialAllowPrPreviews,
     ],
   )
 
@@ -128,6 +139,7 @@ export const usePackageDetailsForm = ({
     hasLicenseChanged,
     hasVisibilityChanged,
     hasDefaultViewChanged,
+    hasAllowPrPreviewsChanged,
     hasChanges,
     isFormValid,
   }


### PR DESCRIPTION
- Add allow_pr_previews field to package schema and update API
- Pass currentAllowPrPreviews to edit dialog components
- Update GitHubRepositorySelector to use allowPrPreviews instead of enablePrPreview
- Include is_pr_preview and github_pr_number in package release mapping