### PR TITLE
Fix settings link and redirect to user-specific settings page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -87,6 +87,9 @@ const ReleasePreviewPage = lazyImport(() => import("@/pages/preview-release"))
 const OrganizationSettingsPage = lazyImport(
   () => import("@/pages/organization-settings"),
 )
+const SettingsRedirectPage = lazyImport(
+  () => import("@/pages/settings-redirect"),
+)
 
 class ErrorBoundary extends React.Component<
   { children: React.ReactNode },
@@ -266,6 +269,9 @@ function App() {
 
             {/* Organization creation route */}
             <Route path="/orgs/new" component={CreateOrganizationPage} />
+
+            {/* User settings redirect */}
+            <Route path="/settings" component={SettingsRedirectPage} />
 
             {/* Organization settings route */}
             <Route

--- a/src/components/HeaderLogin.tsx
+++ b/src/components/HeaderLogin.tsx
@@ -71,7 +71,7 @@ export const HeaderLogin = () => {
         </DropdownMenuItem>
         <DropdownMenuItem asChild>
           <Link
-            href="/settings"
+            href={`/${session?.github_username}/settings`}
             className="cursor-pointer"
             onClick={() => setIsOpen(false)}
           >

--- a/src/pages/settings-redirect.tsx
+++ b/src/pages/settings-redirect.tsx
@@ -1,0 +1,44 @@
+import { useEffect, useState } from "react"
+import { Redirect } from "wouter"
+
+import { FullPageLoader } from "@/App"
+import { useGlobalStore } from "@/hooks/use-global-store"
+
+const SettingsRedirectPage = () => {
+  const session = useGlobalStore((state) => state.session)
+  const [hasHydrated, setHasHydrated] = useState(() => {
+    if (typeof window === "undefined") return false
+    return useGlobalStore.persist?.hasHydrated?.() ?? false
+  })
+
+  useEffect(() => {
+    if (typeof window === "undefined") return
+
+    if (useGlobalStore.persist?.hasHydrated?.()) {
+      setHasHydrated(true)
+      return
+    }
+
+    const unsubFinishHydration = useGlobalStore.persist?.onFinishHydration?.(
+      () => {
+        setHasHydrated(true)
+      },
+    )
+
+    return () => {
+      unsubFinishHydration?.()
+    }
+  }, [])
+
+  if (!hasHydrated) {
+    return <FullPageLoader />
+  }
+
+  if (!session?.github_username) {
+    return <Redirect to="/" />
+  }
+
+  return <Redirect to={`/${session.github_username}/settings`} />
+}
+
+export default SettingsRedirectPage


### PR DESCRIPTION
## Summary
- update the header settings link to go to the signed-in user's settings page
- add a dedicated redirect route so /settings forwards to /{username}/settings

## Testing
- bunx tsc --noEmit


------
https://chatgpt.com/codex/tasks/task_b_68e07e7cfd34832ebeb8ffe2c2546a0d