### PR TITLE
fix: update organization ID handling in NewPackageSavePromptDialog

### DIFF
--- a/src/components/dialogs/new-package-save-prompt-dialog.tsx
+++ b/src/components/dialogs/new-package-save-prompt-dialog.tsx
@@ -91,7 +91,7 @@ export const NewPackageSavePromptDialog = ({
                         organizations.find(
                           (org) => org.org_id === selectedOrgId,
                         )?.name ||
-                        `Org ${selectedOrgId.slice(0, 8)}`}
+                        `Org ${selectedOrgId.slice(0, 10)}`}
                     </span>
                   ) : (
                     <span className="text-slate-500">
@@ -176,11 +176,7 @@ export const NewPackageSavePromptDialog = ({
               onSave({
                 name: fullPackageName,
                 isPrivate,
-                ...(isOwnerPersonalOrg
-                  ? {}
-                  : {
-                      org_id: selectedOrgId,
-                    }),
+                org_id: selectedOrgId,
               })
               onOpenChange(false)
             }}


### PR DESCRIPTION
- Adjusted the display of organization ID to slice the string to 10 characters instead of 8.
- Ensured that the organization ID is always included in the save operation, regardless of ownership status.