### PR TITLE
Optimize package/get Requests

### DIFF
--- a/fake-snippets-api/lib/db/schema.ts
+++ b/fake-snippets-api/lib/db/schema.ts
@@ -311,6 +311,7 @@ export const packageSchema = z.object({
     .default("files")
     .optional(),
   allow_pr_previews: z.boolean().default(false).optional(),
+  is_starred: z.boolean().default(false).optional(),
 })
 export type Package = z.infer<typeof packageSchema>
 

--- a/src/components/ViewPackagePage/components/main-content-header.tsx
+++ b/src/components/ViewPackagePage/components/main-content-header.tsx
@@ -70,7 +70,9 @@ export default function MainContentHeader({
     }
   }
 
-  const { circuitJson } = useCurrentPackageCircuitJson()
+  const hasCircuitJson = packageFiles.some(
+    (file) => file.file_path === "dist/circuit.json",
+  )
 
   return (
     <div className="flex items-center justify-between mb-4">
@@ -84,7 +86,7 @@ export default function MainContentHeader({
           unscopedName={packageInfo?.unscoped_name}
           desiredImageType={activeView}
           author={packageInfo?.owner_github_username ?? undefined}
-          circuitJson={circuitJson}
+          hasCircuitJson={hasCircuitJson}
         />
 
         {/* Code Dropdown */}

--- a/src/components/ViewPackagePage/components/package-header.tsx
+++ b/src/components/ViewPackagePage/components/package-header.tsx
@@ -12,10 +12,7 @@ import { Lock, Globe } from "lucide-react"
 import { GitFork, Package, Star } from "lucide-react"
 
 import { useForkPackageMutation } from "@/hooks/use-fork-package-mutation"
-import {
-  usePackageStarMutationByName,
-  usePackageStarsByName,
-} from "@/hooks/use-package-stars"
+import { usePackageStarMutationByName } from "@/hooks/use-package-stars"
 import { useOrderDialog } from "@tscircuit/runframe"
 import { useGlobalStore } from "@/hooks/use-global-store"
 import { Package as PackageType } from "fake-snippets-api/lib/db/schema"
@@ -45,8 +42,7 @@ export default function PackageHeader({
     isLoggedIn,
     packageReleaseId: packageInfo?.latest_package_release_id ?? "",
   })
-  const { data: starData, isLoading: isStarDataLoading } =
-    usePackageStarsByName(packageInfo?.name ?? null)
+
   const { addStar, removeStar } = usePackageStarMutationByName(
     packageInfo?.name ?? "",
   )
@@ -57,7 +53,7 @@ export default function PackageHeader({
   const handleStarClick = async () => {
     if (!packageInfo?.name || !isLoggedIn) return
 
-    if (starData?.is_starred) {
+    if (packageInfo?.is_starred) {
       await removeStar.mutateAsync()
     } else {
       await addStar.mutateAsync()
@@ -69,8 +65,7 @@ export default function PackageHeader({
     await forkPackage(packageInfo.package_id)
   }
 
-  const isStarLoading =
-    isStarDataLoading || addStar.isLoading || removeStar.isLoading
+  const isStarLoading = addStar.isLoading || removeStar.isLoading
 
   useEffect(() => {
     window.TSCIRCUIT_REGISTRY_API_BASE_URL =
@@ -155,15 +150,15 @@ export default function PackageHeader({
                     >
                       <Star
                         className={`w-4 h-4 mr-2 ${
-                          starData?.is_starred
+                          packageInfo?.is_starred
                             ? "fill-yellow-500 text-yellow-500"
                             : ""
                         }`}
                       />
-                      {starData?.is_starred ? "Starred" : "Star"}
-                      {(starData?.star_count ?? 0) > 0 && (
+                      {packageInfo?.is_starred ? "Starred" : "Star"}
+                      {(packageInfo?.star_count ?? 0) > 0 && (
                         <span className="ml-1.5 bg-gray-100 text-gray-700 rounded-full px-1.5 py-0.5 text-xs font-medium">
-                          {starData?.star_count}
+                          {packageInfo?.star_count}
                         </span>
                       )}
                     </Button>
@@ -229,13 +224,15 @@ export default function PackageHeader({
             >
               <Star
                 className={`w-4 h-4 mr-2 ${
-                  starData?.is_starred ? "fill-yellow-500 text-yellow-500" : ""
+                  packageInfo?.is_starred
+                    ? "fill-yellow-500 text-yellow-500"
+                    : ""
                 }`}
               />
-              {starData?.is_starred ? "Starred" : "Star"}
-              {(starData?.star_count ?? 0) > 0 && (
+              {packageInfo?.is_starred ? "Starred" : "Star"}
+              {(packageInfo?.star_count ?? 0) > 0 && (
                 <span className="ml-1.5 bg-gray-100 text-gray-700 rounded-full px-1.5 py-0.5 text-xs font-medium">
-                  {starData?.star_count}
+                  {packageInfo?.star_count}
                 </span>
               )}
             </Button>

--- a/src/components/ViewPackagePage/components/repo-page-content.tsx
+++ b/src/components/ViewPackagePage/components/repo-page-content.tsx
@@ -23,7 +23,6 @@ import type {
   Package,
   PackageFile as ApiPackageFile,
 } from "fake-snippets-api/lib/db/schema"
-import { useCurrentPackageCircuitJson } from "../hooks/use-current-package-circuit-json"
 import { useRequestAiReviewMutation } from "@/hooks/use-request-ai-review-mutation"
 import { useAiReview } from "@/hooks/use-ai-review"
 import { useQueryClient } from "react-query"
@@ -69,8 +68,12 @@ export default function RepoPageContent({
     }
   }, [aiReview?.ai_review_text, queryClient])
   const session = useGlobalStore((s) => s.session)
-  const { circuitJson, isLoading: isCircuitJsonLoading } =
-    useCurrentPackageCircuitJson()
+
+  // Check if circuit.json exists without downloading it
+  const circuitJsonExists = useMemo(() => {
+    return packageFiles?.some((file) => file.file_path === "dist/circuit.json")
+  }, [packageFiles])
+
   const { mutate: requestAiReview, isLoading: isRequestingAiReview } =
     useRequestAiReviewMutation({
       onSuccess: (_packageRelease, aiReview) => {
@@ -90,13 +93,12 @@ export default function RepoPageContent({
 
   // Handle initial view selection and hash-based view changes
   useEffect(() => {
-    if (isCircuitJsonLoading) return
-    if (!packageInfo) return
+    if (!packageInfo || !arePackageFilesFetched) return
     const hash = window.location.hash.slice(1)
     const validViews = ["files", "3d", "pcb", "schematic", "bom"]
     const circuitDependentViews = ["3d", "pcb", "schematic", "bom"]
 
-    const availableViews = circuitJson
+    const availableViews = circuitJsonExists
       ? validViews
       : validViews.filter((view) => !circuitDependentViews.includes(view))
 
@@ -114,7 +116,7 @@ export default function RepoPageContent({
         window.location.hash = "files"
       }
     }
-  }, [packageInfo?.default_view, circuitJson, isCircuitJsonLoading])
+  }, [packageInfo?.default_view, circuitJsonExists])
 
   const importantFilePaths = packageFiles
     ?.filter((pf) => isPackageFileImportant(pf.file_path))
@@ -234,7 +236,7 @@ export default function RepoPageContent({
 
           {/* Sidebar - Hidden on mobile, shown on md and up */}
           <div className="hidden md:block md:w-[296px] flex-shrink-0">
-            <Sidebar
+            {/* <Sidebar
               packageInfo={packageInfo}
               isLoading={!packageInfo}
               onViewChange={(view) => {
@@ -243,7 +245,7 @@ export default function RepoPageContent({
                 window.location.hash = view
               }}
               onLicenseClick={handleLicenseFileRequest}
-            />
+            /> */}
           </div>
           {/* Releases section - Only visible on small screens */}
           <div className="block md:hidden w-full px-5">

--- a/src/components/ViewPackagePage/components/repo-page-content.tsx
+++ b/src/components/ViewPackagePage/components/repo-page-content.tsx
@@ -236,7 +236,7 @@ export default function RepoPageContent({
 
           {/* Sidebar - Hidden on mobile, shown on md and up */}
           <div className="hidden md:block md:w-[296px] flex-shrink-0">
-            {/* <Sidebar
+            <Sidebar
               packageInfo={packageInfo}
               isLoading={!packageInfo}
               onViewChange={(view) => {
@@ -245,7 +245,7 @@ export default function RepoPageContent({
                 window.location.hash = view
               }}
               onLicenseClick={handleLicenseFileRequest}
-            /> */}
+            />
           </div>
           {/* Releases section - Only visible on small screens */}
           <div className="block md:hidden w-full px-5">

--- a/src/hooks/use-current-package-id.ts
+++ b/src/hooks/use-current-package-id.ts
@@ -1,41 +1,16 @@
-import { useEffect, useState } from "react"
-import { useParams } from "wouter"
-import { usePackageById } from "./use-package-by-package-id"
-import { usePackageByName } from "./use-package-by-package-name"
-import { useUrlParams } from "./use-url-params"
+import { useCurrentPackageInfo } from "./use-current-package-info"
 
 export const useCurrentPackageId = (): {
   packageId: string | null
   isLoading: boolean
   error: (Error & { status: number }) | null
 } => {
-  const urlParams = useUrlParams()
-  const urlPackageId = urlParams.package_id
-  const wouter = useParams()
-  const [packageIdFromUrl, setPackageId] = useState<string | null>(urlPackageId)
-
-  useEffect(() => {
-    if (urlPackageId) {
-      setPackageId(urlPackageId)
-    }
-  }, [urlPackageId])
-
-  const packageName =
-    wouter.author && wouter.packageName
-      ? `${wouter.author}/${wouter.packageName}`
-      : null
-
-  const {
-    data: packageByName,
-    isLoading: isLoadingPackageByName,
-    error: errorPackageByName,
-  } = usePackageByName(packageName)
-
-  const packageId = packageIdFromUrl ?? packageByName?.package_id ?? null
+  const { packageInfo, isLoading, error } = useCurrentPackageInfo()
+  const packageId = packageInfo?.package_id ?? null
 
   return {
     packageId,
-    isLoading: isLoadingPackageByName,
-    error: errorPackageByName,
+    isLoading,
+    error,
   }
 }

--- a/src/hooks/use-current-package-info.ts
+++ b/src/hooks/use-current-package-info.ts
@@ -1,8 +1,32 @@
-import { useCurrentPackageId } from "./use-current-package-id"
+import { useParams } from "wouter"
 import { usePackageById } from "./use-package-by-package-id"
+import { usePackageByName } from "./use-package-by-package-name"
+import { useUrlParams } from "./use-url-params"
+import type { Package } from "fake-snippets-api/lib/db/schema"
 
-export const useCurrentPackageInfo = () => {
-  const { packageId } = useCurrentPackageId()
-  const { data: packageInfo, ...rest } = usePackageById(packageId)
-  return { packageInfo, ...rest }
+export const useCurrentPackageInfo = (): {
+  packageInfo: Package | undefined
+  isLoading: boolean
+  error: (Error & { status: number }) | null
+  refetch: () => Promise<unknown>
+} => {
+  const urlParams = useUrlParams()
+  const packageIdFromQuery = urlParams.package_id ?? null
+
+  const { author, packageName } = useParams()
+  const packageSlug = author && packageName ? `${author}/${packageName}` : null
+
+  const queryById = usePackageById(packageIdFromQuery)
+  const queryByName = usePackageByName(packageSlug)
+
+  const data = queryById.data ?? queryByName.data
+  const isLoading = queryById.isLoading || queryByName.isLoading
+  const error =
+    (queryById.error as (Error & { status: number }) | null) ??
+    (queryByName.error as (Error & { status: number }) | null) ??
+    null
+
+  const refetch = packageIdFromQuery ? queryById.refetch : queryByName.refetch
+
+  return { packageInfo: data, isLoading, error, refetch }
 }

--- a/src/pages/view-package.tsx
+++ b/src/pages/view-package.tsx
@@ -5,18 +5,19 @@ import { useLocation, useParams } from "wouter"
 import { Helmet } from "react-helmet-async"
 import { useEffect, useState } from "react"
 import NotFoundPage from "./404"
-import { useCurrentPackageId } from "@/hooks/use-current-package-id"
-import { usePackage } from "@/hooks/use-package"
+import { usePackageByName } from "@/hooks/use-package-by-package-name"
 
 export const ViewPackagePage = () => {
-  const {
-    packageId,
-    error: packageIdError,
-    isLoading: isLoadingPackageId,
-  } = useCurrentPackageId()
-  const { data: packageInfo } = usePackage(packageId)
   const { author, packageName } = useParams()
+  const packageNameFull = `${author}/${packageName}`
   const [, setLocation] = useLocation()
+
+  // Get package data directly by name - this will also cache by ID
+  const {
+    data: packageInfo,
+    error: packageError,
+    isLoading: isLoadingPackage,
+  } = usePackageByName(packageNameFull)
   const {
     data: packageRelease,
     error: packageReleaseError,
@@ -36,7 +37,7 @@ export const ViewPackagePage = () => {
   const { data: packageFiles, isFetched: arePackageFilesFetched } =
     usePackageFiles(packageRelease?.package_release_id)
 
-  if (!isLoadingPackageId && packageIdError) {
+  if (!isLoadingPackage && packageError) {
     return <NotFoundPage heading="Package Not Found" />
   }
 


### PR DESCRIPTION
Prevent duplicated `packages/get` requests.
Request `circuit.json` only when clicking download buttons. 



This pull request updates how circuit package downloads and starring functionality are handled in the UI, improving reliability and simplifying state management. The main changes include fetching `circuit.json` on demand for download actions, updating the download menu logic to support this, and refactoring the package starring logic to use data from the package info directly. Additionally, a new `is_starred` field was added to the package schema.

**Download logic improvements:**

* The `DownloadButtonAndMenu` component now fetches `circuit.json` on demand if not already available, using a new helper function and state to manage the fetched data. This ensures downloads work even when the JSON isn't loaded initially. [[1]](diffhunk://#diff-983c85bf419d954d1cf7664d2e76e0442607791f7c559b819c138df96e1018fbR25-R89) [[2]](diffhunk://#diff-983c85bf419d954d1cf7664d2e76e0442607791f7c559b819c138df96e1018fbL79-R123) [[3]](diffhunk://#diff-983c85bf419d954d1cf7664d2e76e0442607791f7c559b819c138df96e1018fbR136-R138) [[4]](diffhunk://#diff-983c85bf419d954d1cf7664d2e76e0442607791f7c559b819c138df96e1018fbR161-R163) [[5]](diffhunk://#diff-983c85bf419d954d1cf7664d2e76e0442607791f7c559b819c138df96e1018fbR185-R187) [[6]](diffhunk://#diff-983c85bf419d954d1cf7664d2e76e0442607791f7c559b819c138df96e1018fbL175-R220) [[7]](diffhunk://#diff-983c85bf419d954d1cf7664d2e76e0442607791f7c559b819c138df96e1018fbL188-R234) [[8]](diffhunk://#diff-983c85bf419d954d1cf7664d2e76e0442607791f7c559b819c138df96e1018fbL200-R247) [[9]](diffhunk://#diff-983c85bf419d954d1cf7664d2e76e0442607791f7c559b819c138df96e1018fbL212-R260) [[10]](diffhunk://#diff-983c85bf419d954d1cf7664d2e76e0442607791f7c559b819c138df96e1018fbL224-R274) [[11]](diffhunk://#diff-983c85bf419d954d1cf7664d2e76e0442607791f7c559b819c138df96e1018fbL236-R287) [[12]](diffhunk://#diff-983c85bf419d954d1cf7664d2e76e0442607791f7c559b819c138df96e1018fbL248-R300) [[13]](diffhunk://#diff-983c85bf419d954d1cf7664d2e76e0442607791f7c559b819c138df96e1018fbL260-R313) [[14]](diffhunk://#diff-983c85bf419d954d1cf7664d2e76e0442607791f7c559b819c138df96e1018fbL274-R326) [[15]](diffhunk://#diff-983c85bf419d954d1cf7664d2e76e0442607791f7c559b819c138df96e1018fbR335-R337) [[16]](diffhunk://#diff-983c85bf419d954d1cf7664d2e76e0442607791f7c559b819c138df96e1018fbL302-R357) [[17]](diffhunk://#diff-983c85bf419d954d1cf7664d2e76e0442607791f7c559b819c138df96e1018fbL319-R374) [[18]](diffhunk://#diff-983c85bf419d954d1cf7664d2e76e0442607791f7c559b819c138df96e1018fbL336-R391) [[19]](diffhunk://#diff-983c85bf419d954d1cf7664d2e76e0442607791f7c559b819c138df96e1018fbL353-R408) [[20]](diffhunk://#diff-983c85bf419d954d1cf7664d2e76e0442607791f7c559b819c138df96e1018fbL373-R426)

* The `MainContentHeader` component now passes a `hasCircuitJson` prop instead of the actual JSON, improving efficiency and allowing the download menu to fetch the file only when needed. [[1]](diffhunk://#diff-b4f206544fe64b7d38d042807f1873046800f5112e83e306d544f5174cda62c8L73-R75) [[2]](diffhunk://#diff-b4f206544fe64b7d38d042807f1873046800f5112e83e306d544f5174cda62c8L87-R89)

**Package starring logic refactor:**

* The package starring UI now uses the `is_starred` and `star_count` fields from the package info directly, removing the need for a separate hook and simplifying the state logic for the star button. [[1]](diffhunk://#diff-f4604e56dd33787cf4713347d0112f21d31948d0262e2ab2ed61ca76efef9cb8L15-R15) [[2]](diffhunk://#diff-f4604e56dd33787cf4713347d0112f21d31948d0262e2ab2ed61ca76efef9cb8L48-R45) [[3]](diffhunk://#diff-f4604e56dd33787cf4713347d0112f21d31948d0262e2ab2ed61ca76efef9cb8L60-R56) [[4]](diffhunk://#diff-f4604e56dd33787cf4713347d0112f21d31948d0262e2ab2ed61ca76efef9cb8L72-R68) [[5]](diffhunk://#diff-f4604e56dd33787cf4713347d0112f21d31948d0262e2ab2ed61ca76efef9cb8L158-R161)

**Schema changes:**

* Added an optional `is_starred` boolean property to the `packageSchema`, allowing the backend to indicate if the current user has starred the package.