### PR TITLE
fix: eliminate duplicate package release API requests

### DIFF
--- a/src/components/ViewPackagePage/components/sidebar-about-section.tsx
+++ b/src/components/ViewPackagePage/components/sidebar-about-section.tsx
@@ -2,7 +2,7 @@ import { Badge } from "@/components/ui/badge"
 import { GitFork, Star, Settings, LinkIcon, Github, Plus } from "lucide-react"
 import { Skeleton } from "@/components/ui/skeleton"
 import { useCurrentPackageInfo } from "@/hooks/use-current-package-info"
-import { usePackageReleaseById } from "@/hooks/use-package-release"
+import { useCurrentPackageRelease } from "@/hooks/use-current-package-release"
 import { useGlobalStore } from "@/hooks/use-global-store"
 import { Button } from "@/components/ui/button"
 import { useEditPackageDetailsDialog } from "@/components/dialogs/edit-package-details-dialog"
@@ -21,9 +21,9 @@ export default function SidebarAboutSection({
   onLicenseClick,
 }: SidebarAboutSectionProps = {}) {
   const { packageInfo, refetch: refetchPackageInfo } = useCurrentPackageInfo()
-  const { data: packageRelease } = usePackageReleaseById(
-    packageInfo?.latest_package_release_id,
-  )
+  const { packageRelease } = useCurrentPackageRelease({
+    include_ai_review: true,
+  })
 
   const { data: licenseFileMeta, refetch: refetchLicense } = usePackageFile({
     package_release_id: packageInfo?.latest_package_release_id ?? "",

--- a/src/components/ViewPackagePage/components/sidebar-releases-section.tsx
+++ b/src/components/ViewPackagePage/components/sidebar-releases-section.tsx
@@ -1,7 +1,7 @@
 import { Tag, Clock } from "lucide-react"
 import { Skeleton } from "@/components/ui/skeleton"
 import { useCurrentPackageInfo } from "@/hooks/use-current-package-info"
-import { usePackageReleaseById } from "@/hooks/use-package-release"
+import { useCurrentPackageRelease } from "@/hooks/use-current-package-release"
 import { timeAgo } from "@/lib/utils/timeAgo"
 import { BuildStatus, BuildStep } from "./build-status"
 import type { PackageRelease } from "fake-snippets-api/lib/db/schema"
@@ -39,9 +39,9 @@ function getCircuitJsonStatus(pr?: PackageRelease | null): BuildStep["status"] {
 
 export default function SidebarReleasesSection() {
   const { packageInfo } = useCurrentPackageInfo()
-  const { data: packageRelease } = usePackageReleaseById(
-    packageInfo?.latest_package_release_id,
-  )
+  const { packageRelease } = useCurrentPackageRelease({
+    include_ai_review: true,
+  })
   const { data: latestBuild } = usePackageBuild(
     packageRelease?.latest_package_build_id ?? null,
   )

--- a/src/hooks/use-current-package-release.ts
+++ b/src/hooks/use-current-package-release.ts
@@ -21,12 +21,13 @@ export const useCurrentPackageRelease = (options?: {
 
   let query: Parameters<typeof usePackageRelease>[0] | null = null
 
-  if (releaseId) {
+  // Prioritize package_name + is_latest for better caching consistency
+  if (author && packageName && !version && !releaseId) {
+    query = { package_name: `${author}/${packageName}`, is_latest: true }
+  } else if (releaseId) {
     query = { package_release_id: releaseId }
   } else if (version && author && packageName) {
     query = { package_name_with_version: `${author}/${packageName}@${version}` }
-  } else if (author && packageName) {
-    query = { package_name: `${author}/${packageName}`, is_latest: true }
   } else if (packageId) {
     query = { package_id: packageId, is_latest: true }
   }

--- a/src/pages/view-package.tsx
+++ b/src/pages/view-package.tsx
@@ -1,6 +1,6 @@
 import RepoPageContent from "@/components/ViewPackagePage/components/repo-page-content"
 import { usePackageFiles } from "@/hooks/use-package-files"
-import { usePackageRelease } from "@/hooks/use-package-release"
+import { useCurrentPackageRelease } from "@/hooks/use-current-package-release"
 import { useLocation, useParams } from "wouter"
 import { Helmet } from "react-helmet-async"
 import { useEffect, useState } from "react"
@@ -19,20 +19,14 @@ export const ViewPackagePage = () => {
     isLoading: isLoadingPackage,
   } = usePackageByName(packageNameFull)
   const {
-    data: packageRelease,
+    packageRelease,
     error: packageReleaseError,
     isLoading: isLoadingPackageRelease,
-  } = usePackageRelease(
-    {
-      is_latest: true,
-      package_name: `${author}/${packageName}`,
-      include_ai_review: true,
-    },
-    {
-      refetchInterval: (data) =>
-        data?.ai_review_requested && !data.ai_review_text ? 2000 : false,
-    },
-  )
+  } = useCurrentPackageRelease({
+    include_ai_review: true,
+    refetchInterval: (data) =>
+      data?.ai_review_requested && !data.ai_review_text ? 2000 : false,
+  })
 
   const { data: packageFiles, isFetched: arePackageFilesFetched } =
     usePackageFiles(packageRelease?.package_release_id)


### PR DESCRIPTION
  ## Problem
  Multiple components were making duplicate API requests for the same package release data with different query parameters, causing unnecessary network requests:
  - `view-package.tsx`: `include_ai_review: true`
  - `sidebar-releases-section.tsx`: `include_ai_review: undefined`
  - `sidebar-about-section.tsx`: `include_ai_review: undefined`

  This resulted in duplicate requests like:
  GET /api/package_releases/get?include_ai_review=true
  GET /api/package_releases/get?include_ai_review=undefined

  ## Root Cause
  React Query treats different parameters as separate cache keys, so even though these components were fetching the same package release, React Query couldn't deduplicate the requests due to different `include_ai_review` values.

  ## Solution
  Refactored all components to use a shared `useCurrentPackageRelease` hook with consistent parameters:

  ### Changes Made
  1. **Updated `useCurrentPackageRelease` hook**: Prioritized `package_name` + `is_latest` query pattern for better cache consistency
  2. **Standardized all components**: Now use `useCurrentPackageRelease({ include_ai_review: true })` instead of direct `usePackageRelease` calls
  3. **Centralized logic**: All package release fetching logic now goes through one shared hook

  ### Code Changes
  - **`view-package.tsx`**: Switched to `useCurrentPackageRelease`
  - **`sidebar-releases-section.tsx`**: Replaced direct `usePackageRelease` call
  - **`sidebar-about-section.tsx`**: Replaced direct `usePackageRelease` call

  ## Benefits
  - ✅ **Single API request**: Only one network request instead of multiple duplicates
  - ✅ **Perfect React Query caching**: All components share the same cache entry
  - ✅ **Better performance**: Reduced server load and faster UI updates
  - ✅ **Maintainable code**: Centralized package release logic in one hook
  - ✅ **Consistent pattern**: Follows same approach as `useCurrentPackageInfo`
