### PR TITLE
feat: user sepcific  organization listing

### DIFF
--- a/fake-snippets-api/routes/api/orgs/list.ts
+++ b/fake-snippets-api/routes/api/orgs/list.ts
@@ -6,14 +6,19 @@ import { z } from "zod"
 export default withRouteSpec({
   methods: ["GET", "POST"],
   auth: "optional_session",
+  commonParams: z.object({
+    github_handle: z.string(),
+  }),
   jsonResponse: z.object({
     ok: z.boolean(),
     orgs: z.array(publicOrgSchema),
   }),
 })(async (req, ctx) => {
+  const { github_handle } = req.commonParams
   const orgs = ctx.db.getOrgs(
     {
       owner_account_id: ctx.auth?.account_id,
+      github_handle,
     },
     {
       account_id: ctx.auth?.account_id,

--- a/fake-snippets-api/routes/api/orgs/list.ts
+++ b/fake-snippets-api/routes/api/orgs/list.ts
@@ -7,7 +7,7 @@ export default withRouteSpec({
   methods: ["GET", "POST"],
   auth: "optional_session",
   commonParams: z.object({
-    github_handle: z.string(),
+    github_handle: z.string().optional(),
   }),
   jsonResponse: z.object({
     ok: z.boolean(),

--- a/src/hooks/use-list-user-orgs.ts
+++ b/src/hooks/use-list-user-orgs.ts
@@ -3,19 +3,23 @@ import { useAxios } from "@/hooks/use-axios"
 import type { PublicOrgSchema } from "fake-snippets-api/lib/db/schema"
 import { useGlobalStore } from "./use-global-store"
 
-export const useListUserOrgs = () => {
+export const useListUserOrgs = (githubHandle?: string) => {
   const axios = useAxios()
   const session = useGlobalStore((s) => s.session)
+  const github_handle = githubHandle || session?.github_username
+
   return useQuery<PublicOrgSchema[], Error & { status: number }>(
-    ["orgs", "list"],
+    ["orgs", "list", github_handle],
     async () => {
-      const { data } = await axios.get("/orgs/list")
+      const { data } = await axios.get("/orgs/list", {
+        ...(github_handle && { params: { github_handle } }),
+      })
       return data.orgs
     },
     {
       retry: false,
       refetchOnWindowFocus: false,
-      enabled: Boolean(session),
+      enabled: Boolean(github_handle),
     },
   )
 }

--- a/src/pages/organization-settings.tsx
+++ b/src/pages/organization-settings.tsx
@@ -147,7 +147,7 @@ export default function OrganizationSettingsPage() {
   }, [organization, form])
 
   if (!orgname) {
-    return <NotFoundPage heading="Organization Not Found" />
+    return <NotFoundPage />
   }
 
   if (isLoadingOrg) {

--- a/src/pages/user-profile.tsx
+++ b/src/pages/user-profile.tsx
@@ -32,7 +32,7 @@ import { OrganizationCard } from "@/components/organization/OrganizationCard"
 export const UserProfilePage = () => {
   const { username } = useParams()
   const axios = useAxios()
-  const { data: organizations } = useListUserOrgs()
+  const { data: organizations } = useListUserOrgs(username)
   const [searchQuery, setSearchQuery] = useState("")
   const [activeTab, setActiveTab] = useState("all")
   const [filter, setFilter] = useState("most-recent")


### PR DESCRIPTION
- Added `github_handle` as a common parameter in the organization listing API.
- Updated `useListUserOrgs` hook to accept an optional `githubHandle` parameter and adjusted API call accordingly.
- Modified the user profile page to pass the username as the `githubHandle` to `useListUserOrgs`.
- Simplified the NotFoundPage component usage in the organization settings page.