### PR TITLE
Update UI package links to use package.name

### DIFF
--- a/bun-tests/fake-snippets-api/routes/packages/list_latest.test.ts
+++ b/bun-tests/fake-snippets-api/routes/packages/list_latest.test.ts
@@ -7,7 +7,7 @@ test("list latest packages", async () => {
   // Add some test packages
   const packages = [
     {
-      name: "Package1",
+      name: "user1/Package1",
       unscoped_name: "Package1",
       owner_github_username: "user1",
       creator_account_id: "creator1",
@@ -23,7 +23,7 @@ test("list latest packages", async () => {
       is_snippet: false,
     },
     {
-      name: "Package2",
+      name: "user2/Package2",
       unscoped_name: "Package2",
       owner_github_username: "user2",
       creator_account_id: "creator2",
@@ -39,7 +39,7 @@ test("list latest packages", async () => {
       is_snippet: false,
     },
     {
-      name: "Package3",
+      name: "user3/Package3",
       unscoped_name: "Package3",
       owner_github_username: "user3",
       creator_account_id: "creator3",
@@ -56,7 +56,7 @@ test("list latest packages", async () => {
     },
     // Add a snippet to verify it's filtered out
     {
-      name: "Snippet1",
+      name: "user4/Snippet1",
       unscoped_name: "Snippet1",
       owner_github_username: "user4",
       creator_account_id: "creator4",

--- a/src/components/CmdKMenu.tsx
+++ b/src/components/CmdKMenu.tsx
@@ -372,7 +372,7 @@ const CmdKMenu = () => {
       switch (type) {
         case "package":
         case "recent":
-          window.location.href = `/${item.owner_github_username}/${item.unscoped_name}`
+          window.location.href = `/${item.name}`
           setOpen(false)
           break
         case "account":

--- a/src/components/PackageCard.tsx
+++ b/src/components/PackageCard.tsx
@@ -67,7 +67,7 @@ export const PackageCard: React.FC<PackageCardProps> = ({
 
   const handleShareClick = (e: React.MouseEvent) => {
     e.preventDefault()
-    const shareUrl = `${window.location.origin}/${pkg.owner_github_username}/${pkg.unscoped_name}`
+    const shareUrl = `${window.location.origin}/${pkg.name}`
     copyToClipboard(shareUrl)
   }
 
@@ -178,10 +178,7 @@ export const PackageCard: React.FC<PackageCardProps> = ({
 
   if (withLink) {
     return (
-      <Link
-        key={pkg.package_id}
-        href={`/${pkg.owner_github_username}/${pkg.unscoped_name}`}
-      >
+      <Link key={pkg.package_id} href={`/${pkg.name}`}>
         {cardContent}
       </Link>
     )

--- a/src/components/PackagesList.tsx
+++ b/src/components/PackagesList.tsx
@@ -50,10 +50,10 @@ export const PackagesList = ({
             <li key={pkg.package_id}>
               <div className="flex items-center">
                 <Link
-                  href={`/${pkg.owner_github_username}/${pkg.unscoped_name}`}
+                  href={`/${pkg.name}`}
                   className="text-blue-600 hover:underline text-sm"
                 >
-                  {pkg.owner_github_username}/{pkg.unscoped_name}
+                  {pkg.name}
                 </Link>
                 {pkg.star_count > 0 && (
                   <span className="ml-2 text-gray-500 text-xs flex items-center">

--- a/src/components/TrendingPackagesCarousel.tsx
+++ b/src/components/TrendingPackagesCarousel.tsx
@@ -11,10 +11,10 @@ const CarouselItem = ({
   apiBaseUrl,
 }: { pkg: Package; apiBaseUrl: string }) => {
   return (
-    <Link href={`/${pkg.owner_github_username}/${pkg.unscoped_name}`}>
+    <Link href={`/${pkg.name}`}>
       <div className="flex-shrink-0 w-[200px] bg-white p-3 py-2 rounded-lg shadow-sm border border-gray-200 hover:border-gray-300 transition-colors">
         <div className="font-medium text-blue-600 mb-1 truncate text-sm">
-          {pkg.owner_github_username}/{pkg.unscoped_name}
+          {pkg.name}
         </div>
         <div className="mb-2 h-24 w-full bg-black rounded overflow-hidden">
           <img

--- a/src/components/ViewPackagePage/components/sidebar-releases-section.tsx
+++ b/src/components/ViewPackagePage/components/sidebar-releases-section.tsx
@@ -81,7 +81,7 @@ export default function SidebarReleasesSection() {
     <div className="mb-6">
       <h2 className="text-lg font-semibold mb-2">
         <Link
-          href={`/${packageInfo?.owner_github_username}/${packageInfo?.unscoped_name}/releases`}
+          href={`/${packageInfo?.name}/releases`}
           className="hover:underline"
         >
           Releases
@@ -89,7 +89,7 @@ export default function SidebarReleasesSection() {
       </h2>
       <div className="flex flex-col space-y-2">
         <Link
-          href={`/${packageInfo?.owner_github_username}/${packageInfo?.unscoped_name}/releases`}
+          href={`/${packageInfo?.name}/releases`}
           className="flex items-center hover:underline"
         >
           <Tag className="h-4 w-4 mr-2 text-gray-500 dark:text-[#8b949e]" />

--- a/src/components/preview/ConnectedPackagesList.tsx
+++ b/src/components/preview/ConnectedPackagesList.tsx
@@ -117,7 +117,7 @@ export const ConnectedPackageCard = ({
       <div className="flex items-start justify-between mb-4">
         <div className="flex items-center gap-3">
           <Link
-            href={`/${pkg.owner_github_username}/${pkg.unscoped_name}`}
+            href={`/${pkg.name}`}
             className="text-lg font-semibold text-gray-900 hover:text-blue-600 transition-colors"
           >
             {pkg.unscoped_name}

--- a/src/pages/editor.tsx
+++ b/src/pages/editor.tsx
@@ -7,9 +7,7 @@ import { useCurrentPackageInfo } from "@/hooks/use-current-package-info"
 export const EditorPage = () => {
   const { packageInfo: pkg, error } = useCurrentPackageInfo()
 
-  const projectUrl = pkg
-    ? `https://tscircuit.com/${pkg.owner_github_username}/${pkg.unscoped_name}`
-    : undefined
+  const projectUrl = pkg ? `https://tscircuit.com/${pkg.name}` : undefined
 
   return (
     <div className="overflow-x-hidden">


### PR DESCRIPTION
`/${item.owner_github_username}/${item.unscoped_name}` doesn't always match package name which is used in /packages/get leading to 404 errors. Example:

```
"owner_github_username": "ArnavK-09",
"unscoped_name": "232323",
"name": "imrishab18/232323", // !== ArnavK-09/232323
```