### PR TITLE
Use DB preview image URLs in release detail

### DIFF
--- a/fake-snippets-api/lib/db/seed.ts
+++ b/fake-snippets-api/lib/db/seed.ts
@@ -617,6 +617,9 @@ export default () => (
     is_locked: false,
     has_transpiled: true,
     transpilation_error: null,
+    pcb_preview_image_url: `/api/packages/images/testuser/test2-package/pcb.png`,
+    cad_preview_image_url: `/api/packages/images/testuser/test2-package/3d.png`,
+    sch_preview_image_url: `/api/packages/images/testuser/test2-package/schematic.png`,
   })
   db.addPackageFile({
     package_release_id: test2PackageReleaseId,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -286,10 +286,6 @@ function App() {
               component={ReleaseBuildsPage}
             />
             <Route
-              path="/:author/:packageName/releases/:releaseId"
-              component={ReleaseDetailPage}
-            />
-            <Route
               path="/:author/:packageName/releases/:packageReleaseId/preview"
               component={ReleasePreviewPage}
             />

--- a/src/hooks/use-package-release-db-images.ts
+++ b/src/hooks/use-package-release-db-images.ts
@@ -1,0 +1,58 @@
+import { useMemo } from "react"
+
+interface UsePackageReleaseDbImagesProps {
+  packageRelease?: {
+    pcb_preview_image_url?: string | null
+    sch_preview_image_url?: string | null
+    cad_preview_image_url?: string | null
+  } | null
+}
+
+interface ViewConfig {
+  id: string
+  label: string
+  backgroundClass: string
+  urlField: keyof NonNullable<UsePackageReleaseDbImagesProps["packageRelease"]>
+}
+
+const VIEWS: ViewConfig[] = [
+  {
+    id: "3d",
+    label: "3D",
+    backgroundClass: "bg-gray-100",
+    urlField: "cad_preview_image_url",
+  },
+  {
+    id: "pcb",
+    label: "PCB",
+    backgroundClass: "bg-black",
+    urlField: "pcb_preview_image_url",
+  },
+  {
+    id: "schematic",
+    label: "Schematic",
+    backgroundClass: "bg-[#F5F1ED]",
+    urlField: "sch_preview_image_url",
+  },
+]
+
+export function usePackageReleaseDbImages({
+  packageRelease,
+}: UsePackageReleaseDbImagesProps) {
+  const availableViews = useMemo(() => {
+    if (!packageRelease) return []
+
+    return VIEWS.filter((view) => {
+      const imageUrl = packageRelease[view.urlField]
+      return imageUrl && imageUrl.trim() !== ""
+    }).map((view) => ({
+      id: view.id,
+      label: view.label,
+      imageUrl: packageRelease[view.urlField] as string,
+      isLoading: false,
+      backgroundClass: view.backgroundClass,
+    }))
+  }, [packageRelease])
+
+  return { availableViews }
+}

--- a/src/pages/release-builds.tsx
+++ b/src/pages/release-builds.tsx
@@ -7,7 +7,6 @@ import { BuildsList } from "@/components/preview/BuildsList"
 import Header from "@/components/Header"
 import { useLocation } from "wouter"
 import { PackageBreadcrumb } from "@/components/PackageBreadcrumb"
-import { PackageBuild } from "fake-snippets-api/lib/db/schema"
 
 export default function ReleaseBuildsPage() {
   const params = useParams<{

--- a/src/pages/release-detail.tsx
+++ b/src/pages/release-detail.tsx
@@ -10,7 +10,7 @@ import { Button } from "@/components/ui/button"
 import { Calendar, GitBranch, RefreshCw } from "lucide-react"
 import { formatTimeAgo } from "@/lib/utils/formatTimeAgo"
 import { PackageBreadcrumb } from "@/components/PackageBreadcrumb"
-import { usePackageReleaseImages } from "@/hooks/use-package-release-images"
+import { usePackageReleaseDbImages } from "@/hooks/use-package-release-db-images"
 import { Skeleton } from "@/components/ui/skeleton"
 import { useRebuildPackageReleaseMutation } from "@/hooks/use-rebuild-package-release-mutation"
 import { useGlobalStore } from "@/hooks/use-global-store"
@@ -54,8 +54,8 @@ export default function ReleaseDetailPage() {
     include_logs: true,
   })
 
-  const { availableViews } = usePackageReleaseImages({
-    packageReleaseId: packageRelease?.package_release_id,
+  const { availableViews } = usePackageReleaseDbImages({
+    packageRelease,
   })
 
   const session = useGlobalStore((s) => s.session)


### PR DESCRIPTION
- Add usePackageReleaseDbImages for 3D/PCB/Schematic previews
- Replace usePackageReleaseImages and pass packageRelease directly
- Remove unused import in release-builds
fix #1855 