### PR TITLE
fix: allow long log messages to wrap in ConnectedRepoOverview component

### DIFF
--- a/src/components/preview/ConnectedRepoOverview.tsx
+++ b/src/components/preview/ConnectedRepoOverview.tsx
@@ -419,7 +419,7 @@ export const ConnectedRepoOverview = ({
                         (log: any, i: number) => (
                           <div
                             key={`build-log-${i}`}
-                            className="text-gray-600 whitespace-pre-wrap"
+                            className="text-gray-600 whitespace-pre-wrap break-words"
                           >
                             {log.msg || log.message || JSON.stringify(log)}
                           </div>
@@ -432,7 +432,7 @@ export const ConnectedRepoOverview = ({
                     {usercodeStreamedLogs.map((log: string, i: number) => (
                       <div
                         key={`streamed-log-${i}`}
-                        className="text-gray-600 whitespace-pre-wrap"
+                        className="text-gray-600 whitespace-pre-wrap break-words"
                       >
                         {log}
                       </div>


### PR DESCRIPTION
Problem
Long log lines in the "Usercode Logs" section were causing horizontal overflow, breaking the layout of the build logs display.

Solution
Added break-words CSS class to log line containers to enable natural text wrapping for long tokens.

Changes Made
File: [ConnectedRepoOverview.tsx](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Lines Modified:
Line ~422: Build logs className - added break-words
Line ~431: Streamed logs className - added break-words
Before
After
Impact
Long log lines now wrap naturally instead of causing horizontal overflow
Maintains monospace formatting and whitespace preservation
/fix #2102 

before 
<img width="446" height="917" alt="Screenshot 2025-12-10 at 3 15 02 PM" src="https://github.com/user-attachments/assets/18178ade-fc4c-45d0-a8aa-603c2e5c30de" />
after 
<img width="446" height="917" alt="Screenshot 2025-12-10 at 3 14 52 PM" src="https://github.com/user-attachments/assets/7d0bff4f-97ea-470b-967c-cb18f3ad2de4" />

