### PR TITLE
Default undefined session github_username to tscircuit_handle

### DIFF
--- a/src/pages/authorize.tsx
+++ b/src/pages/authorize.tsx
@@ -67,6 +67,8 @@ const AuthenticatePageInnerContent = () => {
         setSession({
           ...(decodedToken as any),
           token: session_token,
+          github_username:
+            decodedToken.github_username ?? decodedToken.tscircuit_handle,
         })
         setMessage("success! redirecting you now...")
         setTimeout(() => {


### PR DESCRIPTION
Adding the default because we now support org login with Google in which case github_username will be undefined. 