### PR TITLE
Add bug report zip download endpoint

### DIFF
--- a/bun-tests/fake-snippets-api/routes/bug_reports/download_zip.test.ts
+++ b/bun-tests/fake-snippets-api/routes/bug_reports/download_zip.test.ts
@@ -1,0 +1,76 @@
+import JSZip from "jszip"
+import { Buffer } from "node:buffer"
+import { randomUUID } from "node:crypto"
+import { getTestServer } from "bun-tests/fake-snippets-api/fixtures/get-test-server"
+import { expect, test } from "bun:test"
+
+const sampleBase64 = Buffer.from("binary-data").toString("base64")
+
+test("download zip includes all bug report files", async () => {
+  const { axios } = await getTestServer()
+
+  const createResponse = await axios.post("/api/bug_reports/create", {
+    text: "Initial report",
+  })
+  const bugReportId = createResponse.data.bug_report.bug_report_id
+
+  await axios.post("/api/bug_reports/upload_file", {
+    bug_report_id: bugReportId,
+    file_path: "./src//issue.txt",
+    content_text: "Steps to reproduce",
+  })
+
+  await axios.post("/api/bug_reports/upload_file", {
+    bug_report_id: bugReportId,
+    file_path: "attachments/data.bin",
+    content_base64: sampleBase64,
+  })
+
+  const response = await axios.get("/api/bug_reports/download_zip", {
+    params: { bug_report_id: bugReportId },
+    responseType: "arrayBuffer",
+  })
+
+  expect(response.status).toBe(200)
+  expect(response.headers.get("content-type")).toBe("application/zip")
+
+  const zip = await JSZip.loadAsync(response.data)
+  const textFile = await zip.file("src/issue.txt")?.async("string")
+  const binaryFile = await zip.file("attachments/data.bin")?.async("string")
+
+  expect(textFile).toBe("Steps to reproduce")
+  expect(binaryFile).toBe("binary-data")
+})
+
+test("cannot download zip for other user's bug report", async () => {
+  const { axios, jane_axios } = await getTestServer()
+
+  const createResponse = await axios.post("/api/bug_reports/create", {
+    text: "Owned by primary account",
+  })
+  const bugReportId = createResponse.data.bug_report.bug_report_id
+
+  try {
+    await jane_axios.get("/api/bug_reports/download_zip", {
+      params: { bug_report_id: bugReportId },
+    })
+    throw new Error("Expected request to fail")
+  } catch (error: any) {
+    expect(error.status).toBe(403)
+    expect(error.data.error.error_code).toBe("bug_report_forbidden")
+  }
+})
+
+test("downloading unknown bug report returns 404", async () => {
+  const { axios } = await getTestServer()
+
+  try {
+    await axios.get("/api/bug_reports/download_zip", {
+      params: { bug_report_id: randomUUID() },
+    })
+    throw new Error("Expected request to fail")
+  } catch (error: any) {
+    expect(error.status).toBe(404)
+    expect(error.data.error.error_code).toBe("bug_report_not_found")
+  }
+})

--- a/fake-snippets-api/routes/api/bug_reports/download_zip.ts
+++ b/fake-snippets-api/routes/api/bug_reports/download_zip.ts
@@ -1,0 +1,51 @@
+import JSZip from "jszip"
+import { withRouteSpec } from "fake-snippets-api/lib/middleware/with-winter-spec"
+import { z } from "zod"
+
+export default withRouteSpec({
+  methods: ["GET"],
+  auth: "session",
+  queryParams: z.object({
+    bug_report_id: z.string().uuid(),
+  }),
+  rawResponse: true,
+})(async (req, ctx) => {
+  const { bug_report_id } = req.query
+
+  const bugReport = ctx.db.getBugReportById(bug_report_id)
+  if (!bugReport) {
+    return ctx.error(404, {
+      error_code: "bug_report_not_found",
+      message: "Bug report not found",
+    })
+  }
+
+  if (bugReport.reporter_account_id !== ctx.auth.account_id) {
+    return ctx.error(403, {
+      error_code: "bug_report_forbidden",
+      message: "You do not have access to this bug report",
+    })
+  }
+
+  const bugReportFiles = ctx.db.getBugReportFilesByBugReportId(bug_report_id)
+
+  const zip = new JSZip()
+
+  for (const file of bugReportFiles) {
+    if (file.is_text) {
+      zip.file(file.file_path, file.content_text ?? "", { binary: false })
+    } else {
+      const bytes = file.content_bytes ?? new Uint8Array()
+      zip.file(file.file_path, bytes, { binary: true })
+    }
+  }
+
+  const zipContent = await zip.generateAsync({ type: "arraybuffer" })
+
+  return new Response(zipContent, {
+    headers: {
+      "Content-Type": "application/zip",
+      "Content-Disposition": `attachment; filename="bug-report-${bug_report_id}.zip"`,
+    },
+  })
+})


### PR DESCRIPTION
## Summary
- add GET /api/bug_reports/download_zip endpoint to bundle bug report files into a zip archive
- return 403/404 errors when access is forbidden or the report is missing
- add tests covering successful downloads and error cases

## Testing
- bun test bun-tests/fake-snippets-api/routes/bug_reports/download_zip.test.ts


------
https://chatgpt.com/codex/tasks/task_b_68fbd5552fc4832e96203adf2624d852