### PR TITLE
Request 3D preview images as PNG

### DIFF
--- a/src/components/ViewPackagePage/components/mobile-sidebar.tsx
+++ b/src/components/ViewPackagePage/components/mobile-sidebar.tsx
@@ -96,7 +96,7 @@ const MobileSidebar = ({
 
   const viewsToRender =
     svgViews.length === 0 ||
-    svgViews.every((v) => !v.isLoading && !(v as any).svg)
+    svgViews.every((v) => !v.isLoading && !(v as any).image)
       ? (pngViews as any)
       : (svgViews as any)
 
@@ -217,7 +217,7 @@ const MobileSidebar = ({
             view={view.label}
             onClick={() => handleViewClick(view.id)}
             backgroundClass={view.backgroundClass}
-            svg={view.svg}
+            image={view.image}
             isLoading={view.isLoading}
             imageUrl={view.imageUrl}
             status={view.status}
@@ -255,7 +255,7 @@ function PreviewButton({
   view,
   onClick,
   backgroundClass,
-  svg,
+  image,
   isLoading,
   imageUrl,
   status,
@@ -265,14 +265,14 @@ function PreviewButton({
   view: string
   onClick: () => void
   backgroundClass?: string
-  svg?: string | null
+  image?: string | null
   isLoading?: boolean
   imageUrl?: string
   status?: "loading" | "loaded" | "error"
   onLoad?: () => void
   onError?: () => void
 }) {
-  if (!svg && !isLoading && !imageUrl) {
+  if (!image && !isLoading && !imageUrl) {
     return null
   }
 
@@ -284,13 +284,22 @@ function PreviewButton({
       {(isLoading || status === "loading") && (
         <Skeleton className="w-full h-full rounded-lg" />
       )}
-      {!isLoading && !status && svg && (
-        <img
-          src={svgToDataUrl(normalizeSvgForSquareTile(svg))}
-          alt={view}
-          className="w-full h-full object-contain"
-        />
-      )}
+      {!isLoading &&
+        !status &&
+        image &&
+        (image.startsWith("<svg") ? (
+          <img
+            src={svgToDataUrl(normalizeSvgForSquareTile(image))}
+            alt={view}
+            className="w-full h-full object-contain"
+          />
+        ) : (
+          <img
+            src={image}
+            alt={view}
+            className="w-full h-full object-contain"
+          />
+        ))}
       {imageUrl && (
         <img
           src={imageUrl}

--- a/src/components/ViewPackagePage/components/preview-image-squares.tsx
+++ b/src/components/ViewPackagePage/components/preview-image-squares.tsx
@@ -36,7 +36,7 @@ export default function PreviewImageSquares({
 
   const viewsToRender =
     svgViews.length === 0 ||
-    svgViews.every((v) => !v.isLoading && !(v as any).svg)
+    svgViews.every((v) => !v.isLoading && !(v as any).image)
       ? (pngViews as any)
       : (svgViews as any)
 
@@ -55,13 +55,21 @@ export default function PreviewImageSquares({
           {(view.isLoading || view.status === "loading") && (
             <Skeleton className="w-full h-full rounded-lg" />
           )}
-          {view.svg && !view.status && (
-            <img
-              src={svgToDataUrl(normalizeSvgForSquareTile(view.svg))}
-              alt={view.label}
-              className="w-full h-full object-contain"
-            />
-          )}
+          {view.image &&
+            !view.status &&
+            (view.image.startsWith("<svg") ? (
+              <img
+                src={svgToDataUrl(normalizeSvgForSquareTile(view.image))}
+                alt={view.label}
+                className="w-full h-full object-contain"
+              />
+            ) : (
+              <img
+                src={view.image}
+                alt={view.label}
+                className="w-full h-full object-contain"
+              />
+            ))}
           {view.imageUrl && (
             <img
               src={view.imageUrl}

--- a/src/hooks/use-package-release-images.ts
+++ b/src/hooks/use-package-release-images.ts
@@ -24,7 +24,7 @@ export function usePackageReleaseImages({
     {
       id: "3d",
       label: "3D",
-      filePath: "dist/3d.svg",
+      filePath: "dist/3d.png",
       backgroundClass: "bg-gray-100",
     },
     {
@@ -53,7 +53,12 @@ export function usePackageReleaseImages({
             file_path: view.filePath,
           },
         })
-        return data.package_file?.content_text ?? null
+        const content = data.package_file?.content_text
+        if (!content) return null
+        if (view.filePath.endsWith(".png")) {
+          return `data:image/png;base64,${content}`
+        }
+        return content
       },
       enabled:
         Boolean(packageReleaseId) &&
@@ -75,11 +80,11 @@ export function usePackageReleaseImages({
         .map((view, idx) => ({
           id: view.id,
           label: view.label,
-          svg: queries[idx].data as string | null,
+          image: queries[idx].data as string | null,
           isLoading: queries[idx].isLoading,
           backgroundClass: view.backgroundClass,
         }))
-        .filter((v) => v.isLoading || v.svg),
+        .filter((v) => v.isLoading || v.image),
     [queries],
   )
 

--- a/src/pages/release-detail.tsx
+++ b/src/pages/release-detail.tsx
@@ -126,11 +126,19 @@ export default function ReleaseDetailPage() {
                     <Skeleton className="w-full h-full" />
                   ) : (
                     <img
-                      src={`data:image/svg+xml,${encodeURIComponent(
-                        view.svg ?? "",
-                      )}`}
+                      src={
+                        view.image?.startsWith("<svg")
+                          ? `data:image/svg+xml,${encodeURIComponent(view.image)}`
+                          : view.image || ""
+                      }
                       alt={`${view.label} preview`}
-                      className={`w-full h-full object-contain ${view.label.toLowerCase() == "pcb" ? "bg-black" : view.label.toLowerCase() == "schematic" ? "bg-[#F5F1ED]" : "bg-gray-100"}`}
+                      className={`w-full h-full object-contain ${
+                        view.label.toLowerCase() == "pcb"
+                          ? "bg-black"
+                          : view.label.toLowerCase() == "schematic"
+                            ? "bg-[#F5F1ED]"
+                            : "bg-gray-100"
+                      }`}
                     />
                   )}
                 </div>


### PR DESCRIPTION
## Summary
- Fetch 3D package release images as `dist/3d.png` and return a data URL
- Render 3D previews from PNG data across preview components

## Testing
- `bun test bun-tests/fake-snippets-api/routes/packages/images.test.ts`


------
https://chatgpt.com/codex/tasks/task_b_68be6a5c52e0832ebf706ebe8281e625