### PR TITLE
fix(important-files-view): conditionally render AI tabs based on content availability

### DIFF
--- a/src/components/ViewPackagePage/components/important-files-view.tsx
+++ b/src/components/ViewPackagePage/components/important-files-view.tsx
@@ -174,11 +174,13 @@ export default function ImportantFilesView({
     if (readmeTab) return readmeTab
 
     // Priority 2: AI content (only if available)
-    const aiTab = availableTabs.find((tab) => tab.type === "ai")
+    const aiTab = availableTabs.find((tab) => tab.type === "ai" && hasAiContent)
     if (aiTab) return aiTab
 
     // Priority 3: AI review
-    const aiReviewTab = availableTabs.find((tab) => tab.type === "ai-review")
+    const aiReviewTab = availableTabs.find(
+      (tab) => tab.type === "ai-review" && hasAiReview,
+    )
     if (aiReviewTab) return aiReviewTab
 
     // Priority 4: First file


### PR DESCRIPTION
…

Only show AI description tab when hasAiContent is true and AI review tab when hasAiReview is true or user is owner. This prevents showing empty or irrelevant tabs to users.