### PR TITLE
refactor(image-preview): simplify image loading logic to use api and skeletons

### DIFF
--- a/src/components/ViewPackagePage/components/mobile-sidebar.tsx
+++ b/src/components/ViewPackagePage/components/mobile-sidebar.tsx
@@ -80,13 +80,8 @@ const MobileSidebar = ({
     [refetchPackageInfo],
   )
 
-  const availableFilePaths = useMemo(
-    () => releaseFiles?.map((f) => f.file_path),
-    [releaseFiles],
-  )
-  const { availableViews: svgViews } = usePackageReleaseImages({
+  const { availableViews: imageViews } = usePackageReleaseImages({
     packageReleaseId: packageInfo?.latest_package_release_id,
-    availableFilePaths,
   })
 
   const { availableViews: pngViews } = usePreviewImages({
@@ -95,10 +90,10 @@ const MobileSidebar = ({
   })
 
   const viewsToRender =
-    svgViews.length === 0 ||
-    svgViews.every((v) => !v.isLoading && !(v as any).svg)
+    imageViews.length === 0 ||
+    imageViews.every((v) => !v.isLoading && !v.imageUrl)
       ? (pngViews as any)
-      : (svgViews as any)
+      : imageViews
 
   const handleViewClick = useCallback(
     (viewId: string) => {
@@ -291,13 +286,11 @@ function PreviewButton({
           className="w-full h-full object-contain"
         />
       )}
-      {imageUrl && (
+      {imageUrl && !isLoading && (
         <img
           src={imageUrl}
           alt={view}
-          className={`w-full h-full object-cover rounded-lg ${
-            status === "loaded" ? "block" : "hidden"
-          }`}
+          className="w-full h-full object-cover rounded-lg"
           onLoad={onLoad}
           onError={onError}
         />

--- a/src/components/ViewPackagePage/components/preview-image-squares.tsx
+++ b/src/components/ViewPackagePage/components/preview-image-squares.tsx
@@ -24,9 +24,8 @@ export default function PreviewImageSquares({
     packageInfo?.latest_package_release_id,
   )
   const availableFilePaths = releaseFiles?.map((f) => f.file_path)
-  const { availableViews: svgViews } = usePackageReleaseImages({
+  const { availableViews: imageViews } = usePackageReleaseImages({
     packageReleaseId: packageInfo?.latest_package_release_id,
-    availableFilePaths,
   })
 
   const { availableViews: pngViews } = usePreviewImages({
@@ -35,10 +34,10 @@ export default function PreviewImageSquares({
   })
 
   const viewsToRender =
-    svgViews.length === 0 ||
-    svgViews.every((v) => !v.isLoading && !(v as any).svg)
+    imageViews.length === 0 ||
+    imageViews.every((v) => !v.isLoading && !v.imageUrl)
       ? (pngViews as any)
-      : (svgViews as any)
+      : imageViews
 
   const handleViewClick = (viewId: string) => {
     onViewChange?.(viewId as "3d" | "pcb" | "schematic")
@@ -62,13 +61,11 @@ export default function PreviewImageSquares({
               className="w-full h-full object-contain"
             />
           )}
-          {view.imageUrl && (
+          {view.imageUrl && !view.isLoading && (
             <img
               src={view.imageUrl}
               alt={view.label}
-              className={`w-full h-full object-cover rounded-lg ${
-                view.status === "loaded" ? "block" : "hidden"
-              }`}
+              className="w-full h-full object-cover rounded-lg"
               onLoad={view.onLoad}
               onError={view.onError}
             />

--- a/src/hooks/use-package-release-images.ts
+++ b/src/hooks/use-package-release-images.ts
@@ -1,6 +1,8 @@
-import { useMemo } from "react"
+import { useMemo, useCallback } from "react"
 import { useQueries } from "react-query"
 import { useAxios } from "./use-axios"
+import { useParams } from "wouter"
+import { useApiBaseUrl } from "./use-packages-base-api-url"
 
 interface UsePackageReleaseImagesProps {
   packageReleaseId?: string | null
@@ -10,78 +12,94 @@ interface UsePackageReleaseImagesProps {
 interface ViewConfig {
   id: string
   label: string
-  filePath: string
   backgroundClass: string
 }
 
+const VIEWS: ViewConfig[] = [
+  {
+    id: "3d",
+    label: "3D",
+    backgroundClass: "bg-gray-100",
+  },
+  {
+    id: "pcb",
+    label: "PCB",
+    backgroundClass: "bg-black",
+  },
+  {
+    id: "schematic",
+    label: "Schematic",
+    backgroundClass: "bg-[#F5F1ED]",
+  },
+]
+
 export function usePackageReleaseImages({
   packageReleaseId,
-  availableFilePaths,
 }: UsePackageReleaseImagesProps) {
+  const apiurl = useApiBaseUrl()
   const axios = useAxios()
+  const { author, packageName } = useParams()
 
-  const views: ViewConfig[] = [
-    {
-      id: "3d",
-      label: "3D",
-      filePath: "dist/3d.svg",
-      backgroundClass: "bg-gray-100",
-    },
-    {
-      id: "pcb",
-      label: "PCB",
-      filePath: "dist/pcb.svg",
-      backgroundClass: "bg-black",
-    },
-    {
-      id: "schematic",
-      label: "Schematic",
-      filePath: "dist/schematic.svg",
-      backgroundClass: "bg-[#F5F1ED]",
-    },
-  ]
+  const createQueryFn = useCallback(
+    (viewId: string) => async () => {
+      if (!packageReleaseId || !author || !packageName) return null
 
-  const queries = useQueries(
-    views.map((view) => ({
-      queryKey: ["packageReleaseImage", packageReleaseId, view.filePath],
-      queryFn: async () => {
-        if (!packageReleaseId) return null
+      const imageUrl = `${apiurl}/packages/images/${author}/${packageName}/${viewId}.png?package_release_id=${packageReleaseId}`
 
-        const { data } = await axios.get("/package_files/get", {
-          params: {
-            package_release_id: packageReleaseId,
-            file_path: view.filePath,
-          },
-        })
-        return data.package_file?.content_text ?? null
-      },
-      enabled:
-        Boolean(packageReleaseId) &&
-        Boolean(
-          !availableFilePaths || availableFilePaths?.includes(view.filePath),
-        ),
-      retry: false,
-      refetchOnWindowFocus: false,
-      refetchOnMount: false,
-      refetchOnReconnect: false,
-      staleTime: Infinity,
-      cacheTime: Infinity,
-    })),
+      try {
+        const response = await axios.head(imageUrl)
+        return response.status === 200 ? imageUrl : null
+      } catch {
+        return null
+      }
+    },
+    [packageReleaseId, author, packageName, apiurl, axios],
   )
 
-  const availableViews = useMemo(
+  const queryConfigs = useMemo(
     () =>
-      views
-        .map((view, idx) => ({
+      VIEWS.map((view) => ({
+        queryKey: [
+          "packageReleaseImage",
+          packageReleaseId,
+          view.id,
+          author,
+          packageName,
+        ],
+        queryFn: createQueryFn(view.id),
+        enabled: Boolean(packageReleaseId && author && packageName),
+        retry: false,
+        refetchOnWindowFocus: false,
+        refetchOnMount: false,
+        refetchOnReconnect: false,
+        staleTime: Infinity,
+        cacheTime: Infinity,
+      })),
+    [packageReleaseId, author, packageName, createQueryFn],
+  )
+
+  const queries = useQueries(queryConfigs)
+
+  const availableViews = useMemo(() => {
+    const result = []
+
+    for (let i = 0; i < VIEWS.length; i++) {
+      const view = VIEWS[i]
+      const query = queries[i]
+
+      if (query.isLoading || query.data) {
+        result.push({
           id: view.id,
           label: view.label,
-          svg: queries[idx].data as string | null,
-          isLoading: queries[idx].isLoading,
+          imageUrl: query.data || "",
+          isLoading: query.isLoading,
           backgroundClass: view.backgroundClass,
-        }))
-        .filter((v) => v.isLoading || v.svg),
-    [queries],
-  )
+        })
+      }
+    }
+
+    return result
+  }, [queries])
 
   return { availableViews }
 }

--- a/src/pages/release-detail.tsx
+++ b/src/pages/release-detail.tsx
@@ -55,7 +55,37 @@ export default function ReleaseDetailPage() {
   })
 
   if (isLoadingPackage || isLoadingRelease) {
-    return null
+    return (
+      <>
+        <Header />
+        <div className="min-h-screen bg-white">
+          {/* Page Header Skeleton */}
+          <div className="bg-gray-50 border-b py-6">
+            <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+              <Skeleton className="h-6 w-64 mb-4" />
+              <div className="flex items-center gap-4">
+                <Skeleton className="h-4 w-20" />
+                <Skeleton className="h-4 w-32" />
+              </div>
+            </div>
+          </div>
+
+          {/* Images Skeleton */}
+          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+              {[1, 2, 3].map((i) => (
+                <Skeleton key={i} className="h-48 rounded-lg" />
+              ))}
+            </div>
+          </div>
+
+          {/* Main Content Skeleton */}
+          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
+            <Skeleton className="h-64 w-full" />
+          </div>
+        </div>
+      </>
+    )
   }
 
   if (packageError?.status === 404 || !pkg) {
@@ -114,30 +144,31 @@ export default function ReleaseDetailPage() {
           </div>
         </div>
 
-        {availableViews.length > 0 && (
-          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
-            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-              {availableViews.map((view) => (
-                <div
-                  key={view.id}
-                  className="flex items-center justify-center border rounded-lg bg-gray-50 overflow-hidden h-48"
-                >
-                  {view.isLoading ? (
-                    <Skeleton className="w-full h-full" />
-                  ) : (
-                    <img
-                      src={`data:image/svg+xml,${encodeURIComponent(
-                        view.svg ?? "",
-                      )}`}
-                      alt={`${view.label} preview`}
-                      className={`w-full h-full object-contain ${view.label.toLowerCase() == "pcb" ? "bg-black" : view.label.toLowerCase() == "schematic" ? "bg-[#F5F1ED]" : "bg-gray-100"}`}
-                    />
-                  )}
-                </div>
-              ))}
-            </div>
+        {/* Images Section - Always show with skeletons while loading */}
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+            {availableViews.length > 0
+              ? availableViews.map((view) => (
+                  <div
+                    key={view.id}
+                    className="flex items-center justify-center border rounded-lg bg-gray-50 overflow-hidden h-48"
+                  >
+                    {view.isLoading ? (
+                      <Skeleton className="w-full h-full" />
+                    ) : (
+                      <img
+                        src={view.imageUrl}
+                        alt={`${view.label} preview`}
+                        className={`w-full h-full object-contain ${view.label.toLowerCase() == "pcb" ? "bg-black" : view.label.toLowerCase() == "schematic" ? "bg-[#F5F1ED]" : "bg-gray-100"}`}
+                      />
+                    )}
+                  </div>
+                ))
+              : [1, 2, 3].map((i) => (
+                  <Skeleton key={i} className="h-48 rounded-lg" />
+                ))}
           </div>
-        )}
+        </div>
 
         {/* Main Content */}
         <ConnectedRepoOverview


### PR DESCRIPTION
…

fix #1645

- Replace SVG loading with direct PNG URLs from API
- Add skeleton loading states for better UX
- Remove unnecessary file path checks and simplify view rendering
- Consolidate view configuration into a single constant