### PR TITLE
Fix the race condition for Run button first time run

### DIFF
--- a/src/components/package-port/CodeAndPreview.tsx
+++ b/src/components/package-port/CodeAndPreview.tsx
@@ -262,7 +262,7 @@ export function CodeAndPreview({ pkg, projectUrl, isPackageFetched }: Props) {
             showFileMenu={false}
             showRunButton
             forceLatestEvalVersion
-            isLoadingFiles={isLoading}
+            isLoadingFiles={isLoading || !isFullyLoaded}
             onRenderStarted={() =>
               setState((prev) => ({ ...prev, lastRunCode: currentFileCode }))
             }


### PR DESCRIPTION
 The issue was a race condition in tscircuit.com/src/components/package-port/CodeAndPreview.tsx:

  1. The isLoading state becomes false as soon as the priority file (e.g., index.tsx) is loaded
  2. But binary files (.glb, .step) are loaded asynchronously via separate queries in useOptimizedPackageFilesLoader
  3. The RunFrame was using isLoadingFiles={isLoading}, which allowed the "Run" button to be enabled before all files were in the fsMap
  4. On the first run, the .glb file wasn't in fsMap yet, so the import failed
  5. On the second run, all files were loaded, so it worked

 This ensures the Run button is disabled until all files (including .glb, .step, etc.) are fully loaded.