### PR TITLE
feat: add bug report endpoints to fake snippets api

### DIFF
--- a/bun-tests/fake-snippets-api/routes/bug_reports/create.test.ts
+++ b/bun-tests/fake-snippets-api/routes/bug_reports/create.test.ts
@@ -1,0 +1,37 @@
+import { getTestServer } from "bun-tests/fake-snippets-api/fixtures/get-test-server"
+import { expect, test } from "bun:test"
+
+test("create bug report with defaults", async () => {
+  const { axios, db, seed } = await getTestServer()
+
+  const response = await axios.post("/api/bug_reports/create", {})
+
+  expect(response.status).toBe(200)
+  const bugReport = response.data.bug_report
+  expect(bugReport).toBeDefined()
+  expect(bugReport.reporter_account_id).toBe(seed.account.account_id)
+  expect(bugReport.text).toBeNull()
+  expect(bugReport.is_auto_deleted).toBe(false)
+  expect(bugReport.delete_at).toBeNull()
+  expect(bugReport.file_count).toBe(0)
+
+  const stored = db.getBugReportById(bugReport.bug_report_id)
+  expect(stored).toBeDefined()
+  expect(stored?.bug_report_id).toBe(bugReport.bug_report_id)
+})
+
+test("requires delete_at when auto deletion is enabled", async () => {
+  const { axios } = await getTestServer()
+
+  try {
+    await axios.post("/api/bug_reports/create", {
+      is_auto_deleted: true,
+    })
+    throw new Error("Expected request to fail")
+  } catch (error: any) {
+    expect(error.status).toBe(400)
+    expect(error.data.message).toContain(
+      "delete_at is required when is_auto_deleted is true",
+    )
+  }
+})

--- a/bun-tests/fake-snippets-api/routes/bug_reports/upload_file.test.ts
+++ b/bun-tests/fake-snippets-api/routes/bug_reports/upload_file.test.ts
@@ -1,0 +1,89 @@
+import { Buffer } from "node:buffer"
+import { randomUUID } from "node:crypto"
+import { getTestServer } from "bun-tests/fake-snippets-api/fixtures/get-test-server"
+import { expect, test } from "bun:test"
+
+const sampleBase64 = Buffer.from("binary-data").toString("base64")
+
+test("upload text file to bug report", async () => {
+  const { axios, db } = await getTestServer()
+
+  const createResponse = await axios.post("/api/bug_reports/create", {
+    text: "Initial report",
+  })
+  const bugReportId = createResponse.data.bug_report.bug_report_id
+
+  const uploadResponse = await axios.post("/api/bug_reports/upload_file", {
+    bug_report_id: bugReportId,
+    file_path: "./src//issue.txt",
+    content_text: "Steps to reproduce",
+  })
+
+  expect(uploadResponse.status).toBe(200)
+  expect(uploadResponse.data.bug_report_file.file_path).toBe("src/issue.txt")
+  expect(uploadResponse.data.bug_report_file.is_text).toBe(true)
+
+  const storedReport = db.getBugReportById(bugReportId)
+  expect(storedReport?.file_count).toBe(1)
+
+  const storedFiles = db.getBugReportFilesByBugReportId(bugReportId)
+  expect(storedFiles).toHaveLength(1)
+  expect(storedFiles[0].content_text).toBe("Steps to reproduce")
+})
+
+test("upload binary file requires ownership", async () => {
+  const { axios, jane_axios } = await getTestServer()
+
+  const createResponse = await axios.post("/api/bug_reports/create", {
+    text: "Owned by primary account",
+  })
+  const bugReportId = createResponse.data.bug_report.bug_report_id
+
+  try {
+    await jane_axios.post("/api/bug_reports/upload_file", {
+      bug_report_id: bugReportId,
+      file_path: "attachments/data.bin",
+      content_base64: sampleBase64,
+    })
+    throw new Error("Expected request to fail")
+  } catch (error: any) {
+    expect(error.status).toBe(403)
+    expect(error.data.error.error_code).toBe("bug_report_forbidden")
+  }
+})
+
+test("cannot supply both text and base64 content", async () => {
+  const { axios } = await getTestServer()
+
+  const createResponse = await axios.post("/api/bug_reports/create", {
+    text: "Initial",
+  })
+  const bugReportId = createResponse.data.bug_report.bug_report_id
+
+  try {
+    await axios.post("/api/bug_reports/upload_file", {
+      bug_report_id: bugReportId,
+      file_path: "details.txt",
+      content_text: "foo",
+      content_base64: sampleBase64,
+    })
+    throw new Error("Expected request to fail")
+  } catch (error: any) {
+    expect(error.status).toBe(400)
+  }
+})
+
+test("uploading to unknown bug report returns 404", async () => {
+  const { axios } = await getTestServer()
+
+  try {
+    await axios.post("/api/bug_reports/upload_file", {
+      bug_report_id: randomUUID(),
+      file_path: "missing.txt",
+    })
+    throw new Error("Expected request to fail")
+  } catch (error: any) {
+    expect(error.status).toBe(404)
+    expect(error.data.error.error_code).toBe("bug_report_not_found")
+  }
+})

