### PR TITLE
feat(fake-api): add user permissions to package responses

### DIFF
--- a/fake-snippets-api/routes/api/packages/get.ts
+++ b/fake-snippets-api/routes/api/packages/get.ts
@@ -16,6 +16,11 @@ export default withRouteSpec({
     package: packageSchema
       .extend({
         is_starred: z.boolean(),
+        user_permissions: z
+          .object({
+            can_manage_packages: z.boolean(),
+          })
+          .optional(),
       })
       .optional(),
   }),
@@ -53,6 +58,14 @@ export default withRouteSpec({
       is_starred: auth
         ? ctx.db.hasStarred(auth.account_id, foundPackage.package_id)
         : false,
+      ...(auth
+        ? {
+            user_permissions: {
+              can_manage_packages:
+                foundPackage.owner_org_id === auth.personal_org_id,
+            },
+          }
+        : {}),
     },
   })
 })


### PR DESCRIPTION
## Summary
- include user_permissions info on /api/packages/get and /api/packages/list when session token provided
- expose can_manage_packages true for package owners
- test coverage for user_permissions on get and list endpoints

## Testing
- `bun test bun-tests/fake-snippets-api/routes/packages/get.test.ts bun-tests/fake-snippets-api/routes/packages/list-1.test.ts bun-tests/fake-snippets-api/routes/packages/list-2.test.ts`


------
https://chatgpt.com/codex/tasks/task_b_68bf79f8af4c832ea089d731dddc85d3