### PR TITLE
fix release of `fake-snippets` package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tscircuit/fake-snippets",
-  "version": "0.0.98",
+  "version": "0.0.109",
   "type": "module",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Npm release failed for the last 10 workflows, but the git tags were created till 109