### PR TITLE
Update landing page header logo

### DIFF
--- a/src/components/Header2.tsx
+++ b/src/components/Header2.tsx
@@ -1,5 +1,5 @@
 import { Button } from "@/components/ui/button"
-import { CircuitBoard, Search, Menu, X } from "lucide-react"
+import { Search, Menu, X } from "lucide-react"
 import { Link } from "wouter"
 import { HeaderLogin } from "./HeaderLogin"
 import SearchComponent from "./SearchComponent"
@@ -59,9 +59,10 @@ export const Header2 = () => {
     <>
       <header className="sticky top-0 z-50 w-full border-b bg-white md:bg-white/80 md:backdrop-blur supports-[backdrop-filter]:md:bg-white/60">
         <div className="container mx-auto flex h-16 items-center justify-between px-2 md:px-6">
-          <Link href="/" className="flex select-none items-center gap-2">
-            <CircuitBoard className="h-6 w-6" />
-            <span className="text-lg font-bold">tscircuit</span>
+          <Link href="/" className="flex select-none items-center">
+            <span className="bg-blue-500 px-2 py-1 rounded-md text-white text-sm font-semibold sm:text-base">
+              tscircuit
+            </span>
           </Link>
 
           {/* Desktop Navigation */}


### PR DESCRIPTION
## Summary
- update the landing page header logo to match the blue pill style used elsewhere
- remove the unused CircuitBoard icon import from the header

## Testing
- bunx tsc --noEmit
- bun run format

------
https://chatgpt.com/codex/tasks/task_b_68d5848559ec832e9044710983255c75