### PR TITLE
Add fallback preview images from package file list

### DIFF
--- a/src/components/ViewPackagePage/components/preview-image-squares.tsx
+++ b/src/components/ViewPackagePage/components/preview-image-squares.tsx
@@ -8,6 +8,7 @@ interface ViewPlaceholdersProps {
     | "latest_cad_preview_image_url"
     | "latest_pcb_preview_image_url"
     | "latest_sch_preview_image_url"
+    | "latest_package_release_id"
   >
   onViewChange?: (view: "3d" | "pcb" | "schematic") => void
 }
@@ -18,6 +19,7 @@ export default function PreviewImageSquares({
   large = false,
 }: ViewPlaceholdersProps) {
   const { availableViews } = usePreviewImages({
+    packageReleaseId: packageInfo?.latest_package_release_id,
     cadPreviewUrl: packageInfo?.latest_cad_preview_image_url,
     pcbPreviewUrl: packageInfo?.latest_pcb_preview_image_url,
     schematicPreviewUrl: packageInfo?.latest_sch_preview_image_url,

--- a/src/hooks/use-preview-images.ts
+++ b/src/hooks/use-preview-images.ts
@@ -1,50 +1,142 @@
-import { useEffect, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
+import {
+  normalizeSvgForSquareTile,
+  svgToDataUrl,
+} from "@/lib/normalize-svg-for-tile"
+import {
+  usePackageFileById,
+  usePackageFiles,
+} from "@/hooks/use-package-files"
 
 interface UsePreviewImagesProps {
   cadPreviewUrl?: string | null
   pcbPreviewUrl?: string | null
   schematicPreviewUrl?: string | null
+  packageReleaseId?: string | null
 }
 
 export function usePreviewImages({
   cadPreviewUrl,
   pcbPreviewUrl,
   schematicPreviewUrl,
+  packageReleaseId,
 }: UsePreviewImagesProps) {
+  const needsFallbackImages = useMemo(
+    () => !cadPreviewUrl || !pcbPreviewUrl || !schematicPreviewUrl,
+    [cadPreviewUrl, pcbPreviewUrl, schematicPreviewUrl],
+  )
+
+  const { data: packageFiles } = usePackageFiles(
+    needsFallbackImages ? packageReleaseId : null,
+  )
+
+  type ViewKey = "3d" | "pcb" | "schematic"
+
+  const fallbackFileIds = useMemo(() => {
+    if (!packageFiles?.length) return {} as Partial<Record<ViewKey, string>>
+
+    const normalizePath = (path: string) => path.replace(/^\/+/, "")
+
+    const fallbackPaths: Record<ViewKey, string> = {
+      "3d": "dist/3d.svg",
+      pcb: "dist/pcb.svg",
+      schematic: "dist/schematic.svg",
+    }
+
+    return packageFiles.reduce((acc, file) => {
+      const cleanedPath = normalizePath(file.file_path)
+
+      for (const view of Object.keys(fallbackPaths) as ViewKey[]) {
+        if (!acc[view] && cleanedPath === fallbackPaths[view]) {
+          acc[view] = file.package_file_id
+        }
+      }
+
+      return acc
+    }, {} as Partial<Record<ViewKey, string>>)
+  }, [packageFiles])
+
+  const { data: fallbackCadFile } = usePackageFileById(
+    !cadPreviewUrl ? fallbackFileIds["3d"] ?? null : null,
+  )
+  const { data: fallbackPcbFile } = usePackageFileById(
+    !pcbPreviewUrl ? fallbackFileIds.pcb ?? null : null,
+  )
+  const { data: fallbackSchematicFile } = usePackageFileById(
+    !schematicPreviewUrl ? fallbackFileIds.schematic ?? null : null,
+  )
+
+  const convertSvgToUrl = (svg?: string | null) => {
+    if (!svg) return undefined
+    const normalized = normalizeSvgForSquareTile(svg)
+    return svgToDataUrl(normalized)
+  }
+
+  const fallbackCadImageUrl = useMemo(
+    () => convertSvgToUrl(fallbackCadFile?.content_text),
+    [fallbackCadFile?.content_text],
+  )
+  const fallbackPcbImageUrl = useMemo(
+    () => convertSvgToUrl(fallbackPcbFile?.content_text),
+    [fallbackPcbFile?.content_text],
+  )
+  const fallbackSchematicImageUrl = useMemo(
+    () => convertSvgToUrl(fallbackSchematicFile?.content_text),
+    [fallbackSchematicFile?.content_text],
+  )
+
+  const resolvedCadPreviewUrl = cadPreviewUrl ?? fallbackCadImageUrl ?? null
+  const resolvedPcbPreviewUrl = pcbPreviewUrl ?? fallbackPcbImageUrl ?? null
+  const resolvedSchematicPreviewUrl =
+    schematicPreviewUrl ?? fallbackSchematicImageUrl ?? null
+
+  const resolvedUrls = useMemo(
+    () => ({
+      "3d": resolvedCadPreviewUrl,
+      pcb: resolvedPcbPreviewUrl,
+      schematic: resolvedSchematicPreviewUrl,
+    }),
+    [resolvedCadPreviewUrl, resolvedPcbPreviewUrl, resolvedSchematicPreviewUrl],
+  )
+
   const [imageStatus, setImageStatus] = useState<
     Record<string, "loading" | "loaded" | "error">
   >({
-    "3d": cadPreviewUrl ? "loading" : "error",
-    pcb: pcbPreviewUrl ? "loading" : "error",
-    schematic: schematicPreviewUrl ? "loading" : "error",
+    "3d": resolvedCadPreviewUrl ? "loading" : "error",
+    pcb: resolvedPcbPreviewUrl ? "loading" : "error",
+    schematic: resolvedSchematicPreviewUrl ? "loading" : "error",
   })
 
   useEffect(() => {
     setImageStatus({
-      "3d": cadPreviewUrl ? "loading" : "error",
-      pcb: pcbPreviewUrl ? "loading" : "error",
-      schematic: schematicPreviewUrl ? "loading" : "error",
+      "3d": resolvedCadPreviewUrl ? "loading" : "error",
+      pcb: resolvedPcbPreviewUrl ? "loading" : "error",
+      schematic: resolvedSchematicPreviewUrl ? "loading" : "error",
     })
-  }, [cadPreviewUrl, pcbPreviewUrl, schematicPreviewUrl])
+  }, [
+    resolvedCadPreviewUrl,
+    resolvedPcbPreviewUrl,
+    resolvedSchematicPreviewUrl,
+  ])
 
   const views = [
     {
       id: "3d",
       label: "3D View",
       backgroundClass: "bg-gray-100",
-      imageUrl: cadPreviewUrl ?? undefined,
+      imageUrl: resolvedUrls["3d"] ?? undefined,
     },
     {
       id: "pcb",
       label: "PCB View",
       backgroundClass: "bg-black",
-      imageUrl: pcbPreviewUrl ?? undefined,
+      imageUrl: resolvedUrls.pcb ?? undefined,
     },
     {
       id: "schematic",
       label: "Schematic View",
       backgroundClass: "bg-[#F5F1ED]",
-      imageUrl: schematicPreviewUrl ?? undefined,
+      imageUrl: resolvedUrls.schematic ?? undefined,
     },
   ]
 


### PR DESCRIPTION
## Summary
- fetch fallback preview SVGs from package file listings when preview URLs are missing
- surface fallback images in the package preview tiles by supplying the release id

## Testing
- bun run typecheck

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6915a815554c8327aa28d0ef3ef488ef)