### PR TITLE
Fix: Correct `package_name_with_version` construction

### DIFF
--- a/src/components/dialogs/edit-package-details-dialog.tsx
+++ b/src/components/dialogs/edit-package-details-dialog.tsx
@@ -135,7 +135,7 @@ export const EditPackageDetailsDialog = ({
 
       const filesRes = await axios.get("/package_files/list", {
         params: {
-          package_name_with_version: `${packageAuthor}/${formData.unscopedPackageName}`,
+          package_name_with_version: `${packageAuthor}/${formData.unscopedPackageName}@latest`,
         },
       })
       const packageFiles: string[] =
@@ -150,13 +150,13 @@ export const EditPackageDetailsDialog = ({
       if (hasLicenseChanged) {
         if (packageFiles.includes("LICENSE") && !licenseContent) {
           await axios.post("/package_files/delete", {
-            package_name_with_version: `${packageAuthor}/${formData.unscopedPackageName}`,
+            package_name_with_version: `${packageAuthor}/${formData.unscopedPackageName}@latest`,
             file_path: "LICENSE",
           })
         }
         if (licenseContent) {
           await axios.post("/package_files/create_or_update", {
-            package_name_with_version: `${packageAuthor}/${formData.unscopedPackageName}`,
+            package_name_with_version: `${packageAuthor}/${formData.unscopedPackageName}@latest`,
             file_path: "LICENSE",
             content_text: licenseContent,
           })

--- a/src/hooks/useUpdatePackageFilesMutation.ts
+++ b/src/hooks/useUpdatePackageFilesMutation.ts
@@ -53,7 +53,7 @@ export function useUpdatePackageFilesMutation({
                 ?.package_file_id ?? null,
             content_text: file.content,
             file_path: file.path,
-            package_name_with_version: `${newPackage.name}`,
+            package_name_with_version: newPackage.package_name_with_version,
           }
           const response = await axios.post(
             "/package_files/create_or_update",
@@ -78,7 +78,7 @@ export function useUpdatePackageFilesMutation({
 
           if (fileToDelete?.package_file_id) {
             const response = await axios.post("/package_files/delete", {
-              package_name_with_version: `${newPackage.name}`,
+              package_name_with_version: newPackage.package_name_with_version,
               file_path: initialFile.path,
             })
 


### PR DESCRIPTION
/claim #1717 
/closes #1717 

## PR Description:

This PR fixes a bug where the `package_name_with_version` was being constructed incorrectly in `useUpdatePackageFilesMutation.ts` and `edit-package-details-dialog.tsx`. This caused issues with saving packages and managing package files. This PR corrects the construction of `package_name_with_version` in both files, ensuring that the API receives the correctly formatted package name and version.