### PR TITLE
fix: files other than `AI review` on the `ImportFilesView` component fails to copy

### DIFF
--- a/src/components/ViewPackagePage/components/important-files-view.tsx
+++ b/src/components/ViewPackagePage/components/important-files-view.tsx
@@ -182,23 +182,6 @@ export default function ImportantFilesView({
     return null
   }, [isLoading, availableTabs, isReadmeFile])
 
-  // Handle copy functionality
-  const handleCopy = useCallback(() => {
-    let textToCopy = ""
-
-    if (activeTab?.type === "ai-review" && aiReviewText) {
-      textToCopy = aiReviewText
-    } else if (activeTab?.type === "file" && activeFileContent) {
-      textToCopy = activeFileContent
-    }
-
-    if (textToCopy) {
-      navigator.clipboard.writeText(textToCopy)
-      setCopyState("copied")
-      setTimeout(() => setCopyState("copy"), 500)
-    }
-  }, [activeTab, aiReviewText])
-
   // Handle tab selection with validation
   const selectTab = useCallback(
     (tab: TabInfo) => {
@@ -284,6 +267,22 @@ export default function ImportantFilesView({
   )
 
   const activeFileContent = activeFileFull?.content_text || ""
+
+  const handleCopy = () => {
+    let textToCopy = ""
+
+    if (activeTab?.type === "ai-review" && aiReviewText) {
+      textToCopy = aiReviewText
+    } else if (activeTab?.type === "file" && activeFileContent) {
+      textToCopy = activeFileContent
+    }
+
+    if (textToCopy) {
+      navigator.clipboard.writeText(textToCopy)
+      setCopyState("copied")
+      setTimeout(() => setCopyState("copy"), 500)
+    }
+  }
 
   // Render content based on active tab
   const renderAiContent = useCallback(


### PR DESCRIPTION
## Summary
- ensure ImportantFilesView copy button copies currently viewed file content by tracking file content in handler
- remove unnecessary useCallback wrapper around copy handler since copying is lightweight

## Testing
- `bun run format`
- `bun run lint`
- `bun run typecheck`


------
https://chatgpt.com/codex/tasks/task_b_6899b576672083279d46fb534c6a9655