### PR TITLE
Prevent spaces in new package name input

### DIFF
--- a/src/components/dialogs/new-package-save-prompt-dialog.tsx
+++ b/src/components/dialogs/new-package-save-prompt-dialog.tsx
@@ -190,7 +190,7 @@ export const NewPackageSavePromptDialog = ({
             <Input
               value={packageName}
               onChange={(e) =>
-                setPackageName(e.target.value.replaceAll(" ", ""))
+                setPackageName(e.target.value.replace(/ /g, "").trim())
               }
               placeholder="my-awesome-package"
               className="w-full"


### PR DESCRIPTION
## Summary
- normalize the new package modal input to strip spaces from entered names

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_6904c0a115c08327a545121291e408ff