--- a/fake-snippets-api/lib/db/schema.ts
+++ b/fake-snippets-api/lib/db/schema.ts
@@ -103,6 +103,33 @@ export const orderFileSchema = z.object({
 })
 export type OrderFile = z.infer<typeof orderFileSchema>
 
+export const bugReportSchema = z.object({
+  bug_report_id: z.string().uuid(),
+  reporter_account_id: z.string(),
+  text: z.string().nullable(),
+  is_auto_deleted: z.boolean().default(false),
+  delete_at: z.string().datetime().nullable(),
+  created_at: z.string().datetime(),
+  file_count: z.number().int(),
+})
+export type BugReport = z.infer<typeof bugReportSchema>
+
+export const bugReportFileSchema = z.object({
+  bug_report_file_id: z.string().uuid(),
+  bug_report_id: z.string().uuid(),
+  file_path: z.string(),
+  content_mimetype: z.string(),
+  is_text: z.boolean(),
+  created_at: z.string().datetime(),
+  content_text: z.string().nullable(),
+  content_bytes: z.instanceof(Uint8Array).nullable(),
+})
+export const bugReportFileResponseSchema = bugReportFileSchema.omit({
+  content_text: true,
+  content_bytes: true,
+})
+export type BugReportFile = z.infer<typeof bugReportFileSchema>
+
 const shippingOptionSchema = z.object({
   carrier: z.string(),
   service: z.string(),
@@ -469,5 +496,7 @@ export const databaseSchema = z.object({
   datasheets: z.array(datasheetSchema).default([]),
   githubInstallations: z.array(githubInstallationSchema).default([]),
   packageBuilds: z.array(packageBuildSchema).default([]),
+  bugReports: z.array(bugReportSchema).default([]),
+  bugReportFiles: z.array(bugReportFileSchema).default([]),
 })
 export type DatabaseSchema = z.infer<typeof databaseSchema>

--- a/fake-snippets-api/routes/api/bug_reports/create.ts
+++ b/fake-snippets-api/routes/api/bug_reports/create.ts
@@ -1,0 +1,43 @@
+import { bugReportSchema } from "fake-snippets-api/lib/db/schema"
+import { withRouteSpec } from "fake-snippets-api/lib/middleware/with-winter-spec"
+import { z } from "zod"
+
+const requestSchema = z
+  .object({
+    text: z.string().optional(),
+    is_auto_deleted: z.boolean().optional(),
+    delete_at: z.string().datetime().optional(),
+  })
+  .superRefine((data, ctx) => {
+    if (data.is_auto_deleted && !data.delete_at) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "delete_at is required when is_auto_deleted is true",
+        path: ["delete_at"],
+      })
+    }
+  })
+
+export default withRouteSpec({
+  methods: ["POST"],
+  auth: "session",
+  jsonBody: requestSchema,
+  jsonResponse: z.object({
+    ok: z.literal(true),
+    bug_report: bugReportSchema,
+  }),
+})(async (req, ctx) => {
+  const { text, is_auto_deleted = false, delete_at } = req.jsonBody
+
+  const bugReport = ctx.db.addBugReport({
+    reporter_account_id: ctx.auth.account_id,
+    text: text ?? null,
+    is_auto_deleted,
+    delete_at: is_auto_deleted ? delete_at : null,
+  })
+
+  return ctx.json({
+    ok: true,
+    bug_report: bugReport,
+  })
+})

