### PR TITLE
feat: show file loaders without blocking page

### DIFF
--- a/src/components/ViewPackagePage/components/repo-page-content.tsx
+++ b/src/components/ViewPackagePage/components/repo-page-content.tsx
@@ -44,10 +44,12 @@ interface RepoPageContentProps {
   packageRelease?: import("fake-snippets-api/lib/db/schema").PackageRelease
   onFileClicked?: (file: PackageFile) => void
   onEditClicked?: () => void
+  arePackageFilesLoading?: boolean
 }
 
 export default function RepoPageContent({
   packageFiles,
+  arePackageFilesLoading = false,
   packageInfo,
   packageRelease,
   onFileClicked,
@@ -146,7 +148,7 @@ export default function RepoPageContent({
         return (
           <FilesView
             packageFiles={packageFiles}
-            isLoading={!packageFiles}
+            isLoading={arePackageFilesLoading}
             onFileClicked={onFileClicked}
           />
         )
@@ -162,7 +164,7 @@ export default function RepoPageContent({
         return (
           <FilesView
             packageFiles={packageFiles}
-            isLoading={!packageFiles}
+            isLoading={arePackageFilesLoading}
             onFileClicked={onFileClicked}
           />
         )
@@ -215,7 +217,7 @@ export default function RepoPageContent({
             {/* Important Files View - Always shown */}
             <ImportantFilesView
               importantFiles={importantFiles}
-              isLoading={!packageFiles}
+              isLoading={arePackageFilesLoading}
               onEditClicked={onEditClicked}
               packageAuthorOwner={packageInfo?.owner_github_username}
               aiDescription={packageInfo?.ai_description ?? ""}

--- a/src/pages/view-package.tsx
+++ b/src/pages/view-package.tsx
@@ -33,9 +33,8 @@ export const ViewPackagePage = () => {
     },
   )
 
-  const { data: packageFiles } = usePackageFiles(
-    packageRelease?.package_release_id,
-  )
+  const { data: packageFiles, isLoading: arePackageFilesLoading } =
+    usePackageFiles(packageRelease?.package_release_id)
 
   if (!isLoadingPackageId && packageIdError) {
     return <NotFoundPage heading="Package Not Found" />
@@ -51,7 +50,8 @@ export const ViewPackagePage = () => {
         <title>{`${author}/${packageName} - tscircuit`}</title>
       </Helmet>
       <RepoPageContent
-        packageFiles={packageFiles as any}
+        packageFiles={packageFiles ?? []}
+        arePackageFilesLoading={arePackageFilesLoading}
         packageInfo={packageInfo}
         packageRelease={packageRelease}
         importantFilePaths={["README.md", "LICENSE", "package.json"]}


### PR DESCRIPTION
## Summary
- show package page content while package files load
- only display skeletons in file sections if files are loading
- rename loading flag to `arePackageFilesLoading`

## Testing
- `bun test`


------
https://chatgpt.com/codex/tasks/task_b_689cdab77040832e8b99e8c319904ea0