### PR TITLE
Bump Easyeda Version to 0.0.228

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -93,7 +93,7 @@
         "codemirror-copilot": "^0.0.7",
         "dotenv": "^16.5.0",
         "dsn-converter": "^0.0.60",
-        "easyeda": "^0.0.227",
+        "easyeda": "^0.0.228",
         "embla-carousel-react": "^8.3.0",
         "extract-codefence": "^0.0.4",
         "fflate": "^0.8.2",
@@ -1238,7 +1238,7 @@
 
     "eastasianwidth": ["eastasianwidth@0.2.0", "", {}, "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="],
 
-    "easyeda": ["easyeda@0.0.227", "", { "peerDependencies": { "tscircuit": "^0.0.571", "typescript": "^5.5.2", "zod": "3" }, "bin": { "easyeda-converter": "dist/main.cjs", "easyeda": "dist/main.cjs" } }, "sha512-QSYHEqoK9VdaacKE+qzHn+f03g3pMfZmsyN/Wmd0ky9l8hRdvp4Hv2IiLhrW1JsDAnZs87TF/tPo1nuXWDQeGA=="],
+    "easyeda": ["easyeda@0.0.228", "", { "peerDependencies": { "tscircuit": "^0.0.571", "typescript": "^5.5.2", "zod": "3" }, "bin": { "easyeda-converter": "dist/main.cjs", "easyeda": "dist/main.cjs" } }, "sha512-rDzfAxcVL6qjYlBjBJpExDRt//TbzC4oD/NO4tcSBCYvkfASPqt7HeoUQUM83kV6bL0SpV+R4+0t34c6Y43wbQ=="],
 
     "edge-runtime": ["edge-runtime@2.5.10", "", { "dependencies": { "@edge-runtime/format": "2.2.1", "@edge-runtime/ponyfill": "2.4.2", "@edge-runtime/vm": "3.2.0", "async-listen": "3.0.1", "mri": "1.2.0", "picocolors": "1.0.0", "pretty-ms": "7.0.1", "signal-exit": "4.0.2", "time-span": "4.0.0" }, "bin": { "edge-runtime": "dist/cli/index.js" } }, "sha512-oe6JjFbU1MbISzeSBMHqmzBhNEwmy2AYDY0LxStl8FAIWSGdGO+CqzWub9nbgmANuJYPXZA0v3XAlbxeKV/Omw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -56,7 +56,7 @@
         "@tscircuit/mm": "^0.0.8",
         "@tscircuit/pcb-viewer": "^1.11.218",
         "@tscircuit/prompt-benchmarks": "^0.0.28",
-        "@tscircuit/runframe": "^0.0.1003",
+        "@tscircuit/runframe": "^0.0.1011",
         "@tscircuit/schematic-viewer": "^2.0.39",
         "@tscircuit/simple-3d-svg": "^0.0.41",
         "@types/babel__standalone": "^7.1.7",
@@ -780,7 +780,7 @@
 
     "@tscircuit/props": ["@tscircuit/props@0.0.327", "", { "peerDependencies": { "circuit-json": "*", "react": "*", "zod": "*" } }, "sha512-/a3i3SP1/lp2Gw/znEr86Mlgj0ei0/VTrmVm59C8AqAWe5yMcCt77ExCw5OwfOj1WXVp2UO6IhwVo2t+o7+XwQ=="],
 
-    "@tscircuit/runframe": ["@tscircuit/runframe@0.0.1003", "", {}, "sha512-uJ3HAlT9Oi2cL420SqeqnRI2+qCv3g2A+dej/ioeW0AR507Tju93tXT25XtMFOXvBpNdzf2Kvp6A8D+BvgIBGw=="],
+    "@tscircuit/runframe": ["@tscircuit/runframe@0.0.1011", "", {}, "sha512-FWAnG8l95jc4WypR3P37MycygNul/zyP8Ekjf/u89s2NvoxkDUet2FSuSKUE/9qvOVaLGJWSNspz8hlRkp3lpA=="],
 
     "@tscircuit/schematic-autolayout": ["@tscircuit/schematic-autolayout@0.0.6", "", { "dependencies": { "@tscircuit/soup-util": "^0.0.38", "transformation-matrix": "^2.16.1" } }, "sha512-34cQxtlSylBKyHkzaMBCynaWJgN9c/mWm7cz63StTYIafKmfFs383K8Xoc4QX8HXCvVrHYl1aK15onZua9MxeA=="],
 

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "codemirror-copilot": "^0.0.7",
     "dotenv": "^16.5.0",
     "dsn-converter": "^0.0.60",
-    "easyeda": "^0.0.227",
+    "easyeda": "^0.0.228",
     "embla-carousel-react": "^8.3.0",
     "extract-codefence": "^0.0.4",
     "fflate": "^0.8.2",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "@tscircuit/mm": "^0.0.8",
     "@tscircuit/pcb-viewer": "^1.11.218",
     "@tscircuit/prompt-benchmarks": "^0.0.28",
-    "@tscircuit/runframe": "^0.0.1003",
+    "@tscircuit/runframe": "^0.0.1011",
     "@tscircuit/schematic-viewer": "^2.0.39",
     "@tscircuit/simple-3d-svg": "^0.0.41",
     "@types/babel__standalone": "^7.1.7",


### PR DESCRIPTION
Bump Easyeda Version to add POLYGON pad support, to fix Bug with JLCPCB Part C2934569.

See [#easyeda-converter/324](https://github.com/tscircuit/easyeda-converter/issues/324)