### PR TITLE
refactor: use GET for package files list

### DIFF
--- a/api/generated-index.js
+++ b/api/generated-index.js
@@ -240,8 +240,8 @@ async function handleCustomPackageHtml(req, res) {
     if (packageRelease?.package_release_id) {
       try {
         const filesResponse = await ky
-          .post(`${REGISTRY_URL}/package_files/list`, {
-            json: {
+          .get(`${REGISTRY_URL}/package_files/list`, {
+            searchParams: {
               package_release_id: packageRelease.package_release_id,
             },
           })

--- a/bun-tests/fake-snippets-api/routes/package_files/create.test.ts
+++ b/bun-tests/fake-snippets-api/routes/package_files/create.test.ts
@@ -131,8 +131,10 @@ test("create package file using package_name_with_version", async () => {
   // Content is no longer returned from the create endpoint
 
   // Verify the file can be retrieved using the list endpoint
-  const listResponse = await axios.post("/api/package_files/list", {
-    package_name_with_version: `${packageName}@${version}`,
+  const listResponse = await axios.get("/api/package_files/list", {
+    params: {
+      package_name_with_version: `${packageName}@${version}`,
+    },
   })
   expect(listResponse.status).toBe(200)
   expect(listResponse.data.ok).toBe(true)

--- a/bun-tests/fake-snippets-api/routes/package_files/create_or_update.test.ts
+++ b/bun-tests/fake-snippets-api/routes/package_files/create_or_update.test.ts
@@ -189,8 +189,10 @@ test("create package file using package_name_with_version", async () => {
   expect(responseBody.package_file.file_path).toBe(filePath)
   expect(responseBody.package_file.content_text).toBe(fileContent)
 
-  const listResponse = await axios.post("/api/package_files/list", {
-    package_name_with_version: `${packageName}@${version}`,
+  const listResponse = await axios.get("/api/package_files/list", {
+    params: {
+      package_name_with_version: `${packageName}@${version}`,
+    },
   })
   expect(listResponse.status).toBe(200)
   expect(listResponse.data.ok).toBe(true)

--- a/bun-tests/fake-snippets-api/routes/package_files/list.test.ts
+++ b/bun-tests/fake-snippets-api/routes/package_files/list.test.ts
@@ -51,8 +51,8 @@ test("list package files by package_release_id", async () => {
   }
 
   // List files by package_release_id
-  const listResponse = await axios.post("/api/package_files/list", {
-    package_release_id: createdRelease.package_release_id,
+  const listResponse = await axios.get("/api/package_files/list", {
+    params: { package_release_id: createdRelease.package_release_id },
   })
 
   expect(listResponse.status).toBe(200)
@@ -114,9 +114,11 @@ test("list package files by package_name with latest version", async () => {
   }
 
   // List files by package_name with use_latest_version
-  const listResponse = await axios.post("/api/package_files/list", {
-    package_name: packageName.replace(/^@/, ""),
-    use_latest_version: true,
+  const listResponse = await axios.get("/api/package_files/list", {
+    params: {
+      package_name: packageName.replace(/^@/, ""),
+      use_latest_version: true,
+    },
   })
 
   expect(listResponse.status).toBe(200)
@@ -163,8 +165,10 @@ test("list package files by package_name_with_version", async () => {
   }
 
   // List files by package_name_with_version
-  const listResponse = await axios.post("/api/package_files/list", {
-    package_name_with_version: `${packageName}@${version}`,
+  const listResponse = await axios.get("/api/package_files/list", {
+    params: {
+      package_name_with_version: `${packageName}@${version}`,
+    },
   })
 
   expect(listResponse.status).toBe(200)
@@ -178,8 +182,10 @@ test("list package files - 404 for non-existent package release", async () => {
   const { axios } = await getTestServer()
 
   try {
-    await axios.post("/api/package_files/list", {
-      package_release_id: "00000000-0000-0000-0000-000000000000",
+    await axios.get("/api/package_files/list", {
+      params: {
+        package_release_id: "00000000-0000-0000-0000-000000000000",
+      },
     })
     throw new Error("Expected request to fail")
   } catch (error: any) {
@@ -192,9 +198,11 @@ test("list package files - 404 for non-existent package", async () => {
   const { axios } = await getTestServer()
 
   try {
-    await axios.post("/api/package_files/list", {
-      package_name: "non-existent-package",
-      use_latest_version: true,
+    await axios.get("/api/package_files/list", {
+      params: {
+        package_name: "non-existent-package",
+        use_latest_version: true,
+      },
     })
     throw new Error("Expected request to fail")
   } catch (error: any) {

--- a/bun-tests/fake-snippets-api/routes/packages/fork.test.ts
+++ b/bun-tests/fake-snippets-api/routes/packages/fork.test.ts
@@ -41,13 +41,12 @@ test("POST /packages/fork - successful fork using package_id", async () => {
   expect(forkedPackage.is_private).toBe(false)
 
   // List files from the forked package
-  const packageFilesResponse = await jane_axios.post(
-    "/api/package_files/list",
-    {
+  const packageFilesResponse = await jane_axios.get("/api/package_files/list", {
+    params: {
       package_name: forkedPackage.name,
       use_latest_version: true,
     },
-  )
+  })
 
   const package_files = packageFilesResponse.data.package_files
 

--- a/bun-tests/fake-snippets-api/routes/packages/images.test.ts
+++ b/bun-tests/fake-snippets-api/routes/packages/images.test.ts
@@ -41,8 +41,10 @@ test("get schematic svg of a package", async () => {
   // create fsMap by getting all the files in the package with the file_path and content_text
   const fsMap = new Map<string, string>()
   // list all the files in the package
-  const files = await axios.post("/api/package_files/list", {
-    package_release_id: pkg_release.data.package_release.package_release_id,
+  const files = await axios.get("/api/package_files/list", {
+    params: {
+      package_release_id: pkg_release.data.package_release.package_release_id,
+    },
   })
   for (const file of files.data.package_files) {
     fsMap.set(file.file_path, file.content_text)

--- a/fake-snippets-api/lib/db/autoload-dev-packages.ts
+++ b/fake-snippets-api/lib/db/autoload-dev-packages.ts
@@ -52,8 +52,10 @@ const fetchPackageFromRegistry = async (owner: string, name: string) => {
 
   let filesData
   try {
-    const response = await registryApi.post("/package_files/list", {
-      package_release_id: releaseData.package_release.package_release_id,
+    const response = await registryApi.get("/package_files/list", {
+      params: {
+        package_release_id: releaseData.package_release.package_release_id,
+      },
     })
     filesData = response.data
 

--- a/fake-snippets-api/routes/api/package_files/list.ts
+++ b/fake-snippets-api/routes/api/package_files/list.ts
@@ -4,16 +4,19 @@ import * as ZT from "fake-snippets-api/lib/db/schema"
 import { findPackageReleaseId } from "fake-snippets-api/lib/package_release/find-package-release-id"
 
 const routeSpec = {
-  methods: ["POST"],
+  methods: ["GET"],
   auth: "none",
-  jsonBody: z
+  queryParams: z
     .object({
       package_release_id: z.string(),
     })
     .or(
       z.object({
         package_name: z.string(),
-        use_latest_version: z.literal(true),
+        use_latest_version: z.preprocess(
+          (val) => (val === "true" ? true : val),
+          z.literal(true),
+        ),
       }),
     )
     .or(
@@ -28,7 +31,7 @@ const routeSpec = {
 } as const
 
 export default withRouteSpec(routeSpec)(async (req, ctx) => {
-  const packageReleaseId = await findPackageReleaseId(req.jsonBody, ctx)
+  const packageReleaseId = await findPackageReleaseId(req.query, ctx)
 
   if (!packageReleaseId) {
     return ctx.error(404, {

--- a/src/components/dialogs/edit-package-details-dialog.tsx
+++ b/src/components/dialogs/edit-package-details-dialog.tsx
@@ -133,8 +133,10 @@ export const EditPackageDetailsDialog = ({
       if (response.status !== 200)
         throw new Error("Failed to update package details")
 
-      const filesRes = await axios.post("/package_files/list", {
-        package_name_with_version: `${packageAuthor}/${formData.unscopedPackageName}`,
+      const filesRes = await axios.get("/package_files/list", {
+        params: {
+          package_name_with_version: `${packageAuthor}/${formData.unscopedPackageName}`,
+        },
       })
       const packageFiles: string[] =
         filesRes.status === 200

--- a/src/hooks/use-package-as-snippet.ts
+++ b/src/hooks/use-package-as-snippet.ts
@@ -32,8 +32,10 @@ export const usePackageAsSnippet = (packageId: string | null) => {
       if (!packageQuery.data?.latest_package_release_id) {
         throw new Error("No latest release ID available")
       }
-      const { data } = await axios.post("/package_files/list", {
-        package_release_id: packageQuery.data.latest_package_release_id,
+      const { data } = await axios.get("/package_files/list", {
+        params: {
+          package_release_id: packageQuery.data.latest_package_release_id,
+        },
       })
       return data.package_files
     },

--- a/src/hooks/use-package-files.ts
+++ b/src/hooks/use-package-files.ts
@@ -100,8 +100,8 @@ export const usePackageFiles = (packageReleaseId?: string | null) => {
       if (!packageReleaseId) return []
 
       try {
-        const { data } = await axios.post("/package_files/list", {
-          package_release_id: packageReleaseId,
+        const { data } = await axios.get("/package_files/list", {
+          params: { package_release_id: packageReleaseId },
         })
 
         if (!data.package_files) {


### PR DESCRIPTION
## Summary
- switch `/package_files/list` API to GET with query params
- update client hooks and components to fetch package files via GET
- adjust registry utilities and tests to use GET

## Testing
- `bun run lint`
- `bun test bun-tests/fake-snippets-api/routes/package_files/create_or_update.test.ts bun-tests/fake-snippets-api/routes/package_files/create.test.ts bun-tests/fake-snippets-api/routes/package_files/list.test.ts bun-tests/fake-snippets-api/routes/packages/images.test.ts bun-tests/fake-snippets-api/routes/packages/fork.test.ts`


------
https://chatgpt.com/codex/tasks/task_b_68a56c806bdc8331a8c92873edca9025