### PR TITLE
fix(editor): prevent "No files provided" error in RunFrame

### DIFF
--- a/src/components/package-port/CodeAndPreview.tsx
+++ b/src/components/package-port/CodeAndPreview.tsx
@@ -153,10 +153,7 @@ export function CodeAndPreview({ pkg, projectUrl }: Props) {
     })
   }
 
-  const finalfsMap = useMemo(
-    () => (Object.keys(fsMap).length > 0 ? fsMap : {}),
-    [fsMap],
-  )
+  const finalfsMap = useMemo(() => fsMap, [fsMap])
   return (
     <div className="flex flex-col min-h-[50vh]">
       <EditorNav
@@ -222,23 +219,37 @@ export function CodeAndPreview({ pkg, projectUrl }: Props) {
             !state.showPreview && "hidden",
           )}
         >
-          <SuspenseRunFrame
-            showRunButton
-            forceLatestEvalVersion
-            onRenderStarted={() =>
-              setState((prev) => ({ ...prev, lastRunCode: currentFileCode }))
-            }
-            onRenderFinished={({ circuitJson }) => {
-              setState((prev) => ({ ...prev, circuitJson }))
-              toastManualEditConflicts(circuitJson, toast)
-            }}
-            mainComponentPath={mainComponentPath}
-            onEditEvent={(event) => {
-              handleEditEvent(event)
-            }}
-            fsMap={finalfsMap}
-            projectUrl={projectUrl}
-          />
+          {Object.keys(finalfsMap).length > 0 && (
+            <SuspenseRunFrame
+              showRunButton
+              forceLatestEvalVersion
+              onRenderStarted={() =>
+                setState((prev) => ({ ...prev, lastRunCode: currentFileCode }))
+              }
+              onRenderFinished={({ circuitJson }) => {
+                setState((prev) => ({ ...prev, circuitJson }))
+                toastManualEditConflicts(circuitJson, toast)
+              }}
+              mainComponentPath={mainComponentPath}
+              onEditEvent={(event) => {
+                handleEditEvent(event)
+              }}
+              fsMap={finalfsMap}
+              projectUrl={projectUrl}
+            />
+          )}
+          {Object.keys(finalfsMap).length === 0 && (
+            <div className="flex justify-center items-center h-full">
+              <div className="w-48">
+                <div className="loading">
+                  <div className="loading-bar"></div>
+                </div>
+                <p className="text-center mt-2 text-sm text-gray-600">
+                  Loading files...
+                </p>
+              </div>
+            </div>
+          )}
         </div>
       </div>
       <NewPackageSaveDialog initialIsPrivate={false} onSave={savePackage} />


### PR DESCRIPTION
## Summary
- Fix "Execution Error: No files provided" error in `/editor` route
- Conditionally render SuspenseRunFrame only when files are loaded
- Show loading indicator during file loading process

## Problem
The `/editor` route was throwing "Execution Error: No files provided" because the `SuspenseRunFrame` component was being rendered with an empty `fsMap` while package files were still loading from the `package_files/get` API.

## Solution
- Modified `CodeAndPreview.tsx` to conditionally render `SuspenseRunFrame` only when `Object.keys(finalfsMap).length > 0`
- Show a loading indicator with "Loading files..." message while files are being fetched
- Simplified `finalfsMap` logic to directly use `fsMap` instead of returning empty objects

## Test plan
- [x] TypeScript checks pass
- [x] Linting passes
- [x] Development server starts without errors
- [ ] Test `/editor` route with package files to verify no "No files provided" error
- [ ] Verify loading indicator shows during file loading
- [ ] Confirm RunFrame renders correctly once files are loaded

🤖 Generated with [Claude Code](https://claude.ai/code)