### PR TITLE
Mark new packages ready to build after initial upload

### DIFF
--- a/src/hooks/useUpdatePackageFilesMutation.ts
+++ b/src/hooks/useUpdatePackageFilesMutation.ts
@@ -88,6 +88,14 @@ export function useUpdatePackageFilesMutation({
           }
         }
       }
+
+      if (!currentPackage) {
+        await axios.post("/package_releases/update", {
+          package_name_with_version: newPackage.package_name_with_version,
+          ready_to_build: true,
+        })
+      }
+
       return updatedFilesCount
     },
     onSuccess: (updatedFilesCount) => {


### PR DESCRIPTION
## Summary
- mark the initial package release as ready_to_build once files are uploaded for a new package

## Testing
- bunx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_b_68f6a389efe8832e8f27a0bba70a12f8