### PR TITLE
Expand build logs by default

### DIFF
--- a/src/components/preview/ConnectedRepoOverview.tsx
+++ b/src/components/preview/ConnectedRepoOverview.tsx
@@ -40,7 +40,7 @@ export const ConnectedRepoOverview = ({
 }) => {
   const { status, label } = getBuildStatus(packageBuild)
   const [openSections, setOpenSections] = useState({
-    userCode: false,
+    userCode: true,
   })
   const logsEndRef = useRef<HTMLDivElement | null>(null)
 
@@ -337,7 +337,9 @@ export const ConnectedRepoOverview = ({
           onOpenChange={() => toggleSection("userCode")}
         >
           <CollapsibleTrigger asChild>
-            <div className="flex items-center justify-between p-4 bg-white border border-gray-200 rounded-lg cursor-pointer hover:bg-gray-50">
+            <div
+              className={`flex items-center justify-between p-4 bg-white border border-gray-200 rounded-lg cursor-pointer hover:bg-gray-50 ${openSections.userCode ? "rounded-b-none border-b-0" : ""}`}
+            >
               <div className="flex items-center gap-3">
                 <ChevronRight
                   className={`w-4 h-4 transition-transform ${openSections.userCode ? "rotate-90" : ""}`}
@@ -351,7 +353,7 @@ export const ConnectedRepoOverview = ({
                 ) : (
                   <Clock className="w-5 h-5 text-gray-400" />
                 )}
-                <span className="font-medium">Usercode Logs</span>
+                <span className="font-medium">Build Logs</span>
               </div>
               <div className="flex items-center gap-2">
                 {getStepDuration(


### PR DESCRIPTION
### Motivation
- Improve visibility by expanding the build log section by default so users immediately see build output.  
- Use a clearer label by renaming the section from `Usercode Logs` to `Build Logs`.  
- Fix a small UI glitch where the header shows a double border/corner radius when the collapsible is open.  

### Description
- Default `openSections.userCode` to `true` in `src/components/preview/ConnectedRepoOverview.tsx`.  
- Rename the header text from `Usercode Logs` to `Build Logs`.  
- Add conditional classes `rounded-b-none border-b-0` to the log header wrapper when `openSections.userCode` is true to remove the bottom border and rounded corner.  

### Testing
- Ran `bun run format` and it completed successfully.  
- Ran `bunx tsc --noEmit` for TypeScript type-checking and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695ae57d7078832e94acd46048ad87e7)