### PR TITLE
feat: add owner_org_id filtering to package list API and update organ…

### DIFF
--- a/fake-snippets-api/routes/api/packages/list.ts
+++ b/fake-snippets-api/routes/api/packages/list.ts
@@ -9,6 +9,7 @@ export default withRouteSpec({
     creator_account_id: z.string().optional(),
     owner_github_username: z.string().optional(),
     is_writable: z.boolean().optional(),
+    owner_org_id: z.string().optional(),
     name: z.string().optional(),
     limit: z.number().int().min(1).optional(),
   }),
@@ -31,12 +32,19 @@ export default withRouteSpec({
     owner_github_username,
     name,
     is_writable,
+    owner_org_id,
     limit,
   } = req.commonParams
 
   const auth = "auth" in ctx && ctx.auth ? ctx.auth : null
 
-  if (!auth && !is_writable && !creator_account_id && !owner_github_username) {
+  if (
+    !auth &&
+    !is_writable &&
+    !creator_account_id &&
+    !owner_github_username &&
+    !owner_org_id
+  ) {
     return ctx.error(400, {
       error_code: "invalid_request",
       message: "You must provide some filtering parameters or be logged in",
@@ -69,6 +77,9 @@ export default withRouteSpec({
   }
   if (name) {
     packages = packages.filter((p) => p.name === name)
+  }
+  if (owner_org_id) {
+    packages = packages.filter((p) => p.owner_org_id === owner_org_id)
   }
   if (limit) {
     packages = packages.slice(0, limit)

--- a/src/pages/organization-profile.tsx
+++ b/src/pages/organization-profile.tsx
@@ -41,7 +41,7 @@ export const OrganizationProfilePageContent = ({
     ["userPackages", org.name],
     async () => {
       const response = await axios.post(`/packages/list`, {
-        owner_github_username: org.name,
+        owner_org_id: org.org_id,
       })
       return response.data.packages
     },


### PR DESCRIPTION
…ization profile handling

- Introduced `owner_org_id` as an optional filtering parameter in the package list API.
- Updated the organization profile page to use `owner_org_id` instead of `owner_github_username` for package retrieval.