### PR TITLE
fix: correct source of trending packages in list_trending.ts

### DIFF
--- a/fake-snippets-api/routes/api/packages/list_trending.ts
+++ b/fake-snippets-api/routes/api/packages/list_trending.ts
@@ -24,7 +24,7 @@ export default withRouteSpec({
   })
 
   // Filter out packages with no stars and sort by star count
-  const trendingPackages = ctx.db.packages
+  const trendingPackages = packagesWithStars
     .filter((p) => p.star_count > 0)
     .sort((a, b) => b.star_count - a.star_count)
     .slice(0, 50)


### PR DESCRIPTION
/fix #1934 

## Fix trending packages returning 0 stars in production

### Problem
The `list_trending` endpoint was returning packages with 0 stars because it was filtering the wrong array.

### Root Cause
Line 26 was using `ctx.db.packages` instead of `packagesWithStars`, attempting to filter on a `star_count` field that didn't exist yet on the raw package objects.

### Solution
Changed the filter to use `packagesWithStars` which contains the calculated `star_count` field.

### Changes
- Fixed trending packages endpoint to correctly filter packages with stars
- Now properly sorts and returns the top 10 randomized packages from the 50 most-starred packages
