### PR TITLE
fix: allow public organization pages to be visible without session

### DIFF
--- a/fake-snippets-api/routes/api/orgs/get.ts
+++ b/fake-snippets-api/routes/api/orgs/get.ts
@@ -9,7 +9,7 @@ export default withRouteSpec({
     .object({ org_id: z.string() })
     .or(z.object({ org_name: z.string() }))
     .or(z.object({ github_handle: z.string() })),
-  auth: "session",
+  auth: "optional_session",
   jsonResponse: z.object({
     org: publicOrgSchema,
   }),
@@ -20,13 +20,15 @@ export default withRouteSpec({
     github_handle?: string
   }
 
+  const auth = "auth" in ctx && ctx.auth ? ctx.auth : undefined
+
   const org = ctx.db.getOrg(
     {
       org_id: params.org_id,
       org_name: params.org_name,
       github_handle: params.github_handle,
     },
-    ctx.auth,
+    auth,
   )
 
   if (!org) {

--- a/src/hooks/use-org-by-github-handle.ts
+++ b/src/hooks/use-org-by-github-handle.ts
@@ -18,7 +18,7 @@ export const useOrgByGithubHandle = (githubHandle: string | null) => {
       return data.org
     },
     {
-      enabled: Boolean(githubHandle && session),
+      enabled: Boolean(githubHandle),
       retry: false,
       refetchOnWindowFocus: false,
     },


### PR DESCRIPTION
fix #1764 
/claim #1764

before:
<img width="1910" height="1020" alt="image" src="https://github.com/user-attachments/assets/9996447b-d79a-4b17-b44f-d92ac0881f5b" />


after:
<img width="1915" height="1017" alt="image" src="https://github.com/user-attachments/assets/605a132b-67b1-4589-9b6b-8839cc99f9a8" />
