### PR TITLE
Use direct package image URLs for release previews

### DIFF
--- a/src/components/ViewPackagePage/components/mobile-sidebar.tsx
+++ b/src/components/ViewPackagePage/components/mobile-sidebar.tsx
@@ -2,7 +2,6 @@ import { GitFork, Star, Tag, Settings, LinkIcon } from "lucide-react"
 import { Badge } from "@/components/ui/badge"
 import { Skeleton } from "@/components/ui/skeleton"
 import { usePackageReleaseImages } from "@/hooks/use-package-release-images"
-import { usePreviewImages } from "@/hooks/use-preview-images"
 import { useGlobalStore } from "@/hooks/use-global-store"
 import { Button } from "@/components/ui/button"
 import { useEditPackageDetailsDialog } from "@/components/dialogs/edit-package-details-dialog"
@@ -80,25 +79,10 @@ const MobileSidebar = ({
     [refetchPackageInfo],
   )
 
-  const availableFilePaths = useMemo(
-    () => releaseFiles?.map((f) => f.file_path),
-    [releaseFiles],
-  )
-  const { availableViews: svgViews } = usePackageReleaseImages({
-    packageReleaseId: packageInfo?.latest_package_release_id,
-    availableFilePaths,
-  })
-
-  const { availableViews: pngViews } = usePreviewImages({
+  const { availableViews: viewsToRender } = usePackageReleaseImages({
     packageName: packageInfo?.name,
-    fsMapHash: packageInfo?.latest_package_release_fs_sha ?? "",
+    fsSha: packageInfo?.latest_package_release_fs_sha ?? "",
   })
-
-  const viewsToRender =
-    svgViews.length === 0 ||
-    svgViews.every((v) => !v.isLoading && !(v as any).image)
-      ? (pngViews as any)
-      : (svgViews as any)
 
   const handleViewClick = useCallback(
     (viewId: string) => {
@@ -217,8 +201,6 @@ const MobileSidebar = ({
             view={view.label}
             onClick={() => handleViewClick(view.id)}
             backgroundClass={view.backgroundClass}
-            image={view.image}
-            isLoading={view.isLoading}
             imageUrl={view.imageUrl}
             status={view.status}
             onLoad={view.onLoad}

--- a/src/components/ViewPackagePage/components/preview-image-squares.tsx
+++ b/src/components/ViewPackagePage/components/preview-image-squares.tsx
@@ -1,18 +1,9 @@
 import { Skeleton } from "@/components/ui/skeleton"
 import { usePackageReleaseImages } from "@/hooks/use-package-release-images"
-import { usePreviewImages } from "@/hooks/use-preview-images"
-import { usePackageFiles } from "@/hooks/use-package-files"
-import {
-  normalizeSvgForSquareTile,
-  svgToDataUrl,
-} from "@/lib/normalize-svg-for-tile"
 import type { Package } from "fake-snippets-api/lib/db/schema"
 
 interface ViewPlaceholdersProps {
-  packageInfo?: Pick<
-    Package,
-    "name" | "latest_package_release_fs_sha" | "latest_package_release_id"
-  >
+  packageInfo?: Pick<Package, "name" | "latest_package_release_fs_sha">
   onViewChange?: (view: "3d" | "pcb" | "schematic") => void
 }
 
@@ -20,25 +11,10 @@ export default function PreviewImageSquares({
   packageInfo,
   onViewChange,
 }: ViewPlaceholdersProps) {
-  const { data: releaseFiles } = usePackageFiles(
-    packageInfo?.latest_package_release_id,
-  )
-  const availableFilePaths = releaseFiles?.map((f) => f.file_path)
-  const { availableViews: svgViews } = usePackageReleaseImages({
-    packageReleaseId: packageInfo?.latest_package_release_id,
-    availableFilePaths,
-  })
-
-  const { availableViews: pngViews } = usePreviewImages({
+  const { availableViews: viewsToRender } = usePackageReleaseImages({
     packageName: packageInfo?.name,
-    fsMapHash: packageInfo?.latest_package_release_fs_sha ?? "",
+    fsSha: packageInfo?.latest_package_release_fs_sha ?? "",
   })
-
-  const viewsToRender =
-    svgViews.length === 0 ||
-    svgViews.every((v) => !v.isLoading && !(v as any).image)
-      ? (pngViews as any)
-      : (svgViews as any)
 
   const handleViewClick = (viewId: string) => {
     onViewChange?.(viewId as "3d" | "pcb" | "schematic")
@@ -52,24 +28,9 @@ export default function PreviewImageSquares({
           className={`aspect-square ${view.backgroundClass ?? "bg-gray-100"} rounded-lg border border-gray-200 dark:border-[#30363d] flex items-center justify-center transition-colors overflow-hidden mb-6`}
           onClick={() => handleViewClick(view.id)}
         >
-          {(view.isLoading || view.status === "loading") && (
+          {view.status === "loading" && (
             <Skeleton className="w-full h-full rounded-lg" />
           )}
-          {view.image &&
-            !view.status &&
-            (view.image.startsWith("<svg") ? (
-              <img
-                src={svgToDataUrl(normalizeSvgForSquareTile(view.image))}
-                alt={view.label}
-                className="w-full h-full object-contain"
-              />
-            ) : (
-              <img
-                src={view.image}
-                alt={view.label}
-                className="w-full h-full object-contain"
-              />
-            ))}
           {view.imageUrl && (
             <img
               src={view.imageUrl}

--- a/src/pages/release-detail.tsx
+++ b/src/pages/release-detail.tsx
@@ -51,7 +51,8 @@ export default function ReleaseDetailPage() {
   })
 
   const { availableViews } = usePackageReleaseImages({
-    packageReleaseId: packageRelease?.package_release_id,
+    packageName: pkg?.name,
+    fsSha: packageRelease?.fs_sha ?? "",
   })
 
   if (isLoadingPackage || isLoadingRelease) {
@@ -120,25 +121,17 @@ export default function ReleaseDetailPage() {
               {availableViews.map((view) => (
                 <div
                   key={view.id}
-                  className="flex items-center justify-center border rounded-lg bg-gray-50 overflow-hidden h-48"
+                  className={`flex items-center justify-center border rounded-lg overflow-hidden h-48 ${view.backgroundClass}`}
                 >
-                  {view.isLoading ? (
+                  {view.status === "loading" ? (
                     <Skeleton className="w-full h-full" />
                   ) : (
                     <img
-                      src={
-                        view.image?.startsWith("<svg")
-                          ? `data:image/svg+xml,${encodeURIComponent(view.image)}`
-                          : view.image || ""
-                      }
+                      src={view.imageUrl}
                       alt={`${view.label} preview`}
-                      className={`w-full h-full object-contain ${
-                        view.label.toLowerCase() == "pcb"
-                          ? "bg-black"
-                          : view.label.toLowerCase() == "schematic"
-                            ? "bg-[#F5F1ED]"
-                            : "bg-gray-100"
-                      }`}
+                      className="w-full h-full object-contain"
+                      onLoad={view.onLoad}
+                      onError={view.onError}
                     />
                   )}
                 </div>


### PR DESCRIPTION
## Summary
- load release images via `/packages/images` instead of `/package_files/get`
- show 3D preview as PNG and set image sources directly for PCB and schematic views
- simplify release and package pages to rely on image URLs

## Testing
- `bun test bun-tests/fake-snippets-api/routes/packages/images.test.ts`
- `bun run typecheck`
- `bun run format`


------
https://chatgpt.com/codex/tasks/task_b_68be6fcb11fc832e8002d82509e58ebc