### PR TITLE
Allow public org pages to be visible without session

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -80,7 +80,7 @@
         "circuit-json-to-bom-csv": "^0.0.7",
         "circuit-json-to-gerber": "^0.0.29",
         "circuit-json-to-gltf": "^0.0.14",
-        "circuit-json-to-kicad": "^0.0.6",
+        "circuit-json-to-kicad": "^0.0.9",
         "circuit-json-to-pnp-csv": "^0.0.7",
         "circuit-json-to-readable-netlist": "^0.0.13",
         "circuit-json-to-simple-3d": "^0.0.7",
@@ -1077,7 +1077,7 @@
 
     "circuit-json-to-gltf": ["circuit-json-to-gltf@0.0.14", "", { "peerDependencies": { "@resvg/resvg-js": "2", "@resvg/resvg-wasm": "2", "@tscircuit/circuit-json-util": "*", "circuit-json": "*", "circuit-to-svg": "*", "typescript": "^5" }, "optionalPeers": ["@resvg/resvg-wasm"] }, "sha512-z+O7vlCpe5zhmsbZXdvG73S0t4XDwXyvCe4q+imR7oMMCqMv4xhIqSyHdazYnHuHrA/taTTrGQwWrFtFr18dTA=="],
 
-    "circuit-json-to-kicad": ["circuit-json-to-kicad@0.0.6", "", { "peerDependencies": { "typescript": "^5" } }, "sha512-4X+lGJyBG6UWia+Sx7Z/tSUiXdjrMLfNlOmwwUnVpL7wuS5fm6lvlL5eJZJc7KBCFLmf6y5PT5J9sukcqVbSMQ=="],
+    "circuit-json-to-kicad": ["circuit-json-to-kicad@0.0.9", "", { "peerDependencies": { "typescript": "^5" } }, "sha512-TZYgvKNoCqIQnvE4NL4twgI1rIxvOU0YRzmK0mPvUbAW2yWLmsHO1Abr395XAh4ZR16q/eZyTxf/pr6vOc31tw=="],
 
     "circuit-json-to-pnp-csv": ["circuit-json-to-pnp-csv@0.0.7", "", { "dependencies": { "papaparse": "^5.4.1" }, "peerDependencies": { "@tscircuit/soup-util": "*", "typescript": "^5.0.0" } }, "sha512-WAdNRHtaPhQM8X5NN/43WMBKDCEKQSLShg/mHIZxMUzJviymnfbq6rJj/2WvDqm/bogey34PyTEHwF3mC7zxlQ=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -80,7 +80,7 @@
         "circuit-json-to-bom-csv": "^0.0.7",
         "circuit-json-to-gerber": "^0.0.29",
         "circuit-json-to-gltf": "^0.0.14",
-        "circuit-json-to-kicad": "^0.0.9",
+        "circuit-json-to-kicad": "^0.0.6",
         "circuit-json-to-pnp-csv": "^0.0.7",
         "circuit-json-to-readable-netlist": "^0.0.13",
         "circuit-json-to-simple-3d": "^0.0.7",
@@ -1077,7 +1077,7 @@
 
     "circuit-json-to-gltf": ["circuit-json-to-gltf@0.0.14", "", { "peerDependencies": { "@resvg/resvg-js": "2", "@resvg/resvg-wasm": "2", "@tscircuit/circuit-json-util": "*", "circuit-json": "*", "circuit-to-svg": "*", "typescript": "^5" }, "optionalPeers": ["@resvg/resvg-wasm"] }, "sha512-z+O7vlCpe5zhmsbZXdvG73S0t4XDwXyvCe4q+imR7oMMCqMv4xhIqSyHdazYnHuHrA/taTTrGQwWrFtFr18dTA=="],
 
-    "circuit-json-to-kicad": ["circuit-json-to-kicad@0.0.9", "", { "peerDependencies": { "typescript": "^5" } }, "sha512-TZYgvKNoCqIQnvE4NL4twgI1rIxvOU0YRzmK0mPvUbAW2yWLmsHO1Abr395XAh4ZR16q/eZyTxf/pr6vOc31tw=="],
+    "circuit-json-to-kicad": ["circuit-json-to-kicad@0.0.6", "", { "peerDependencies": { "typescript": "^5" } }, "sha512-4X+lGJyBG6UWia+Sx7Z/tSUiXdjrMLfNlOmwwUnVpL7wuS5fm6lvlL5eJZJc7KBCFLmf6y5PT5J9sukcqVbSMQ=="],
 
     "circuit-json-to-pnp-csv": ["circuit-json-to-pnp-csv@0.0.7", "", { "dependencies": { "papaparse": "^5.4.1" }, "peerDependencies": { "@tscircuit/soup-util": "*", "typescript": "^5.0.0" } }, "sha512-WAdNRHtaPhQM8X5NN/43WMBKDCEKQSLShg/mHIZxMUzJviymnfbq6rJj/2WvDqm/bogey34PyTEHwF3mC7zxlQ=="],
 

--- a/fake-snippets-api/routes/api/orgs/get.ts
+++ b/fake-snippets-api/routes/api/orgs/get.ts
@@ -9,7 +9,7 @@ export default withRouteSpec({
     .object({ org_id: z.string() })
     .or(z.object({ org_name: z.string() }))
     .or(z.object({ github_handle: z.string() })),
-  auth: "session",
+  auth: "optional_session",
   jsonResponse: z.object({
     org: publicOrgSchema,
   }),

--- a/fake-snippets-api/routes/api/orgs/list_members.ts
+++ b/fake-snippets-api/routes/api/orgs/list_members.ts
@@ -35,13 +35,6 @@ export default withRouteSpec({
     })
   }
 
-  if (!org.can_manage_org) {
-    return ctx.error(403, {
-      error_code: "not_authorized",
-      message: "You do not have permission to manage this organization",
-    })
-  }
-
   const members = ctx.db.orgAccounts
     .map((m) => {
       if (m.org_id == org.org_id) return ctx.db.getAccount(m.account_id)

--- a/fake-snippets-api/routes/api/orgs/list_members.ts
+++ b/fake-snippets-api/routes/api/orgs/list_members.ts
@@ -13,7 +13,7 @@ export default withRouteSpec({
         name: z.string(),
       }),
     ),
-  auth: "session",
+  auth: "optional_session",
   jsonResponse: z.object({
     members: z.array(accountSchema),
   }),

--- a/src/hooks/use-org-by-github-handle.ts
+++ b/src/hooks/use-org-by-github-handle.ts
@@ -18,7 +18,7 @@ export const useOrgByGithubHandle = (githubHandle: string | null) => {
       return data.org
     },
     {
-      enabled: Boolean(githubHandle && session),
+      enabled: Boolean(githubHandle),
       retry: false,
       refetchOnWindowFocus: false,
     },


### PR DESCRIPTION
## Summary

Fix org visibility issue where public org pages are not accessible for unauthenticated users. This PR updates the API routes to use optional auth instead and remove session req. from the org hook.

Fixes #1764
/claim #1764