### PR TITLE
feat: surface image generation logs

### DIFF
--- a/bun-tests/fake-snippets-api/routes/package_releases/get_image_generation_fields.test.ts
+++ b/bun-tests/fake-snippets-api/routes/package_releases/get_image_generation_fields.test.ts
@@ -1,0 +1,38 @@
+import { expect, test } from "bun:test"
+import { getTestServer } from "bun-tests/fake-snippets-api/fixtures/get-test-server"
+
+// ensure image generation fields are returned by /api/package_releases/get
+
+test("POST /api/package_releases/get includes image generation fields", async () => {
+  const { axios } = await getTestServer()
+
+  const packageRes = await axios.post("/api/packages/create", {
+    name: "@test/image-fields",
+    description: "test package",
+  })
+
+  const { package_id } = packageRes.data.package
+
+  const releaseRes = await axios.post("/api/package_releases/create", {
+    package_id,
+    version: "0.0.1",
+    is_latest: true,
+  })
+
+  const { package_release } = releaseRes.data
+
+  const res = await axios.post("/api/package_releases/get", {
+    package_release_id: package_release.package_release_id,
+  })
+
+  const pr = res.data.package_release
+
+  expect(pr.image_generation_in_progress).toBe(false)
+  expect(pr.image_generation_started_at).toBeNull()
+  expect(pr.image_generation_completed_at).toBeNull()
+  expect(pr.image_generation_logs).toBeNull()
+  expect(pr.image_generation_is_stale).toBe(false)
+  expect(pr.image_generation_error).toBeNull()
+  expect(pr.image_generation_error_last_updated_at).toBeNull()
+  expect(pr.image_generation_display_status).toBe("pending")
+})

