### PR TITLE
refactor(releases): move git metadata from builds to releases

### DIFF
--- a/bun-tests/fake-snippets-api/routes/package_builds/get.test.ts
+++ b/bun-tests/fake-snippets-api/routes/package_builds/get.test.ts
@@ -71,9 +71,6 @@ test("GET /api/package_builds/get - returns 403 for unauthorized package build a
     build_error_last_updated_at: new Date().toISOString(),
     build_logs: null,
     preview_url: "https://preview.tscircuit.com/pb_test",
-    branch_name: "main",
-    commit_message: "Test build",
-    commit_author: "jane.doe",
   })
 
   const res = await axios.get(
@@ -126,9 +123,6 @@ test("GET /api/package_builds/get - successfully returns package build with logs
     ).toISOString(),
     build_logs: buildLogs.join(" "),
     preview_url: "https://preview.tscircuit.com/pb_1a2b3c4d",
-    branch_name: "main",
-    commit_message: "Add new LED component with improved brightness control",
-    commit_author: "john.doe",
   })
 
   const res = await axios.get(
@@ -174,9 +168,6 @@ test("GET /api/package_builds/get - returns package build without logs when incl
     build_error_last_updated_at: new Date().toISOString(),
     build_logs: "Some build logs",
     preview_url: "https://preview.tscircuit.com/pb_test",
-    branch_name: "main",
-    commit_message: "Test build",
-    commit_author: "john.doe",
   })
 
   const res = await axios.get(
@@ -222,9 +213,6 @@ test("GET /api/package_builds/get - handles build with errors", async () => {
     build_error_last_updated_at: new Date().toISOString(),
     build_logs: null,
     preview_url: null,
-    branch_name: "feature/new-component",
-    commit_message: "Add broken component",
-    commit_author: "john.doe",
   })
 
   const res = await axios.get(
@@ -274,9 +262,6 @@ test("GET /api/package_builds/get - handles build in progress", async () => {
     build_error_last_updated_at: new Date().toISOString(),
     build_logs: null,
     preview_url: null,
-    branch_name: "main",
-    commit_message: "Building in progress",
-    commit_author: "john.doe",
   })
 
   const res = await axios.get(

--- a/bun-tests/fake-snippets-api/routes/package_builds/list.test.ts
+++ b/bun-tests/fake-snippets-api/routes/package_builds/list.test.ts
@@ -125,9 +125,6 @@ test("GET /api/package_builds/list - returns created builds", async () => {
     ).toISOString(),
     build_logs: null,
     preview_url: "https://preview.tscircuit.com/pb_1a2b3c4d",
-    branch_name: "main",
-    commit_message: "Add new LED component with improved brightness control",
-    commit_author: "john.doe",
   })
 
   const res = await axios.get(
@@ -175,9 +172,6 @@ test("GET /api/package_builds/list - sorts builds by created_at descending", asy
     ).toISOString(),
     build_logs: null,
     preview_url: "https://preview.tscircuit.com/pb_1",
-    branch_name: "main",
-    commit_message: "First build",
-    commit_author: "john.doe",
   })
 
   db.addPackageBuild({
@@ -210,9 +204,6 @@ test("GET /api/package_builds/list - sorts builds by created_at descending", asy
     ).toISOString(),
     build_logs: null,
     preview_url: "https://preview.tscircuit.com/pb_2",
-    branch_name: "main",
-    commit_message: "Second build",
-    commit_author: "john.doe",
   })
 
   const res = await axios.get(
@@ -286,9 +277,6 @@ test("GET /api/package_builds/list - returns created builds with logs or not", a
     ).toISOString(),
     build_logs: buildLogs.join(" "),
     preview_url: "https://preview.tscircuit.com/pb_1a2b3c4d",
-    branch_name: "main",
-    commit_message: "Add new LED component with improved brightness control",
-    commit_author: "john.doe",
   })
 
   const resWithoutLogs = await axios.get(

--- a/fake-snippets-api/lib/db/db-client.ts
+++ b/fake-snippets-api/lib/db/db-client.ts
@@ -242,7 +242,13 @@ const initializer = combine(databaseSchema.parse({}), (set, get) => ({
     snippet: Omit<
       z.input<typeof snippetSchema>,
       "snippet_id" | "package_release_id"
-    > & { creator_account_id?: string; github_repo_full_name?: string },
+    > & {
+      creator_account_id?: string
+      github_repo_full_name?: string
+      branch_name?: string
+      commit_message?: string
+      commit_author?: string
+    },
   ): Snippet => {
     const timestamp = Date.now()
     const currentTime = new Date(timestamp).toISOString()
@@ -291,6 +297,9 @@ const initializer = combine(databaseSchema.parse({}), (set, get) => ({
       is_locked: false,
       created_at: currentTime,
       updated_at: currentTime,
+      branch_name: snippet.branch_name,
+      commit_message: snippet.commit_message,
+      commit_author: snippet.commit_author,
       has_transpiled: true,
       transpilation_error: null,
       ...(snippet.name == "testuser/my-test-board"

--- a/fake-snippets-api/lib/db/schema.ts
+++ b/fake-snippets-api/lib/db/schema.ts
@@ -258,6 +258,9 @@ export const packageReleaseSchema = z.object({
 
   // Latest Build Reference
   latest_package_build_id: z.string().nullable().optional(),
+  branch_name: z.string().nullable().optional(),
+  commit_message: z.string().nullable().optional(),
+  commit_author: z.string().nullable().optional(),
 })
 export type PackageRelease = z.infer<typeof packageReleaseSchema>
 
@@ -370,9 +373,6 @@ export const packageBuildSchema = z.object({
   build_error_last_updated_at: z.string().datetime(),
   preview_url: z.string().nullable().optional(),
   build_logs: z.string().nullable().optional(),
-  branch_name: z.string().nullable().optional(),
-  commit_message: z.string().nullable().optional(),
-  commit_author: z.string().nullable().optional(),
 })
 export type PackageBuild = z.infer<typeof packageBuildSchema>
 

--- a/fake-snippets-api/lib/db/seed.ts
+++ b/fake-snippets-api/lib/db/seed.ts
@@ -31,6 +31,9 @@ export const seed = (db: DbClient) => {
     unscoped_name: "my-test-board",
     github_repo_full_name: "testuser/my-test-board",
     owner_name: "testuser",
+    branch_name: "main",
+    commit_message: "Attempted build of a555timer-square-wave package",
+    commit_author: "testuser",
     creator_account_id: account_id,
     code: `
 import { A555Timer } from "@tsci/seveibar.a555timer"
@@ -570,9 +573,6 @@ export default () => (
       "3. Code compilation - FAILED\n" +
       "Error: Invalid syntax in component declaration\n" +
       "Build terminated with errors",
-    branch_name: "main",
-    commit_message: "Attempted build of a555timer-square-wave package",
-    commit_author: "testuser",
   })
 
   // Update the package release with the latest build ID
@@ -1116,6 +1116,9 @@ exports.A555Timer = A555Timer;
     name: "testuser/a555timer-square-wave",
     unscoped_name: "a555timer-square-wave",
     owner_name: "testuser",
+    branch_name: "main",
+    commit_message: "Attempted build of a555timer-square-wave package",
+    commit_author: "testuser",
     creator_account_id: account_id,
     code: `
 import { A555Timer } from "@tsci/seveibar.a555timer"
@@ -1659,9 +1662,6 @@ export const SquareWaveModule = () => (
       "3. Code compilation - FAILED\n" +
       "Error: Invalid syntax in component declaration\n" +
       "Build terminated with errors",
-    branch_name: "main",
-    commit_message: "Attempted build of a555timer-square-wave package",
-    commit_author: "testuser",
   })
 
   // Add successful build
@@ -1704,9 +1704,6 @@ export const SquareWaveModule = () => (
       "4. Circuit validation - OK\n" +
       "5. Package assembly - OK\n" +
       "Build completed successfully",
-    branch_name: "main",
-    commit_message: "Initial build of a555timer-square-wave package",
-    commit_author: "testuser",
   })
 
   // Update the package release with the latest (successful) build ID

--- a/fake-snippets-api/lib/public-mapping/public-map-package-build.ts
+++ b/fake-snippets-api/lib/public-mapping/public-map-package-build.ts
@@ -32,9 +32,6 @@ export const publicMapPackageBuild = (
       internalPackageBuild.build_error_last_updated_at,
     preview_url: internalPackageBuild.preview_url,
     build_logs: options.include_logs ? internalPackageBuild.build_logs : null,
-    branch_name: internalPackageBuild.branch_name,
-    commit_message: internalPackageBuild.commit_message,
-    commit_author: internalPackageBuild.commit_author,
   }
 
   return result

--- a/fake-snippets-api/lib/public-mapping/public-map-package-release.ts
+++ b/fake-snippets-api/lib/public-mapping/public-map-package-release.ts
@@ -26,6 +26,9 @@ export const publicMapPackageRelease = (
       : [],
     is_pr_preview: Boolean(internal_package_release.is_pr_preview),
     github_pr_number: internal_package_release.github_pr_number,
+    branch_name: internal_package_release.branch_name,
+    commit_message: internal_package_release.commit_message ?? null,
+    commit_author: internal_package_release.commit_author ?? null,
   }
 
   if (options.include_ai_review && options.db) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -262,11 +262,11 @@ function App() {
             <Route path="/dev-login" component={DevLoginPage} />
             <Route path="/:username" component={UserProfilePage} />
             <Route
-              path="/:author/:packageName/release/:releaseId/builds"
+              path="/:author/:packageName/releases/:releaseId/builds"
               component={ReleaseBuildsPage}
             />
             <Route
-              path="/:author/:packageName/release/:releaseId"
+              path="/:author/:packageName/releases/:releaseId"
               component={ReleaseDetailPage}
             />
             <Route

--- a/src/components/PackageBreadcrumb.tsx
+++ b/src/components/PackageBreadcrumb.tsx
@@ -77,7 +77,7 @@ export function PackageBreadcrumb({
               {currentPage === "builds" ? (
                 <BreadcrumbLink asChild>
                   <PrefetchPageLink
-                    href={`/${packageName}/release/${releaseVersion}`}
+                    href={`/${packageName}/releases/${releaseVersion}`}
                   >
                     {releaseVersion}
                   </PrefetchPageLink>

--- a/src/components/ViewPackagePage/components/sidebar-about-section.tsx
+++ b/src/components/ViewPackagePage/components/sidebar-about-section.tsx
@@ -1,5 +1,5 @@
 import { Badge } from "@/components/ui/badge"
-import { GitFork, Star, Settings, LinkIcon, Github } from "lucide-react"
+import { GitFork, Star, Settings, LinkIcon, Github, Plus } from "lucide-react"
 import { Skeleton } from "@/components/ui/skeleton"
 import { useCurrentPackageInfo } from "@/hooks/use-current-package-info"
 import { usePackageReleaseById } from "@/hooks/use-package-release"
@@ -164,7 +164,7 @@ export default function SidebarAboutSection({
             <GitFork className="h-4 w-4 mr-2 text-gray-500 dark:text-[#8b949e]" />
             <span>{(packageInfo as any)?.fork_count ?? "0"} forks</span>
           </div>
-          {packageInfo?.github_repo_full_name && (
+          {packageInfo?.github_repo_full_name ? (
             <a
               target="_blank"
               href={`https://github.com/${packageInfo.github_repo_full_name}`}
@@ -173,6 +173,22 @@ export default function SidebarAboutSection({
               <Github className="h-4 w-4 mr-2 text-gray-500 dark:text-[#8b949e]" />
               <span>{packageInfo?.github_repo_full_name.split("/")[1]}</span>
             </a>
+          ) : (
+            <>
+              {isOwner && (
+                <div
+                  className="flex items-center hover:underline hover:underline-offset-2 cursor-pointer hover:decoration-gray-500"
+                  onClick={openEditPackageDetailsDialog}
+                  title="Connect GitHub"
+                >
+                  <div className="relative mr-2">
+                    <Github className="h-4 w-4 text-gray-500 dark:text-[#8b949e]" />
+                    <Plus className="h-2 w-2 absolute -bottom-0.5 -right-0.5 text-gray-500 dark:text-[#8b949e] bg-white dark:bg-[#0d1117] rounded-full" />
+                  </div>
+                  <span>Connect GitHub</span>
+                </div>
+              )}
+            </>
           )}
         </div>
       </div>

--- a/src/components/preview/BuildsList.tsx
+++ b/src/components/preview/BuildsList.tsx
@@ -19,7 +19,7 @@ import {
 } from "@/components/ui/table"
 import { getBuildStatus, StatusIcon } from "."
 import { formatTimeAgo } from "@/lib/utils/formatTimeAgo"
-import { Package } from "fake-snippets-api/lib/db/schema"
+import { Package, PackageBuild } from "fake-snippets-api/lib/db/schema"
 import { usePackageReleasesByPackageId } from "@/hooks/use-package-release"
 import { useQueries } from "react-query"
 import { useAxios } from "@/hooks/use-axios"
@@ -53,7 +53,8 @@ export const BuildsList = ({ pkg }: { pkg: Package }) => {
     isLoadingReleases || latestBuildQueries.some((q) => q.isLoading)
 
   // Create a map of release ID to latest build for easy access
-  const latestBuildsMap = new Map()
+  const latestBuildsMap = new Map<string, PackageBuild>()
+
   latestBuildQueries.forEach((query, index) => {
     if (query.data && releases?.[index]) {
       latestBuildsMap.set(releases[index].package_release_id, query.data)
@@ -111,16 +112,14 @@ export const BuildsList = ({ pkg }: { pkg: Package }) => {
                         const latestBuild = latestBuildsMap.get(
                           release.package_release_id,
                         )
-                        const { status, label } = latestBuild
-                          ? getBuildStatus(latestBuild)
-                          : { status: "unknown", label: "No builds" }
+                        const { status, label } = getBuildStatus(latestBuild)
                         return (
                           <TableRow
                             key={release.package_release_id}
                             className="cursor-pointer hover:bg-gray-50 no-scrollbar"
                             onClick={() => {
                               setLocation(
-                                `/${pkg.name}/release/${release.package_release_id}`,
+                                `/${pkg.name}/releases/${release.package_release_id}`,
                               )
                             }}
                           >
@@ -199,14 +198,23 @@ export const BuildsList = ({ pkg }: { pkg: Package }) => {
                                   <DropdownMenuContent align="end">
                                     <DropdownMenuItem
                                       onClick={() => {
-                                        window.location.href = `/${pkg.name}/release/${release.package_release_id}`
+                                        window.location.href = `/${pkg.name}/releases/${release.package_release_id}`
                                       }}
                                     >
                                       View Release
                                     </DropdownMenuItem>
+                                    {status !== "error" && (
+                                      <DropdownMenuItem>
+                                        <a
+                                          href={`/${pkg.name}/releases/${latestBuild?.package_release_id}/preview`}
+                                        >
+                                          Preview Release
+                                        </a>
+                                      </DropdownMenuItem>
+                                    )}
                                     <DropdownMenuItem
                                       onClick={() => {
-                                        window.location.href = `/${pkg.name}/release/${release.package_release_id}/builds`
+                                        window.location.href = `/${pkg.name}/releases/${release.package_release_id}/builds`
                                       }}
                                     >
                                       View All Builds

--- a/src/components/preview/ConnectedPackagesList.tsx
+++ b/src/components/preview/ConnectedPackagesList.tsx
@@ -8,7 +8,10 @@ import { formatTimeAgo } from "@/lib/utils/formatTimeAgo"
 import { getBuildStatus, StatusIcon } from "."
 import { Package } from "fake-snippets-api/lib/db/schema"
 import { usePackageBuild } from "@/hooks/use-package-builds"
-import { useLatestPackageRelease } from "@/hooks/use-package-release"
+import {
+  useLatestPackageRelease,
+  usePackageReleaseById,
+} from "@/hooks/use-package-release"
 
 export const ConnectedPackageCardSkeleton = () => {
   return (
@@ -86,6 +89,10 @@ export const ConnectedPackageCard = ({
     pkg.package_id,
   )
 
+  const { data: packageRelease } = usePackageReleaseById(
+    latestBuildInfo?.package_release_id,
+  )
+
   if (isLoading && !latestBuildInfo) {
     return <ConnectedPackageCardSkeleton />
   }
@@ -146,25 +153,25 @@ export const ConnectedPackageCard = ({
         </a>
       </div>
 
-      {latestBuildInfo?.commit_message && (
-        <div className="mb-6 flex-1">
+      <div className="mb-6 flex-1">
+        {packageRelease?.commit_message && (
           <h4
-            title={latestBuildInfo.commit_message}
+            title={packageRelease.commit_message}
             className="text-sm font-medium truncate text-gray-900 mb-2"
           >
-            {latestBuildInfo.commit_message}
+            {packageRelease.commit_message}
           </h4>
-          <div className="flex items-center gap-2 text-xs text-gray-500">
-            <span>{formatTimeAgo(latestBuildInfo.created_at)} on</span>
-            <div className="flex items-center gap-1">
-              <GitBranch className="w-3 h-3" />
-              <span className="bg-blue-100 text-blue-800 px-2 py-0.5 rounded-full font-medium">
-                {latestBuildInfo.branch_name || "main"}
-              </span>
-            </div>
+        )}
+        <div className="flex items-center gap-2 text-xs text-gray-500">
+          <span>{formatTimeAgo(String(latestBuildInfo?.created_at))} on</span>
+          <div className="flex items-center gap-1">
+            <GitBranch className="w-3 h-3" />
+            <span className="bg-blue-100 text-blue-800 px-2 py-0.5 rounded-full font-medium">
+              {packageRelease?.branch_name || "main"}
+            </span>
           </div>
         </div>
-      )}
+      </div>
 
       <div className="flex gap-2 w-full mt-auto">
         <PrefetchPageLink className="w-full" href={`/${pkg.name}/releases`}>

--- a/src/components/preview/ConnectedRepoOverview.tsx
+++ b/src/components/preview/ConnectedRepoOverview.tsx
@@ -179,19 +179,21 @@ export const ConnectedRepoOverview = ({
               </div>
             </div>
             <div className="flex items-center gap-3 flex-shrink-0">
-              <Button
-                size="sm"
-                className="flex items-center gap-2 min-w-[80px] h-9"
-                onClick={() =>
-                  window.open(
-                    `/${pkg.name}/releases/${packageBuild.package_build_id}/preview`,
-                    "_blank",
-                  )
-                }
-              >
-                <ExternalLink className="w-3 h-3" />
-                Preview
-              </Button>
+              {status !== "error" && (
+                <Button
+                  size="sm"
+                  className="flex items-center gap-2 min-w-[80px] h-9"
+                  onClick={() =>
+                    window.open(
+                      `/${pkg.name}/releases/${packageBuild.package_release_id}/preview`,
+                      "_blank",
+                    )
+                  }
+                >
+                  <ExternalLink className="w-3 h-3" />
+                  Preview
+                </Button>
+              )}
             </div>
           </div>
         </div>
@@ -230,8 +232,8 @@ export const ConnectedRepoOverview = ({
                 <a
                   href={
                     packageRelease?.is_pr_preview
-                      ? `https://github.com/${pkg.github_repo_full_name}/pull/${packageRelease.github_pr_number}`
-                      : `https://github.com/${pkg.github_repo_full_name}/tree/${packageBuild.branch_name || "main"}`
+                      ? `https://github.com/${pkg.github_repo_full_name}/pull/${packageRelease?.github_pr_number}`
+                      : `https://github.com/${pkg.github_repo_full_name}/tree/${packageRelease?.branch_name || "main"}`
                   }
                   target="_blank"
                   rel="noopener noreferrer"
@@ -243,7 +245,7 @@ export const ConnectedRepoOverview = ({
                   >
                     {packageRelease?.is_pr_preview
                       ? `#${packageRelease.github_pr_number}`
-                      : packageBuild?.branch_name || "main"}
+                      : packageRelease?.branch_name || "main"}
                   </Badge>
                 </a>
               </div>
@@ -282,13 +284,13 @@ export const ConnectedRepoOverview = ({
             </div>
           </div>
 
-          {packageBuild.commit_message && (
+          {packageRelease?.commit_message && (
             <div className="mt-6 p-4 bg-gray-50 rounded-lg hover:bg-gray-100 transition-colors group">
               <p className="text-xs text-gray-500 uppercase tracking-wide mb-2">
                 Commit Message
               </p>
               <p className="text-sm text-gray-900 group-hover:text-gray-700 transition-colors">
-                {packageBuild.commit_message}
+                {packageRelease?.commit_message}
               </p>
             </div>
           )}
@@ -301,7 +303,7 @@ export const ConnectedRepoOverview = ({
             Latest Build Logs
           </h2>
           <a
-            href={`/${pkg.name.split("/")[0]}/${pkg.name.split("/")[1]}/release/${packageRelease.package_release_id}/builds`}
+            href={`/${pkg.name.split("/")[0]}/${pkg.name.split("/")[1]}/releases/${packageRelease.package_release_id}/builds`}
             className="text-sm text-blue-600 hover:text-blue-800 transition-colors"
           >
             (previous builds)

--- a/src/components/preview/PackageReleasesDashboard.tsx
+++ b/src/components/preview/PackageReleasesDashboard.tsx
@@ -15,12 +15,18 @@ import { formatTimeAgo } from "@/lib/utils/formatTimeAgo"
 import { getBuildStatus } from "."
 import { PrefetchPageLink } from "../PrefetchPageLink"
 import { PackageBreadcrumb } from "../PackageBreadcrumb"
-import { Package, PackageBuild } from "fake-snippets-api/lib/db/schema"
+import {
+  Package,
+  PackageBuild,
+  PackageRelease,
+} from "fake-snippets-api/lib/db/schema"
 
 export const PackageReleasesDashboard = ({
+  latestRelease,
   latestBuild,
   pkg,
 }: {
+  latestRelease: PackageRelease
   latestBuild: PackageBuild | null
   pkg: Package
 }) => {
@@ -88,14 +94,14 @@ export const PackageReleasesDashboard = ({
                       className="flex cursor-pointer items-center gap-1"
                       onClick={() =>
                         window?.open(
-                          `https://github.com/${pkg.github_repo_full_name}/tree/${latestBuild?.branch_name || "main"}`,
+                          `https://github.com/${pkg.github_repo_full_name}/tree/${latestRelease?.branch_name || "main"}`,
                           "_blank",
                         )
                       }
                     >
                       <GitBranch className="w-4 h-4 flex-shrink-0" />
                       <span className="truncate">
-                        {latestBuild?.branch_name || "main"}
+                        {latestRelease?.branch_name || "main"}
                       </span>
                     </div>
                     <div className="flex items-center gap-1">

--- a/src/components/preview/index.tsx
+++ b/src/components/preview/index.tsx
@@ -1,9 +1,14 @@
 export { ConnectedRepoOverview } from "./ConnectedRepoOverview"
 export { BuildsList } from "./BuildsList"
 export { PackageReleasesDashboard } from "./PackageReleasesDashboard"
-import { Package, PackageBuild } from "fake-snippets-api/lib/db/schema"
+import { PackageBuild } from "fake-snippets-api/lib/db/schema"
 import { Clock, CheckCircle, AlertCircle, Loader2 } from "lucide-react"
-export const getBuildStatus = (build: PackageBuild | null) => {
+export const getBuildStatus = (
+  build?: PackageBuild | null,
+): {
+  status: "pending" | "building" | "success" | "error" | "queued"
+  label: string
+} => {
   if (!build) {
     return { status: "pending", label: "No builds" }
   }
@@ -34,147 +39,6 @@ export const getBuildStatus = (build: PackageBuild | null) => {
   }
   return { status: "queued", label: "Queued" }
 }
-export const MOCK_PACKAGE_BUILDS: PackageBuild[] = [
-  {
-    package_build_id: "pb_1a2b3c4d",
-    package_release_id: "pr_5e6f7g8h",
-    created_at: new Date(Date.now() - 1000 * 60 * 30).toISOString(),
-    transpilation_in_progress: false,
-    transpilation_started_at: new Date(
-      Date.now() - 1000 * 60 * 35,
-    ).toISOString(),
-    transpilation_completed_at: new Date(
-      Date.now() - 1000 * 60 * 32,
-    ).toISOString(),
-    transpilation_logs: [],
-    transpilation_error: null,
-    circuit_json_build_in_progress: false,
-    circuit_json_build_started_at: new Date(
-      Date.now() - 1000 * 60 * 32,
-    ).toISOString(),
-    circuit_json_build_completed_at: new Date(
-      Date.now() - 1000 * 60 * 30,
-    ).toISOString(),
-    circuit_json_build_logs: [],
-    circuit_json_build_error: null,
-    build_in_progress: false,
-    build_started_at: new Date(Date.now() - 1000 * 60 * 30).toISOString(),
-    build_completed_at: new Date(Date.now() - 1000 * 60 * 25).toISOString(),
-    build_error: null,
-    build_error_last_updated_at: new Date(
-      Date.now() - 1000 * 60 * 25,
-    ).toISOString(),
-    build_logs: null,
-    preview_url: "https://preview.tscircuit.com/pb_1a2b3c4d",
-    branch_name: "main",
-    commit_message: "Add new LED component with improved brightness control",
-    commit_author: "john.doe",
-  },
-  {
-    package_build_id: "pb_9i8j7k6l",
-    package_release_id: "pr_5m4n3o2p",
-    created_at: new Date(Date.now() - 1000 * 60 * 60 * 2).toISOString(),
-    transpilation_in_progress: false,
-    transpilation_started_at: new Date(
-      Date.now() - 1000 * 60 * 60 * 2,
-    ).toISOString(),
-    transpilation_completed_at: new Date(
-      Date.now() - 1000 * 60 * 60 * 2 + 1000 * 60 * 3,
-    ).toISOString(),
-    transpilation_logs: [],
-    transpilation_error: null,
-    circuit_json_build_in_progress: true,
-    circuit_json_build_started_at: new Date(
-      Date.now() - 1000 * 60 * 5,
-    ).toISOString(),
-    circuit_json_build_completed_at: null,
-    circuit_json_build_logs: [],
-    circuit_json_build_error: null,
-    build_in_progress: false,
-    build_started_at: null,
-    build_completed_at: null,
-    build_error: null,
-    build_error_last_updated_at: new Date(
-      Date.now() - 1000 * 60 * 60 * 2,
-    ).toISOString(),
-    build_logs: null,
-    preview_url: null,
-    branch_name: "feature/resistor-update",
-    commit_message: "Update resistor component with new tolerance values",
-    commit_author: "jane.smith",
-  },
-  {
-    package_build_id: "pb_1q2w3e4r",
-    package_release_id: "pr_5t6y7u8i",
-    created_at: new Date(Date.now() - 1000 * 60 * 60 * 6).toISOString(),
-    transpilation_in_progress: false,
-    transpilation_started_at: new Date(
-      Date.now() - 1000 * 60 * 60 * 6,
-    ).toISOString(),
-    transpilation_completed_at: new Date(
-      Date.now() - 1000 * 60 * 60 * 6 + 1000 * 60 * 2,
-    ).toISOString(),
-    transpilation_logs: [],
-    transpilation_error:
-      "TypeScript compilation failed: Cannot find module 'missing-dependency'",
-    circuit_json_build_in_progress: false,
-    circuit_json_build_started_at: null,
-    circuit_json_build_completed_at: null,
-    circuit_json_build_logs: [],
-    circuit_json_build_error: null,
-    build_in_progress: false,
-    build_started_at: null,
-    build_completed_at: null,
-    build_error: null,
-    build_error_last_updated_at: new Date(
-      Date.now() - 1000 * 60 * 60 * 6,
-    ).toISOString(),
-    build_logs: null,
-    preview_url: null,
-    branch_name: "hotfix/critical-bug",
-    commit_message: "Fix critical issue with capacitor placement",
-    commit_author: "alex.wilson",
-  },
-  {
-    package_build_id: "pb_9o8i7u6y",
-    package_release_id: "pr_5t4r3e2w",
-    created_at: new Date(Date.now() - 1000 * 60 * 60 * 24).toISOString(),
-    transpilation_in_progress: false,
-    transpilation_started_at: new Date(
-      Date.now() - 1000 * 60 * 60 * 24,
-    ).toISOString(),
-    transpilation_completed_at: new Date(
-      Date.now() - 1000 * 60 * 60 * 24 + 1000 * 60 * 4,
-    ).toISOString(),
-    transpilation_logs: [],
-    transpilation_error: null,
-    circuit_json_build_in_progress: false,
-    circuit_json_build_started_at: new Date(
-      Date.now() - 1000 * 60 * 60 * 24 + 1000 * 60 * 4,
-    ).toISOString(),
-    circuit_json_build_completed_at: new Date(
-      Date.now() - 1000 * 60 * 60 * 24 + 1000 * 60 * 8,
-    ).toISOString(),
-    circuit_json_build_logs: [],
-    circuit_json_build_error: null,
-    build_in_progress: false,
-    build_started_at: new Date(
-      Date.now() - 1000 * 60 * 60 * 24 + 1000 * 60 * 8,
-    ).toISOString(),
-    build_completed_at: new Date(
-      Date.now() - 1000 * 60 * 60 * 24 + 1000 * 60 * 12,
-    ).toISOString(),
-    build_error: null,
-    build_error_last_updated_at: new Date(
-      Date.now() - 1000 * 60 * 60 * 24 + 1000 * 60 * 12,
-    ).toISOString(),
-    build_logs: null,
-    preview_url: "https://preview.tscircuit.com/pb_9o8i7u6y",
-    branch_name: "main",
-    commit_message: "Initial project setup with basic components",
-    commit_author: "sarah.johnson",
-  },
-]
 
 export const StatusIcon = ({ status }: { status: string }) => {
   switch (status) {
@@ -187,8 +51,4 @@ export const StatusIcon = ({ status }: { status: string }) => {
     default:
       return <Clock className="w-4 h-4 text-gray-500" />
   }
-}
-
-export const getLatestBuildForPackage = (pkg: Package): PackageBuild => {
-  return MOCK_PACKAGE_BUILDS[0]
 }

--- a/src/hooks/use-packages-base-api-url.ts
+++ b/src/hooks/use-packages-base-api-url.ts
@@ -1,4 +1,3 @@
 export const useApiBaseUrl = () => {
-  return "https://api.tscircuit.com"
-  // return "/api"
+  return import.meta.env.VITE_SNIPPETS_API_URL ?? "/api"
 }

--- a/src/hooks/use-packages-base-api-url.ts
+++ b/src/hooks/use-packages-base-api-url.ts
@@ -1,3 +1,4 @@
 export const useApiBaseUrl = () => {
-  return import.meta.env.VITE_SNIPPETS_API_URL ?? "/api"
+  return "https://api.tscircuit.com"
+  // return "/api"
 }

--- a/src/pages/preview-release.tsx
+++ b/src/pages/preview-release.tsx
@@ -37,7 +37,7 @@ export default function PreviewBuildPage() {
   const author = params?.author || null
   const packageName = params?.packageName || null
 
-  const [sidebarCollapsed, setSidebarCollapsed] = useState(false)
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(true)
   const [selectedFile, setSelectedFile] = useState<string | null>("index.tsx")
   const [selectedItemId, setSelectedItemId] = useState<string>("")
 
@@ -132,19 +132,19 @@ export default function PreviewBuildPage() {
                           {build?.package_build_id}
                         </PrefetchPageLink>
                       </div>
-                      {build?.commit_message && (
+                      {packageRelease?.commit_message && (
                         <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
                           <span className="text-xs text-gray-500 uppercase tracking-wide">
                             Commit
                           </span>
                           <a
-                            title={build?.commit_message}
+                            title={packageRelease?.commit_message}
                             target="_blank"
                             rel="noopener noreferrer"
-                            href={`https://github.com/${pkg?.github_repo_full_name}/commit/${build?.commit_message}`}
+                            href={`https://github.com/${pkg?.github_repo_full_name}/commit/${packageRelease?.commit_message}`}
                             className="font-mono text-xs text-gray-600 bg-gray-50 px-2 text-right py-1 rounded truncate"
                           >
-                            {build?.commit_message}
+                            {packageRelease?.commit_message}
                           </a>
                         </div>
                       )}
@@ -157,7 +157,7 @@ export default function PreviewBuildPage() {
                           className={`text-xs font-medium px-2 py-1 w-fit rounded-full capitalize ${
                             status === "success"
                               ? "bg-emerald-100 text-emerald-800"
-                              : status === "failed"
+                              : status === "error"
                                 ? "bg-red-100 text-red-800"
                                 : status === "building"
                                   ? "bg-blue-100 text-blue-800"
@@ -232,7 +232,7 @@ export default function PreviewBuildPage() {
                       <Loader2 className="w-6 h-6 animate-spin" />
                       <p>Building…</p>
                     </div>
-                  ) : status === "failed" ? (
+                  ) : status === "error" ? (
                     <div className="text-center">
                       <p className="text-red-600 font-medium mb-2">
                         Build Failed

--- a/src/pages/release-detail.tsx
+++ b/src/pages/release-detail.tsx
@@ -6,8 +6,7 @@ import { usePackageBuild } from "@/hooks/use-package-builds"
 import { ConnectedRepoOverview } from "@/components/preview/ConnectedRepoOverview"
 import Header from "@/components/Header"
 import { Badge } from "@/components/ui/badge"
-import { Button } from "@/components/ui/button"
-import { Calendar, GitBranch, Hash, Copy, Check } from "lucide-react"
+import { Calendar, GitBranch } from "lucide-react"
 import { useState } from "react"
 import { formatTimeAgo } from "@/lib/utils/formatTimeAgo"
 import { PackageBreadcrumb } from "@/components/PackageBreadcrumb"
@@ -83,12 +82,18 @@ export default function ReleaseDetailPage() {
               <div className="flex-1">
                 <div className="flex items-center gap-4 text-sm text-gray-600">
                   {packageRelease.is_pr_preview && (
-                    <div className="flex items-center gap-1">
-                      <GitBranch className="w-4 h-4" />
-                      <Badge variant="outline" className="text-xs">
-                        PR #{packageRelease.github_pr_number}
-                      </Badge>
-                    </div>
+                    <a
+                      href={`https://github.com/${pkg.github_repo_full_name}/pull/${packageRelease.github_pr_number}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      <div className="flex items-center gap-1">
+                        <GitBranch className="w-4 h-4" />
+                        <Badge variant="outline" className="text-xs">
+                          PR #{packageRelease.github_pr_number}
+                        </Badge>
+                      </div>
+                    </a>
                   )}
                   <div className="flex items-center gap-1">
                     <Calendar className="w-4 h-4" />

--- a/src/pages/releases.tsx
+++ b/src/pages/releases.tsx
@@ -46,6 +46,10 @@ export default function ReleasesPage() {
   // If there's no build, we still want to show the releases page
   // The PackageReleasesDashboard will handle the case where latestBuild is null
   return (
-    <PackageReleasesDashboard latestBuild={latestBuild ?? null} pkg={pkg} />
+    <PackageReleasesDashboard
+      latestRelease={latestRelease}
+      latestBuild={latestBuild ?? null}
+      pkg={pkg}
+    />
   )
 }


### PR DESCRIPTION
- Update schema to move branch_name, commit_message, and commit_author from PackageBuild to PackageRelease
- Update UI components to use release metadata instead of build metadata
- Fix route paths to use "releases" instead of "release"
- Remove mock package builds data
- Set default sidebar state to collapsed in preview page
- Ask user to connect github repo