### PR TITLE
refetches the latest editor content after saves.

### DIFF
--- a/src/hooks/useUpdatePackageFilesMutation.ts
+++ b/src/hooks/useUpdatePackageFilesMutation.ts
@@ -101,7 +101,9 @@ export function useUpdatePackageFilesMutation({
             const key = q.queryKey as any
             return (
               Array.isArray(key) &&
-              (key[0] === "packageFiles" || key[0] === "packageFile")
+              (key[0] === "packageFiles" ||
+                key[0] === "packageFile" ||
+                key[0] === "priorityPackageFile")
             )
           },
         })


### PR DESCRIPTION
After deleting the file, the backend shows the file is not present. I checked the network request, the `/list` endpoint doesn't show it there too in the file system. But I can see the file being there in the editor even after a full reload of page cause the cache aren't being invalidated


https://github.com/user-attachments/assets/933e2f84-b486-49e2-8623-025a67c7e1de

