### PR TITLE
Use preview image URLs for package visuals

### DIFF
--- a/src/components/SearchComponent.tsx
+++ b/src/components/SearchComponent.tsx
@@ -4,7 +4,6 @@ import { useLocation } from "wouter"
 import React, { useEffect, useRef, useState } from "react"
 import { useQuery } from "react-query"
 import { Alert } from "./ui/alert"
-import { useApiBaseUrl } from "@/hooks/use-packages-base-api-url"
 import { Link } from "wouter"
 import { CircuitBoard } from "lucide-react"
 import { cn } from "@/lib/utils"
@@ -60,7 +59,6 @@ const SearchComponent: React.FC<SearchComponentProps> = ({
   const resultsRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLInputElement>(null)
   const [location, setLocation] = useLocation()
-  const apiBaseUrl = useApiBaseUrl()
 
   const { data: searchResults, isLoading } = useQuery(
     ["packageSearch", searchQuery],
@@ -202,60 +200,73 @@ const SearchComponent: React.FC<SearchComponentProps> = ({
         >
           {searchResults.length > 0 ? (
             <ul className="divide-y divide-gray-200 no-scrollbar">
-              {searchResults.map((pkg: any, index: number) => (
-                <li
-                  key={pkg.package_id}
-                  className={cn(
-                    "p-2 hover:bg-gray-50",
-                    index === highlightedIndex && "bg-gray-100",
-                  )}
-                >
-                  <LinkWithNewTabHandling
-                    href={
-                      shouldOpenInEditor
-                        ? `/editor?package_id=${pkg.package_id}`
-                        : `/${pkg.name}`
-                    }
-                    shouldOpenInNewTab={shouldOpenInNewTab}
-                    className="flex"
-                    onClick={() => {
-                      setShowResults(false)
-                      if (closeOnClick) closeOnClick()
-                    }}
+              {searchResults.map((pkg: any, index: number) => {
+                const previewImageUrl =
+                  pkg.latest_pcb_preview_image_url ??
+                  pkg.latest_cad_preview_image_url ??
+                  pkg.latest_sch_preview_image_url ??
+                  undefined
+                const hasPreviewImage = Boolean(previewImageUrl)
+
+                return (
+                  <li
+                    key={pkg.package_id}
+                    className={cn(
+                      "p-2 hover:bg-gray-50",
+                      index === highlightedIndex && "bg-gray-100",
+                    )}
                   >
-                    <div className="w-12 h-12 overflow-hidden mr-2 flex-shrink-0 rounded-sm bg-gray-50 border flex items-center justify-center">
-                      <img
-                        src={`${apiBaseUrl}/packages/images/${pkg.name}/pcb.svg`}
-                        alt={`PCB preview for ${pkg.name}`}
-                        draggable={false}
-                        className="w-12 h-12 object-contain p-1 scale-[4] rotate-45"
-                        onError={(e) => {
-                          e.currentTarget.style.display = "none"
-                          e.currentTarget.nextElementSibling?.classList.remove(
-                            "hidden",
-                          )
-                          e.currentTarget.nextElementSibling?.classList.add(
-                            "flex",
-                          )
-                        }}
-                      />
-                      <div className="w-12 h-12 hidden items-center justify-center">
-                        <CircuitBoard className="w-6 h-6 text-gray-300" />
-                      </div>
-                    </div>
-                    <div className="flex-grow">
-                      <div className="font-medium text-blue-600 break-words text-xs">
-                        {pkg.name}
-                      </div>
-                      {pkg.description && (
-                        <div className="text-xs text-gray-500 break-words h-8 overflow-hidden">
-                          {pkg.description}
+                    <LinkWithNewTabHandling
+                      href={
+                        shouldOpenInEditor
+                          ? `/editor?package_id=${pkg.package_id}`
+                          : `/${pkg.name}`
+                      }
+                      shouldOpenInNewTab={shouldOpenInNewTab}
+                      className="flex"
+                      onClick={() => {
+                        setShowResults(false)
+                        if (closeOnClick) closeOnClick()
+                      }}
+                    >
+                      <div className="w-12 h-12 overflow-hidden mr-2 flex-shrink-0 rounded-sm bg-gray-50 border flex items-center justify-center">
+                        {hasPreviewImage ? (
+                          <img
+                            src={previewImageUrl}
+                            alt={`PCB preview for ${pkg.name}`}
+                            draggable={false}
+                            className="w-12 h-12 object-contain p-1 scale-[4] rotate-45"
+                            onError={(e) => {
+                              e.currentTarget.style.display = "none"
+                              e.currentTarget.nextElementSibling?.classList.remove(
+                                "hidden",
+                              )
+                              e.currentTarget.nextElementSibling?.classList.add(
+                                "flex",
+                              )
+                            }}
+                          />
+                        ) : null}
+                        <div
+                          className={`w-12 h-12 ${hasPreviewImage ? "hidden" : "flex"} items-center justify-center`}
+                        >
+                          <CircuitBoard className="w-6 h-6 text-gray-300" />
                         </div>
-                      )}
-                    </div>
-                  </LinkWithNewTabHandling>
-                </li>
-              ))}
+                      </div>
+                      <div className="flex-grow">
+                        <div className="font-medium text-blue-600 break-words text-xs">
+                          {pkg.name}
+                        </div>
+                        {pkg.description && (
+                          <div className="text-xs text-gray-500 break-words h-8 overflow-hidden">
+                            {pkg.description}
+                          </div>
+                        )}
+                      </div>
+                    </LinkWithNewTabHandling>
+                  </li>
+                )
+              })}
             </ul>
           ) : (
             <Alert variant="default" className="p-4 text-center">

--- a/src/components/TrendingPackagesCarousel.tsx
+++ b/src/components/TrendingPackagesCarousel.tsx
@@ -3,13 +3,14 @@ import { useAxios } from "@/hooks/use-axios"
 import { StarFilledIcon } from "@radix-ui/react-icons"
 import { Link } from "wouter"
 import { Package } from "fake-snippets-api/lib/db/schema"
-import { useRef, useState } from "react"
-import { useApiBaseUrl } from "@/hooks/use-packages-base-api-url"
+import { useRef } from "react"
+const CarouselItem = ({ pkg }: { pkg: Package }) => {
+  const previewImageUrl =
+    pkg.latest_pcb_preview_image_url ??
+    pkg.latest_cad_preview_image_url ??
+    pkg.latest_sch_preview_image_url ??
+    undefined
 
-const CarouselItem = ({
-  pkg,
-  apiBaseUrl,
-}: { pkg: Package; apiBaseUrl: string }) => {
   return (
     <Link href={`/${pkg.name}`}>
       <div className="flex-shrink-0 w-[200px] bg-white p-3 py-2 rounded-lg shadow-sm border border-gray-200 hover:border-gray-300 transition-colors">
@@ -17,11 +18,13 @@ const CarouselItem = ({
           {pkg.name}
         </div>
         <div className="mb-2 h-24 w-full bg-black rounded overflow-hidden">
-          <img
-            src={`${apiBaseUrl}/packages/images/${pkg.owner_github_username}/${pkg.unscoped_name}/pcb.svg?fs_map=${pkg.latest_package_release_fs_sha}`}
-            alt="PCB preview"
-            className="w-full h-full object-contain p-2 scale-[3] rotate-45 hover:scale-[3.5] transition-transform"
-          />
+          {previewImageUrl ? (
+            <img
+              src={previewImageUrl}
+              alt="PCB preview"
+              className="w-full h-full object-contain p-2 scale-[3] rotate-45 hover:scale-[3.5] transition-transform"
+            />
+          ) : null}
         </div>
         <div className="flex items-center text-xs text-gray-500">
           <StarFilledIcon className="w-3 h-3 mr-1" />
@@ -35,8 +38,6 @@ const CarouselItem = ({
 export const TrendingPackagesCarousel = () => {
   const axios = useAxios()
   const scrollRef = useRef<HTMLDivElement>(null)
-  const [isHovered, setIsHovered] = useState(false)
-  const apiBaseUrl = useApiBaseUrl()
 
   const { data: trendingPackages } = useQuery<Package[]>(
     "trendingPackages",
@@ -59,22 +60,14 @@ export const TrendingPackagesCarousel = () => {
           <div className="container mx-auto px-4">
             <h2 className="text-2xl font-semibold mb-6">Trending Packages</h2>
           </div>
-          <div
-            className="flex gap-6 overflow-x-hidden relative"
-            onMouseEnter={() => setIsHovered(true)}
-            onMouseLeave={() => setIsHovered(false)}
-          >
+          <div className="flex gap-6 overflow-x-hidden relative">
             <div
               ref={scrollRef}
               className="flex gap-6 transition-transform duration-1000 animate-carousel-left"
             >
               {[...(trendingPackages ?? []), ...(trendingPackages ?? [])].map(
                 (pkg, i) => (
-                  <CarouselItem
-                    key={`${pkg.package_id}-${i}`}
-                    pkg={pkg}
-                    apiBaseUrl={apiBaseUrl}
-                  />
+                  <CarouselItem key={`${pkg.package_id}-${i}`} pkg={pkg} />
                 ),
               )}
             </div>

--- a/src/components/ViewPackagePage/components/mobile-sidebar.tsx
+++ b/src/components/ViewPackagePage/components/mobile-sidebar.tsx
@@ -85,8 +85,9 @@ const MobileSidebar = ({
   })
 
   const { availableViews: pngViews } = usePreviewImages({
-    packageName: packageInfo?.name,
-    fsMapHash: packageInfo?.latest_package_release_fs_sha ?? "",
+    cadPreviewUrl: packageInfo?.latest_cad_preview_image_url,
+    pcbPreviewUrl: packageInfo?.latest_pcb_preview_image_url,
+    schematicPreviewUrl: packageInfo?.latest_sch_preview_image_url,
   })
 
   const viewsToRender =

--- a/src/components/ViewPackagePage/components/preview-image-squares.tsx
+++ b/src/components/ViewPackagePage/components/preview-image-squares.tsx
@@ -4,7 +4,9 @@ import type { Package } from "fake-snippets-api/lib/db/schema"
 interface ViewPlaceholdersProps {
   packageInfo?: Pick<
     Package,
-    "name" | "latest_package_release_fs_sha" | "latest_package_release_id"
+    | "latest_cad_preview_image_url"
+    | "latest_pcb_preview_image_url"
+    | "latest_sch_preview_image_url"
   >
   onViewChange?: (view: "3d" | "pcb" | "schematic") => void
 }
@@ -14,8 +16,9 @@ export default function PreviewImageSquares({
   onViewChange,
 }: ViewPlaceholdersProps) {
   const { availableViews } = usePreviewImages({
-    packageName: packageInfo?.name,
-    fsMapHash: packageInfo?.latest_package_release_fs_sha ?? "",
+    cadPreviewUrl: packageInfo?.latest_cad_preview_image_url,
+    pcbPreviewUrl: packageInfo?.latest_pcb_preview_image_url,
+    schematicPreviewUrl: packageInfo?.latest_sch_preview_image_url,
   })
   const handleViewClick = (viewId: string) => {
     onViewChange?.(viewId as "3d" | "pcb" | "schematic")

--- a/src/hooks/use-preview-images.ts
+++ b/src/hooks/use-preview-images.ts
@@ -1,46 +1,50 @@
-import { useState } from "react"
+import { useEffect, useState } from "react"
 
 interface UsePreviewImagesProps {
-  packageName?: string
-  fsMapHash?: string
+  cadPreviewUrl?: string | null
+  pcbPreviewUrl?: string | null
+  schematicPreviewUrl?: string | null
 }
 
 export function usePreviewImages({
-  packageName,
-  fsMapHash,
+  cadPreviewUrl,
+  pcbPreviewUrl,
+  schematicPreviewUrl,
 }: UsePreviewImagesProps) {
   const [imageStatus, setImageStatus] = useState<
     Record<string, "loading" | "loaded" | "error">
   >({
-    "3d": "loading",
-    pcb: "loading",
-    schematic: "loading",
+    "3d": cadPreviewUrl ? "loading" : "error",
+    pcb: pcbPreviewUrl ? "loading" : "error",
+    schematic: schematicPreviewUrl ? "loading" : "error",
   })
+
+  useEffect(() => {
+    setImageStatus({
+      "3d": cadPreviewUrl ? "loading" : "error",
+      pcb: pcbPreviewUrl ? "loading" : "error",
+      schematic: schematicPreviewUrl ? "loading" : "error",
+    })
+  }, [cadPreviewUrl, pcbPreviewUrl, schematicPreviewUrl])
 
   const views = [
     {
       id: "3d",
       label: "3D View",
       backgroundClass: "bg-gray-100",
-      imageUrl: packageName
-        ? `https://api.tscircuit.com/packages/images/${packageName}/3d.png?fs_sha=${fsMapHash}`
-        : undefined,
+      imageUrl: cadPreviewUrl ?? undefined,
     },
     {
       id: "pcb",
       label: "PCB View",
       backgroundClass: "bg-black",
-      imageUrl: packageName
-        ? `https://api.tscircuit.com/packages/images/${packageName}/pcb.png?fs_sha=${fsMapHash}`
-        : undefined,
+      imageUrl: pcbPreviewUrl ?? undefined,
     },
     {
       id: "schematic",
       label: "Schematic View",
       backgroundClass: "bg-[#F5F1ED]",
-      imageUrl: packageName
-        ? `https://api.tscircuit.com/packages/images/${packageName}/schematic.png?fs_sha=${fsMapHash}`
-        : undefined,
+      imageUrl: schematicPreviewUrl ?? undefined,
     },
   ]
 
@@ -59,6 +63,7 @@ export function usePreviewImages({
   }
 
   const availableViews = views
+    .filter((view) => Boolean(view.imageUrl))
     .map((view) => ({
       ...view,
       status: imageStatus[view.id],

--- a/src/pages/editor.tsx
+++ b/src/pages/editor.tsx
@@ -8,6 +8,11 @@ export const EditorPage = () => {
   const { packageInfo: pkg, error } = useCurrentPackageInfo()
 
   const projectUrl = pkg ? `https://tscircuit.com/${pkg.name}` : undefined
+  const previewImageUrl =
+    pkg?.latest_pcb_preview_image_url ??
+    pkg?.latest_sch_preview_image_url ??
+    pkg?.latest_cad_preview_image_url ??
+    undefined
 
   return (
     <div className="overflow-x-hidden">
@@ -21,15 +26,13 @@ export const EditorPage = () => {
               property="og:title"
               content={`${pkg.unscoped_name} - tscircuit`}
             />
-            <meta
-              property="og:image"
-              content={`https://api.tscircuit.com/packages/images/${pkg.owner_github_username}/${pkg.unscoped_name}/pcb.png?fs_sha=${pkg.latest_package_release_fs_sha}`}
-            />
-            <meta name="twitter:card" content="summary_large_image" />
-            <meta
-              name="twitter:image"
-              content={`https://api.tscircuit.com/packages/images/${pkg.owner_github_username}/${pkg.unscoped_name}/pcb.png?fs_sha=${pkg.latest_package_release_fs_sha}`}
-            />
+            {previewImageUrl && (
+              <>
+                <meta property="og:image" content={previewImageUrl} />
+                <meta name="twitter:card" content="summary_large_image" />
+                <meta name="twitter:image" content={previewImageUrl} />
+              </>
+            )}
           </>
         )}
       </Helmet>

--- a/src/pages/package-editor.tsx
+++ b/src/pages/package-editor.tsx
@@ -12,6 +12,12 @@ export const EditorPage = () => {
     /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$/,
   )
 
+  const previewImageUrl =
+    pkg?.latest_pcb_preview_image_url ??
+    pkg?.latest_sch_preview_image_url ??
+    pkg?.latest_cad_preview_image_url ??
+    undefined
+
   return (
     <div className="flex flex-col h-screen overflow-x-hidden">
       <Helmet>
@@ -22,15 +28,13 @@ export const EditorPage = () => {
               property="og:title"
               content={`${pkg.unscoped_name} - tscircuit`}
             />
-            <meta
-              property="og:image"
-              content={`https://api.tscircuit.com/packages/images/${pkg.owner_github_username}/${pkg.unscoped_name}/pcb.png?fs_sha=${pkg.latest_package_release_fs_sha}`}
-            />
-            <meta name="twitter:card" content="summary_large_image" />
-            <meta
-              name="twitter:image"
-              content={`https://api.tscircuit.com/packages/images/${pkg.owner_github_username}/${pkg.unscoped_name}/pcb.png?fs_sha=${pkg.latest_package_release_fs_sha}`}
-            />
+            {previewImageUrl && (
+              <>
+                <meta property="og:image" content={previewImageUrl} />
+                <meta name="twitter:card" content="summary_large_image" />
+                <meta name="twitter:image" content={previewImageUrl} />
+              </>
+            )}
           </>
         )}
       </Helmet>


### PR DESCRIPTION
## Summary
- replace deprecated package image endpoints with preview image URLs across package previews
- update shared preview hook and related components to consume the new preview fields
- ensure editor pages and discovery surfaces render social cards and thumbnails from stored preview URLs

## Testing
- bunx tsc --noEmit
- bun run format

------
https://chatgpt.com/codex/tasks/task_b_68f7b3009e50832eae2006b305196843