### PR TITLE
chore: remove drag-and-drop from homepage subtitle

### DIFF
--- a/api/generated-index.js
+++ b/api/generated-index.js
@@ -36,7 +36,7 @@ const PREFETCHABLE_PAGES = new Set([
 
 const pageDescriptions = {
   landing:
-    "Build electronics with code, AI, and drag'n'drop tools. Render code into schematics, PCBs, 3D, fabrication files, and more. Open-source MIT licensed electronic design automation tool.",
+    "Build electronics with code and AI tools. Render code into schematics, PCBs, 3D, fabrication files, and more. Open-source MIT licensed electronic design automation tool.",
   dashboard:
     "Your tscircuit dashboard - manage your electronic circuit packages, view trending and latest packages, and access your recent designs.",
   search:

--- a/src/pages/landing.tsx
+++ b/src/pages/landing.tsx
@@ -53,7 +53,7 @@ export function LandingPage() {
                       AI codes electronics with tscircuit
                     </h1>
                     <p className="max-w-[600px] text-muted-foreground md:text-xl">
-                      Build electronics with code, AI, and drag'n'drop tools.
+                      Build electronics with code and AI tools.
                       <br />
                       Render code into schematics, PCBs, 3D, fabrication files,
                       and more.


### PR DESCRIPTION
## Summary
- drop drag-and-drop mention from homepage subtitle
- update generated index description to match new subtitle

## Testing
- `bun test`
- `bun run format`


------
https://chatgpt.com/codex/tasks/task_b_68a73137863c832e96eb08c18740dc62