--- a/fake-snippets-api/routes/api/bug_reports/upload_file.ts
+++ b/fake-snippets-api/routes/api/bug_reports/upload_file.ts
@@ -1,0 +1,113 @@
+import { Buffer } from "node:buffer"
+import { bugReportFileResponseSchema } from "fake-snippets-api/lib/db/schema"
+import { withRouteSpec } from "fake-snippets-api/lib/middleware/with-winter-spec"
+import { normalizeProjectFilePathAndValidate } from "fake-snippets-api/utils/normalizeProjectFilePath"
+import { z } from "zod"
+
+const requestSchema = z
+  .object({
+    bug_report_id: z.string().uuid(),
+    file_path: z.string(),
+    content_mimetype: z.string().optional(),
+    content_text: z.string().optional(),
+    content_base64: z.string().optional(),
+  })
+  .superRefine((data, ctx) => {
+    if (data.content_text !== undefined && data.content_base64 !== undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Provide either content_text or content_base64, not both",
+        path: ["content_text"],
+      })
+    }
+  })
+
+const inferMimetype = (filePath: string, provided?: string) => {
+  if (provided) return provided
+
+  const lowerPath = filePath.toLowerCase()
+  if (lowerPath.endsWith(".ts") || lowerPath.endsWith(".tsx")) {
+    return "text/typescript"
+  }
+  if (lowerPath.endsWith(".js")) return "application/javascript"
+  if (lowerPath.endsWith(".json")) return "application/json"
+  if (lowerPath.endsWith(".md")) return "text/markdown"
+  if (lowerPath.endsWith(".html")) return "text/html"
+  if (lowerPath.endsWith(".css")) return "text/css"
+  if (lowerPath.endsWith(".txt")) return "text/plain"
+  return "application/octet-stream"
+}
+
+export default withRouteSpec({
+  methods: ["POST"],
+  auth: "session",
+  jsonBody: requestSchema,
+  jsonResponse: z.object({
+    ok: z.literal(true),
+    bug_report_file: bugReportFileResponseSchema,
+  }),
+})(async (req, ctx) => {
+  const {
+    bug_report_id,
+    file_path,
+    content_mimetype,
+    content_text,
+    content_base64,
+  } = req.jsonBody
+
+  const bugReport = ctx.db.getBugReportById(bug_report_id)
+  if (!bugReport) {
+    return ctx.error(404, {
+      error_code: "bug_report_not_found",
+      message: "Bug report not found",
+    })
+  }
+
+  if (bugReport.reporter_account_id !== ctx.auth.account_id) {
+    return ctx.error(403, {
+      error_code: "bug_report_forbidden",
+      message: "You do not have access to modify this bug report",
+    })
+  }
+
+  let normalizedPath: string
+  try {
+    normalizedPath = normalizeProjectFilePathAndValidate(file_path)
+  } catch (error) {
+    return ctx.error(400, {
+      error_code: "invalid_file_path",
+      message: error instanceof Error ? error.message : "Invalid file path",
+    })
+  }
+
+  const mimeType = inferMimetype(normalizedPath, content_mimetype)
+  const hasBase64 = content_base64 !== undefined
+  const hasText = content_text !== undefined
+  const isTextUpload = hasText || !hasBase64
+  const storedText = isTextUpload ? (content_text ?? "") : null
+  const storedBytes =
+    isTextUpload || !hasBase64
+      ? null
+      : Buffer.from(content_base64 ?? "", "base64")
+
+  const bugReportFile = ctx.db.addBugReportFile({
+    bug_report_id,
+    file_path: normalizedPath,
+    content_mimetype: mimeType,
+    is_text: isTextUpload,
+    content_text: storedText,
+    content_bytes: storedBytes,
+  })
+
+  return ctx.json({
+    ok: true,
+    bug_report_file: {
+      bug_report_file_id: bugReportFile.bug_report_file_id,
+      bug_report_id: bugReportFile.bug_report_id,
+      file_path: bugReportFile.file_path,
+      content_mimetype: bugReportFile.content_mimetype,
+      is_text: bugReportFile.is_text,
+      created_at: bugReportFile.created_at,
+    },
+  })
+})


### PR DESCRIPTION
## Summary
- add schemas and database helpers for bug reports and their files
- implement the /bug_reports/create and /bug_reports/upload_file endpoints in the fake snippets API
- cover the new endpoints with integration tests

## Testing
- bun test bun-tests/fake-snippets-api/routes/bug_reports
- bunx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_b_68f7cd190788832e8044806eca74619f