### PR TITLE
Add automatic package website fallback for built releases (TSC-264)

### DIFF
--- a/src/components/ViewPackagePage/components/mobile-sidebar.tsx
+++ b/src/components/ViewPackagePage/components/mobile-sidebar.tsx
@@ -15,6 +15,8 @@ import { useCurrentPackageInfo } from "@/hooks/use-current-package-info"
 import { usePackageFileById, usePackageFiles } from "@/hooks/use-package-files"
 import { getLicenseFromLicenseContent } from "@/lib/getLicenseFromLicenseContent"
 import PreviewImageSquares from "./preview-image-squares"
+import { useCurrentPackageRelease } from "@/hooks/use-current-package-release"
+import { usePackageWebsite } from "@/hooks/use-package-website"
 
 interface MobileSidebarProps {
   isLoading?: boolean
@@ -26,6 +28,7 @@ const MobileSidebar = ({
   onViewChange,
 }: MobileSidebarProps) => {
   const { packageInfo, refetch: refetchPackageInfo } = useCurrentPackageInfo()
+  const { packageRelease } = useCurrentPackageRelease()
   const { data: releaseFiles } = usePackageFiles(
     packageInfo?.latest_package_release_id,
   )
@@ -74,25 +77,32 @@ const MobileSidebar = ({
   }, [openEditPackageDetailsDialog])
 
   const [localDescription, setLocalDescription] = useState<string>("")
-  const [localWebsite, setLocalWebsite] = useState<string>("")
+  const [websiteOverride, setWebsiteOverride] = useState<string | null>(null)
 
   useEffect(() => {
     if (packageInfo) {
       setLocalDescription(
         packageInfo.description || packageInfo.ai_description || "",
       )
-      setLocalWebsite((packageInfo as any)?.website || "")
+      setWebsiteOverride(null)
     }
   }, [packageInfo])
 
   const handlePackageUpdate = useCallback(
     (newDescription: string, newWebsite: string) => {
       setLocalDescription(newDescription)
-      setLocalWebsite(newWebsite)
+      setWebsiteOverride(newWebsite)
       refetchPackageInfo()
     },
     [refetchPackageInfo],
   )
+
+  const website = usePackageWebsite({
+    packageInfo,
+    packageRelease,
+    releaseFiles,
+    overrideWebsite: websiteOverride,
+  })
 
   if (isLoading) {
     return (
@@ -139,15 +149,15 @@ const MobileSidebar = ({
         )}
       </div>
 
-      {localWebsite && (
+      {website && (
         <a
-          href={localWebsite}
+          href={website}
           target="_blank"
           rel="noopener noreferrer"
           className="text-blue-600 font-medium dark:text-[#58a6ff] hover:underline text-sm flex items-center mb-4 max-w-full overflow-hidden"
         >
           <LinkIcon className="h-4 w-4 min-w-[16px] mr-1 flex-shrink-0" />
-          <span className="truncate">{localWebsite}</span>
+          <span className="truncate">{website}</span>
         </a>
       )}
 

--- a/src/components/ViewPackagePage/components/sidebar-about-section.tsx
+++ b/src/components/ViewPackagePage/components/sidebar-about-section.tsx
@@ -11,6 +11,7 @@ import { usePackageFileById, usePackageFiles } from "@/hooks/use-package-files"
 import { getLicenseFromLicenseContent } from "@/lib/getLicenseFromLicenseContent"
 import { PackageInfo } from "@/lib/types"
 import { useOrganization } from "@/hooks/use-organization"
+import { usePackageWebsite } from "@/hooks/use-package-website"
 
 interface SidebarAboutSectionProps {
   packageInfo?: PackageInfo
@@ -71,7 +72,7 @@ export default function SidebarAboutSection({
 
   // Local state to store updated values before the query refetches
   const [localDescription, setLocalDescription] = useState<string>("")
-  const [localWebsite, setLocalWebsite] = useState<string>("")
+  const [websiteOverride, setWebsiteOverride] = useState<string | null>(null)
 
   // Update local state when packageInfo changes
   useEffect(() => {
@@ -79,7 +80,7 @@ export default function SidebarAboutSection({
       setLocalDescription(
         packageInfo.description || packageInfo.ai_description || "",
       )
-      setLocalWebsite((packageInfo as any)?.website || "")
+      setWebsiteOverride(null)
     }
   }, [packageInfo])
 
@@ -103,13 +104,17 @@ export default function SidebarAboutSection({
 
   // Handle updates from the dialog
   const handlePackageUpdate = (newDescription: string, newWebsite: string) => {
-    // Update local state immediately for a responsive UI
     setLocalDescription(newDescription)
-    setLocalWebsite(newWebsite)
-
-    // Refetch the package info to get the updated data from the server
+    setWebsiteOverride(newWebsite)
     refetchPackageInfo()
   }
+
+  const website = usePackageWebsite({
+    packageInfo,
+    packageRelease,
+    releaseFiles,
+    overrideWebsite: websiteOverride,
+  })
 
   if (isLoading) {
     return (
@@ -154,15 +159,15 @@ export default function SidebarAboutSection({
             packageInfo?.description ||
             packageInfo?.ai_description}
         </p>
-        {localWebsite && (
+        {website && (
           <a
-            href={localWebsite}
+            href={website}
             target="_blank"
             rel="noopener noreferrer"
             className="text-blue-600 font-medium dark:text-[#58a6ff] hover:underline text-sm flex items-center mb-4 max-w-full overflow-hidden"
           >
             <LinkIcon className="h-4 w-4 min-w-[16px] mr-1 flex-shrink-0" />
-            <span className="truncate">{localWebsite}</span>
+            <span className="truncate">{website}</span>
           </a>
         )}
         <div className="flex flex-wrap gap-2 mb-4">

--- a/src/hooks/use-package-website.ts
+++ b/src/hooks/use-package-website.ts
@@ -1,0 +1,52 @@
+import { useMemo } from "react"
+import type {
+  PackageFile,
+  PackageRelease,
+} from "fake-snippets-api/lib/db/schema"
+import type { PackageInfo } from "@/lib/types"
+
+interface UsePackageWebsiteParams {
+  packageInfo?: PackageInfo
+  packageRelease?: PackageRelease | null
+  releaseFiles?: PackageFile[] | null
+  overrideWebsite?: string | null
+}
+
+const buildPreviewDomain = (packageInfo?: PackageInfo) => {
+  if (!packageInfo?.name?.includes("/")) return null
+  const [owner, pkgName] = packageInfo.name.split("/")
+  if (!owner || !pkgName) return null
+  return `${owner}-${pkgName}.tscircuit.app`
+}
+
+const hasDistIndexHtml = (releaseFiles?: PackageFile[] | null) => {
+  return releaseFiles?.some((file) => file.file_path === "dist/index.html")
+}
+
+const isLatestReleaseBuilt = (packageRelease?: PackageRelease | null) => {
+  return packageRelease?.display_status === "complete"
+}
+
+export const usePackageWebsite = ({
+  packageInfo,
+  packageRelease,
+  releaseFiles,
+  overrideWebsite,
+}: UsePackageWebsiteParams) => {
+  return useMemo(() => {
+    const trimmedOverride = overrideWebsite?.trim()
+    if (trimmedOverride) return trimmedOverride
+
+    const providedWebsite = (packageInfo as any)?.website as string | undefined
+    if (providedWebsite) return providedWebsite
+
+    if (isLatestReleaseBuilt(packageRelease) && hasDistIndexHtml(releaseFiles)) {
+      const previewDomain = buildPreviewDomain(packageInfo)
+      if (previewDomain) {
+        return `https://${previewDomain}`
+      }
+    }
+
+    return ""
+  }, [overrideWebsite, packageInfo, packageRelease, releaseFiles])
+}


### PR DESCRIPTION
## Summary
- add a shared hook that derives a package website when the latest release is fully built and includes dist/index.html
- use the new hook in package sidebars to show the preview domain and simplify local website state management

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695ab0969d608327a4106d62a88d27c5)