### PR TITLE
Allow shorter organization display names

### DIFF
--- a/bun-tests/fake-snippets-api/routes/orgs/create.test.ts
+++ b/bun-tests/fake-snippets-api/routes/orgs/create.test.ts
@@ -54,6 +54,20 @@ test("POST /api/orgs/create - should accept display_name and use it", async () =
   expect(responseBody.org.display_name).toBe(displayName)
 })
 
+test("POST /api/orgs/create - should accept 3 character display_name", async () => {
+  const { axios } = await getTestServer()
+  const name = "acme-corp-96"
+  const displayName = "abc"
+  const createResponse = await axios.post("/api/orgs/create", {
+    tscircuit_handle: name,
+    display_name: displayName,
+  })
+
+  expect(createResponse.status).toBe(200)
+  const responseBody = createResponse.data
+  expect(responseBody.org.display_name).toBe(displayName)
+})
+
 test("POST /api/orgs/create - should map tscircuit_handle as display_name when not provided", async () => {
   const { axios, db } = await getTestServer()
   const name = "acme-corp"

--- a/fake-snippets-api/routes/api/orgs/create.ts
+++ b/fake-snippets-api/routes/api/orgs/create.ts
@@ -10,7 +10,7 @@ export default withRouteSpec({
   methods: ["GET", "POST"],
   commonParams: z
     .object({
-      display_name: z.string().min(5).max(40).optional(),
+      display_name: z.string().min(3).max(40).optional(),
       tscircuit_handle: tscircuitHandleSchema.optional(),
       name: tscircuitHandleSchema.optional(),
     })

--- a/src/pages/create-organization.tsx
+++ b/src/pages/create-organization.tsx
@@ -57,8 +57,8 @@ export const CreateOrganizationPage = () => {
     if (formData.display_name) {
       if (formData.display_name.length > 40) {
         newErrors.display_name = "Display name must be less than 40 characters"
-      } else if (formData.display_name.length < 5) {
-        newErrors.display_name = "Display name must be at least 5 characters"
+      } else if (formData.display_name.length < 3) {
+        newErrors.display_name = "Display name must be at least 3 characters"
       }
     }
 


### PR DESCRIPTION
## Summary
- lower the minimum display name length for organization creation to three characters on both the frontend and API
- add a backend test to confirm three-character display names are accepted

## Testing
- bun test bun-tests/fake-snippets-api/routes/orgs/create.test.ts
- bunx tsc --noEmit
- bun run format

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693732733984832eb5a33e489945ffd2)