### PR TITLE
chore: update schematic-symbols dependency

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -136,7 +136,7 @@
         "redaxios": "^0.5.1",
         "remark-gfm": "^4.0.1",
         "rollup-plugin-visualizer": "^5.12.0",
-        "schematic-symbols": "^0.0.195",
+        "schematic-symbols": "^0.0.201",
         "sharp": "^0.33.5",
         "shiki": "^3.2.1",
         "sitemap": "^8.0.0",
@@ -2039,7 +2039,7 @@
 
     "scheduler": ["scheduler@0.26.0", "", {}, "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA=="],
 
-    "schematic-symbols": ["schematic-symbols@0.0.195", "", { "peerDependencies": { "typescript": "^5.5.4" } }, "sha512-mWmFTC832Cx+s8dSj6174IvlVuuHGBGExg/1qffCXdM+tQvj4quiGTCUsyPdy1oneZLpg6keDOHB6nF2xvDsMQ=="],
+    "schematic-symbols": ["schematic-symbols@0.0.201", "", { "peerDependencies": { "typescript": "^5.5.4" } }, "sha512-+VFXZQvPFdkWPTMhIk6C8tEEzisiJmWa7Nszj7ADN70Y0nn+A9/xkzqVAr1yZttUqu2m2buzqSklt7GYuS7OaA=="],
 
     "secure-json-parse": ["secure-json-parse@4.0.0", "", {}, "sha512-dxtLJO6sc35jWidmLxo7ij+Eg48PM/kleBsxpC8QJE0qJICe+KawkDQmvCMZUr9u7WKVHgMW6vy3fQ7zMiFZMA=="],
 

--- a/package.json
+++ b/package.json
@@ -166,7 +166,7 @@
     "redaxios": "^0.5.1",
     "remark-gfm": "^4.0.1",
     "rollup-plugin-visualizer": "^5.12.0",
-    "schematic-symbols": "^0.0.195",
+    "schematic-symbols": "^0.0.201",
     "sharp": "^0.33.5",
     "shiki": "^3.2.1",
     "sitemap": "^8.0.0",


### PR DESCRIPTION
## Summary
- update schematic-symbols to latest version

## Testing
- `BUN_UPDATE_SNAPSHOTS=1 bun test`
- `bunx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_b_68c5a976547c832e9f83caae56bb4ca5