--- a/fake-snippets-api/lib/db/db-client.ts
+++ b/fake-snippets-api/lib/db/db-client.ts
@@ -17,6 +17,7 @@ import {
   type PackageRelease,
   packageReleaseSchema,
   type PackageBuild,
+  packageBuildSchema,
   type AiReview,
   aiReviewSchema,
   type Datasheet,
@@ -1489,12 +1490,12 @@ const initializer = combine(databaseSchema.parse({}), (set, get) => ({
     return updated
   },
   addPackageBuild: (
-    packageBuild: Omit<PackageBuild, "package_build_id">,
+    packageBuild: Omit<z.input<typeof packageBuildSchema>, "package_build_id">,
   ): PackageBuild => {
-    const newPackageBuild = {
+    const newPackageBuild = packageBuildSchema.parse({
       package_build_id: crypto.randomUUID(),
       ...packageBuild,
-    }
+    })
     set((state) => ({
       packageBuilds: [...state.packageBuilds, newPackageBuild],
       // Automatically update the package release to reference this as the latest build

--- a/fake-snippets-api/lib/db/schema.ts
+++ b/fake-snippets-api/lib/db/schema.ts
@@ -244,6 +244,22 @@ export const packageReleaseSchema = z.object({
   circuit_json_build_logs: z.array(z.any()).default([]),
   circuit_json_build_is_stale: z.boolean().default(false),
 
+  // Image Generation Process
+  image_generation_display_status: z
+    .enum(["pending", "building", "complete", "error"])
+    .default("pending"),
+  image_generation_in_progress: z.boolean().default(false),
+  image_generation_started_at: z.string().datetime().nullable().optional(),
+  image_generation_completed_at: z.string().datetime().nullable().optional(),
+  image_generation_logs: z.array(z.any()).nullable().default(null),
+  image_generation_is_stale: z.boolean().default(false),
+  image_generation_error: z.string().nullable().optional(),
+  image_generation_error_last_updated_at: z
+    .string()
+    .datetime()
+    .nullable()
+    .optional(),
+
   // AI Review
   ai_review_text: z.string().nullable().default(null).optional(),
   ai_review_started_at: z.string().datetime().nullable().optional(),
@@ -367,6 +383,11 @@ export const packageBuildSchema = z.object({
   circuit_json_build_completed_at: z.string().datetime().nullable().optional(),
   circuit_json_build_logs: z.array(z.any()).default([]),
   circuit_json_build_error: z.string().nullable().optional(),
+  image_generation_in_progress: z.boolean().default(false),
+  image_generation_started_at: z.string().datetime().nullable().optional(),
+  image_generation_completed_at: z.string().datetime().nullable().optional(),
+  image_generation_logs: z.array(z.any()).default([]),
+  image_generation_error: z.string().nullable().optional(),
   build_in_progress: z.boolean().default(false),
   build_started_at: z.string().datetime().nullable().optional(),
   build_completed_at: z.string().datetime().nullable().optional(),

--- a/fake-snippets-api/lib/public-mapping/public-map-package-build.ts
+++ b/fake-snippets-api/lib/public-mapping/public-map-package-build.ts
@@ -25,6 +25,16 @@ export const publicMapPackageBuild = (
       ? internalPackageBuild.circuit_json_build_logs
       : [],
     circuit_json_build_error: internalPackageBuild.circuit_json_build_error,
+    image_generation_in_progress:
+      internalPackageBuild.image_generation_in_progress,
+    image_generation_started_at:
+      internalPackageBuild.image_generation_started_at,
+    image_generation_completed_at:
+      internalPackageBuild.image_generation_completed_at,
+    image_generation_logs: options.include_logs
+      ? internalPackageBuild.image_generation_logs
+      : [],
+    image_generation_error: internalPackageBuild.image_generation_error,
     build_started_at: internalPackageBuild.build_started_at,
     build_completed_at: internalPackageBuild.build_completed_at,
     build_error: internalPackageBuild.build_error,

--- a/fake-snippets-api/lib/public-mapping/public-map-package-release.ts
+++ b/fake-snippets-api/lib/public-mapping/public-map-package-release.ts
@@ -24,6 +24,23 @@ export const publicMapPackageRelease = (
     circuit_json_build_logs: options.include_logs
       ? internal_package_release.circuit_json_build_logs
       : [],
+    image_generation_logs: options.include_logs
+      ? internal_package_release.image_generation_logs
+      : null,
+    image_generation_in_progress:
+      internal_package_release.image_generation_in_progress,
+    image_generation_started_at:
+      internal_package_release.image_generation_started_at ?? null,
+    image_generation_completed_at:
+      internal_package_release.image_generation_completed_at ?? null,
+    image_generation_is_stale:
+      internal_package_release.image_generation_is_stale,
+    image_generation_error:
+      internal_package_release.image_generation_error ?? null,
+    image_generation_error_last_updated_at:
+      internal_package_release.image_generation_error_last_updated_at ?? null,
+    image_generation_display_status:
+      internal_package_release.image_generation_display_status,
     is_pr_preview: Boolean(internal_package_release.is_pr_preview),
     github_pr_number: internal_package_release.github_pr_number,
     branch_name: internal_package_release.branch_name,

--- a/src/components/PackageBuildsPage/PackageBuildDetailsPage.tsx
+++ b/src/components/PackageBuildsPage/PackageBuildDetailsPage.tsx
@@ -38,6 +38,14 @@ export const PackageBuildDetailsPage = () => {
     circuit_json_build_display_status,
     transpilation_display_status,
     transpilation_error,
+    image_generation_logs,
+    image_generation_completed_at,
+    image_generation_in_progress,
+    image_generation_is_stale,
+    image_generation_started_at,
+    image_generation_error,
+    image_generation_error_last_updated_at,
+    image_generation_display_status,
   } = packageRelease ?? ({} as Partial<PackageRelease>)
 
   const toggleSection = (section: string) => {
@@ -104,6 +112,26 @@ export const PackageBuildDetailsPage = () => {
                 ]
               }
               error={circuit_json_build_error!}
+            />
+          </CollapsibleSection>
+
+          <CollapsibleSection
+            title="Image Generation Logs"
+            duration={computeDuration(
+              image_generation_started_at,
+              image_generation_completed_at,
+            )}
+            displayStatus={image_generation_display_status}
+            isOpen={openSections.image}
+            onToggle={() => toggleSection("image")}
+          >
+            <LogContent
+              logs={
+                image_generation_logs ?? [
+                  { msg: "No Image Generation logs available" },
+                ]
+              }
+              error={image_generation_error}
             />
           </CollapsibleSection>
         </div>

--- a/src/components/PackageBuildsPage/package-build-details-panel.tsx
+++ b/src/components/PackageBuildsPage/package-build-details-panel.tsx
@@ -55,20 +55,25 @@ export function PackageBuildDetailsPanel() {
     transpilation_error,
     transpilation_started_at,
     commit_sha,
+    image_generation_started_at,
+    image_generation_completed_at,
   } = packageRelease
 
   const buildStartedAt = (() => {
-    if (transpilation_started_at && circuit_json_build_started_at) {
-      return new Date(transpilation_started_at) <
-        new Date(circuit_json_build_started_at)
-        ? transpilation_started_at
-        : circuit_json_build_started_at
-    }
-    return transpilation_started_at || circuit_json_build_started_at || null
+    const times = [
+      transpilation_started_at,
+      circuit_json_build_started_at,
+      image_generation_started_at,
+    ].filter((t): t is string => Boolean(t))
+    if (times.length === 0) return null
+    return times.reduce((min, t) => (new Date(t) < new Date(min) ? t : min))
   })()
 
   const buildCompletedAt =
-    circuit_json_build_completed_at || transpilation_completed_at || null
+    image_generation_completed_at ||
+    circuit_json_build_completed_at ||
+    transpilation_completed_at ||
+    null
 
   const elapsedMs = buildStartedAt
     ? (buildCompletedAt ? new Date(buildCompletedAt).getTime() : now) -


### PR DESCRIPTION
## Summary
- expose image generation build info in API and schema
- show image generation logs on preview and build details pages
- test that package releases return image generation fields

## Testing
- `bun run lint`
- `bun run typecheck`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_b_68aea9e560088331b1b373c031ebf6e5