### PR TITLE
use GET with query params for package_files/get

### DIFF
--- a/bun-tests/fake-snippets-api/routes/package_files/create.test.ts
+++ b/bun-tests/fake-snippets-api/routes/package_files/create.test.ts
@@ -40,8 +40,8 @@ test("create package file with content_text", async () => {
   expect(responseBody.package_file.file_path).toBe(filePath)
 
   // Verify the file can be retrieved using the get endpoint
-  const getResponse = await axios.post("/api/package_files/get", {
-    package_file_id: responseBody.package_file.package_file_id,
+  const getResponse = await axios.get("/api/package_files/get", {
+    params: { package_file_id: responseBody.package_file.package_file_id },
   })
   expect(getResponse.status).toBe(200)
   expect(getResponse.data.package_file.file_path).toBe(filePath)
@@ -86,8 +86,8 @@ test("create package file with content_base64", async () => {
   // Content is no longer returned from the create endpoint
 
   // Verify the file can be retrieved using the get endpoint with package_name_with_version
-  const getResponse = await axios.post("/api/package_files/get", {
-    package_file_id: responseBody.package_file.package_file_id,
+  const getResponse = await axios.get("/api/package_files/get", {
+    params: { package_file_id: responseBody.package_file.package_file_id },
   })
   expect(getResponse.status).toBe(200)
   // content_text is no longer returned by the get endpoint

--- a/bun-tests/fake-snippets-api/routes/package_files/create_or_update.test.ts
+++ b/bun-tests/fake-snippets-api/routes/package_files/create_or_update.test.ts
@@ -40,8 +40,8 @@ test("create new package file with content_text", async () => {
   expect(responseBody.package_file.file_path).toBe(filePath)
   expect(responseBody.package_file.content_text).toBe(fileContent)
 
-  const getResponse = await axios.post("/api/package_files/get", {
-    package_file_id: responseBody.package_file.package_file_id,
+  const getResponse = await axios.get("/api/package_files/get", {
+    params: { package_file_id: responseBody.package_file.package_file_id },
   })
   expect(getResponse.status).toBe(200)
   expect(getResponse.data.package_file.file_path).toBe(filePath)
@@ -101,8 +101,8 @@ test("update existing package file with content_text", async () => {
   expect(responseBody.package_file.file_path).toBe(filePath)
   expect(responseBody.package_file.content_text).toBe(updatedContent)
 
-  const getResponse = await axios.post("/api/package_files/get", {
-    package_file_id: responseBody.package_file.package_file_id,
+  const getResponse = await axios.get("/api/package_files/get", {
+    params: { package_file_id: responseBody.package_file.package_file_id },
   })
   expect(getResponse.status).toBe(200)
   expect(getResponse.data.package_file.file_path).toBe(filePath)
@@ -145,8 +145,8 @@ test("create package file with content_base64", async () => {
   expect(responseBody.package_file.file_path).toBe(filePath)
   expect(responseBody.package_file.content_text).toBe(fileContent)
 
-  const getResponse = await axios.post("/api/package_files/get", {
-    package_file_id: responseBody.package_file.package_file_id,
+  const getResponse = await axios.get("/api/package_files/get", {
+    params: { package_file_id: responseBody.package_file.package_file_id },
   })
   expect(getResponse.status).toBe(200)
   expect(getResponse.data.package_file.file_path).toBe(filePath)
@@ -475,8 +475,8 @@ test.skip("update package file with content_base64", async () => {
   )
   expect(responseBody.package_file.content_text).toBe(updatedContent)
 
-  const getResponse = await axios.post("/api/package_files/get", {
-    package_file_id: responseBody.package_file.package_file_id,
+  const getResponse = await axios.get("/api/package_files/get", {
+    params: { package_file_id: responseBody.package_file.package_file_id },
   })
   expect(getResponse.status).toBe(200)
   expect(getResponse.data.package_file.file_path).toBe(filePath)

--- a/bun-tests/fake-snippets-api/routes/package_files/delete.test.ts
+++ b/bun-tests/fake-snippets-api/routes/package_files/delete.test.ts
@@ -37,8 +37,8 @@ test("delete package file using package_release_id", async () => {
   expect(deleteResponse.data.ok).toBe(true)
 
   try {
-    await axios.post("/api/package_files/get", {
-      package_file_id: createdFile.package_file_id,
+    await axios.get("/api/package_files/get", {
+      params: { package_file_id: createdFile.package_file_id },
     })
     throw new Error("Expected request to fail")
   } catch (error: any) {
@@ -84,8 +84,8 @@ test("delete package file using package_name_with_version", async () => {
   expect(deleteResponse.data.ok).toBe(true)
 
   try {
-    await axios.post("/api/package_files/get", {
-      package_file_id: createdFile.package_file_id,
+    await axios.get("/api/package_files/get", {
+      params: { package_file_id: createdFile.package_file_id },
     })
     throw new Error("Expected request to fail")
   } catch (error: any) {

--- a/bun-tests/fake-snippets-api/routes/package_files/get.test.ts
+++ b/bun-tests/fake-snippets-api/routes/package_files/get.test.ts
@@ -2,7 +2,7 @@ import { getTestServer } from "bun-tests/fake-snippets-api/fixtures/get-test-ser
 import { expect, test } from "bun:test"
 import { packageFileSchema } from "fake-snippets-api/lib/db/schema"
 
-test("POST /api/package_files/get - should return package file by package_file_id", async () => {
+test("GET /api/package_files/get - should return package file by package_file_id", async () => {
   const { axios, db } = await getTestServer()
 
   // First create a package
@@ -34,8 +34,8 @@ test("POST /api/package_files/get - should return package file by package_file_i
   const addedFile = db.addPackageFile(packageFile)
 
   // Get the file by package_file_id
-  const getResponse = await axios.post("/api/package_files/get", {
-    package_file_id: addedFile.package_file_id,
+  const getResponse = await axios.get("/api/package_files/get", {
+    params: { package_file_id: addedFile.package_file_id },
   })
 
   expect(getResponse.status).toBe(200)
@@ -44,7 +44,7 @@ test("POST /api/package_files/get - should return package file by package_file_i
   expect(responseBody.package_file).toEqual(packageFileSchema.parse(addedFile))
 })
 
-test("POST /api/package_files/get - should return package file by package_release_id and file_path", async () => {
+test("GET /api/package_files/get - should return package file by package_release_id and file_path", async () => {
   const { axios, db } = await getTestServer()
 
   // First create a package
@@ -77,9 +77,11 @@ test("POST /api/package_files/get - should return package file by package_releas
   db.addPackageFile(packageFile)
 
   // Get the file by package_release_id and file_path
-  const getResponse = await axios.post("/api/package_files/get", {
-    package_release_id: createdRelease.package_release_id,
-    file_path: filePath,
+  const getResponse = await axios.get("/api/package_files/get", {
+    params: {
+      package_release_id: createdRelease.package_release_id,
+      file_path: filePath,
+    },
   })
 
   expect(getResponse.status).toBe(200)
@@ -91,7 +93,7 @@ test("POST /api/package_files/get - should return package file by package_releas
   )
 })
 
-test("POST /api/package_files/get - should return package file by package_name_with_version and file_path", async () => {
+test("GET /api/package_files/get - should return package file by package_name_with_version and file_path", async () => {
   const { axios, db } = await getTestServer()
 
   // First create a package
@@ -126,9 +128,11 @@ test("POST /api/package_files/get - should return package file by package_name_w
   db.addPackageFile(packageFile)
 
   // Get the file by package_name_with_version and file_path
-  const getResponse = await axios.post("/api/package_files/get", {
-    package_name_with_version: `${packageName}@${version}`,
-    file_path: filePath,
+  const getResponse = await axios.get("/api/package_files/get", {
+    params: {
+      package_name_with_version: `${packageName}@${version}`,
+      file_path: filePath,
+    },
   })
 
   expect(getResponse.status).toBe(200)
@@ -140,12 +144,14 @@ test("POST /api/package_files/get - should return package file by package_name_w
   )
 })
 
-test("POST /api/package_files/get - should return 404 if package file not found", async () => {
+test("GET /api/package_files/get - should return 404 if package file not found", async () => {
   const { axios } = await getTestServer()
 
   try {
-    await axios.post("/api/package_files/get", {
-      package_file_id: "123e4567-e89b-12d3-a456-426614174000", // valid UUID format
+    await axios.get("/api/package_files/get", {
+      params: {
+        package_file_id: "123e4567-e89b-12d3-a456-426614174000", // valid UUID format
+      },
     })
     throw new Error("Expected request to fail")
   } catch (error: any) {
@@ -154,14 +160,16 @@ test("POST /api/package_files/get - should return 404 if package file not found"
   }
 })
 
-test("POST /api/package_files/get - should return 404 if package not found with package_name", async () => {
+test("GET /api/package_files/get - should return 404 if package not found with package_name", async () => {
   const { axios } = await getTestServer()
 
   try {
-    await axios.post("/api/package_files/get", {
-      package_name: "non-existent-package",
-      version: "1.0.0",
-      file_path: "/index.js",
+    await axios.get("/api/package_files/get", {
+      params: {
+        package_name: "non-existent-package",
+        version: "1.0.0",
+        file_path: "/index.js",
+      },
     })
     throw new Error("Expected request to fail")
   } catch (error: any) {
@@ -170,7 +178,7 @@ test("POST /api/package_files/get - should return 404 if package not found with 
   }
 })
 
-test("POST /api/package_files/get - should return file using package_id and version", async () => {
+test("GET /api/package_files/get - should return file using package_id and version", async () => {
   const { axios, db } = await getTestServer()
 
   // First create a package
@@ -204,10 +212,12 @@ test("POST /api/package_files/get - should return file using package_id and vers
   db.addPackageFile(packageFile)
 
   // Get the file by package_id and version
-  const getResponse = await axios.post("/api/package_files/get", {
-    package_id: createdPackage.package_id,
-    version,
-    file_path: filePath,
+  const getResponse = await axios.get("/api/package_files/get", {
+    params: {
+      package_id: createdPackage.package_id,
+      version,
+      file_path: filePath,
+    },
   })
 
   expect(getResponse.status).toBe(200)

--- a/fake-snippets-api/lib/db/autoload-dev-packages.ts
+++ b/fake-snippets-api/lib/db/autoload-dev-packages.ts
@@ -60,9 +60,11 @@ const fetchPackageFromRegistry = async (owner: string, name: string) => {
     // Fetch content_text for each file individually
     for (const file of filesData.package_files) {
       try {
-        const fileResponse = await registryApi.post("/package_files/get", {
-          package_release_id: releaseData.package_release.package_release_id,
-          file_path: file.file_path,
+        const fileResponse = await registryApi.get("/package_files/get", {
+          params: {
+            package_release_id: releaseData.package_release.package_release_id,
+            file_path: file.file_path,
+          },
         })
         file.content_text = fileResponse.data.package_file.content_text
       } catch (e) {

--- a/fake-snippets-api/routes/api/package_files/get.ts
+++ b/fake-snippets-api/routes/api/package_files/get.ts
@@ -4,9 +4,9 @@ import * as ZT from "fake-snippets-api/lib/db/schema"
 import { getPackageFileIdFromFileDescriptor } from "fake-snippets-api/lib/package_file/get-package-file-id-from-file-descriptor"
 
 const routeSpec = {
-  methods: ["POST"],
+  methods: ["GET"],
   auth: "none",
-  jsonBody: z
+  queryParams: z
     .object({
       package_file_id: z.string(),
     })
@@ -45,10 +45,7 @@ const routeSpec = {
 } as const
 
 export default withRouteSpec(routeSpec)(async (req, ctx) => {
-  const packageFileId = await getPackageFileIdFromFileDescriptor(
-    req.jsonBody,
-    ctx,
-  )
+  const packageFileId = await getPackageFileIdFromFileDescriptor(req.query, ctx)
 
   const packageFile = ctx.db.packageFiles.find(
     (pf: ZT.PackageFile) => pf.package_file_id === packageFileId,

--- a/src/components/DownloadButtonAndMenu.tsx
+++ b/src/components/DownloadButtonAndMenu.tsx
@@ -65,9 +65,8 @@ export function DownloadButtonAndMenu({
       return fetchedCircuitJson
     setIsFetchingCircuitJson(true)
     try {
-      const { data } = await axios.post("/package_files/get", {
-        package_id: packageId,
-        file_path: "dist/circuit.json",
+      const { data } = await axios.get("/package_files/get", {
+        params: { package_id: packageId, file_path: "dist/circuit.json" },
       })
       const content = data?.package_file?.content_text
       if (!content) throw new Error("Circuit JSON not found")

--- a/src/hooks/use-download-zip.ts
+++ b/src/hooks/use-download-zip.ts
@@ -20,8 +20,8 @@ export const useDownloadZip = () => {
 
       for (const file of visibleFiles) {
         try {
-          const response = await axios.post("/package_files/get", {
-            package_file_id: file.package_file_id,
+          const response = await axios.get("/package_files/get", {
+            params: { package_file_id: file.package_file_id },
           })
 
           const content = response.data.package_file?.content_text || ""

--- a/src/hooks/use-package-files.ts
+++ b/src/hooks/use-package-files.ts
@@ -36,7 +36,9 @@ export const usePackageFile = (
     async () => {
       if (!query) return
 
-      const { data } = await axios.post("/package_files/get", query)
+      const { data } = await axios.get("/package_files/get", {
+        params: query,
+      })
 
       if (!data.package_file) {
         throw new Error("Package file not found")

--- a/src/hooks/useOptimizedPackageFilesLoader.ts
+++ b/src/hooks/useOptimizedPackageFilesLoader.ts
@@ -76,8 +76,8 @@ export function useOptimizedPackageFilesLoader(
     queryFn: async () => {
       if (!priorityFileData) return null
 
-      const response = await axios.post(`/package_files/get`, {
-        package_file_id: priorityFileData.package_file_id,
+      const response = await axios.get(`/package_files/get`, {
+        params: { package_file_id: priorityFileData.package_file_id },
       })
       const content = response.data.package_file?.content_text
       const file = { path: priorityFileData.file_path, content: content ?? "" }
@@ -103,8 +103,8 @@ export function useOptimizedPackageFilesLoader(
       ?.map((file) => ({
         queryKey: ["packageFile", file.package_file_id],
         queryFn: async () => {
-          const response = await axios.post(`/package_files/get`, {
-            package_file_id: file.package_file_id,
+          const response = await axios.get(`/package_files/get`, {
+            params: { package_file_id: file.package_file_id },
           })
           const content = response.data.package_file?.content_text
           const fileData = { path: file.file_path, content: content ?? "" }

--- a/src/hooks/usePackageFilesLoader.ts
+++ b/src/hooks/usePackageFilesLoader.ts
@@ -30,8 +30,8 @@ export function usePackageFilesLoader(pkg?: Package) {
           }
         }
 
-        const response = await axios.post(`/package_files/get`, {
-          package_file_id: file.package_file_id,
+        const response = await axios.get(`/package_files/get`, {
+          params: { package_file_id: file.package_file_id },
         })
         const content = response.data.package_file?.content_text
         return { path: file.file_path, content: content ?? "" }


### PR DESCRIPTION
## Summary
- change package_files/get endpoint to GET with query parameters
- update client hooks and scripts to call package_files/get via GET
- align tests with new GET behavior

## Testing
- `bun test bun-tests/fake-snippets-api/routes/package_files/get.test.ts bun-tests/fake-snippets-api/routes/package_files/create_or_update.test.ts bun-tests/fake-snippets-api/routes/package_files/create.test.ts bun-tests/fake-snippets-api/routes/package_files/delete.test.ts | tail -n 10`


------
https://chatgpt.com/codex/tasks/task_b_68a560654fb48331babf7aa42bc0272e