### PR TITLE
Preserve forked package visibility (TSC-285)

### DIFF
--- a/src/components/ViewPackagePage/components/package-header.tsx
+++ b/src/components/ViewPackagePage/components/package-header.tsx
@@ -65,7 +65,10 @@ export default function PackageHeader({
 
   const handleForkClick = async () => {
     if (!packageInfo?.package_id || !isLoggedIn) return
-    await forkPackage(packageInfo.package_id)
+    await forkPackage({
+      packageId: packageInfo.package_id,
+      isPrivate,
+    })
   }
 
   useEffect(() => {

--- a/src/hooks/use-fork-package-mutation.ts
+++ b/src/hooks/use-fork-package-mutation.ts
@@ -15,11 +15,18 @@ export const useForkPackageMutation = ({
 
   return useMutation(
     ["forkPackage"],
-    async (packageId: string) => {
+    async ({
+      packageId,
+      isPrivate,
+    }: {
+      packageId: string
+      isPrivate?: boolean
+    }) => {
       if (!session) throw new Error("No session")
 
       const { data } = await axios.post("/packages/fork", {
         package_id: packageId,
+        is_private: isPrivate,
       })
 
       const forkedPackage: Package = data.package

--- a/src/hooks/useForkPackageMutation.ts
+++ b/src/hooks/useForkPackageMutation.ts
@@ -25,6 +25,7 @@ export const useForkPackageMutation = ({
 
       const { data } = await axios.post("/packages/fork", {
         package_id: pkg?.package_id,
+        is_private: pkg?.is_private,
       })
       return data.package
     },


### PR DESCRIPTION
### Motivation
- Ensure a newly forked package inherits the same visibility (`private`/`public`) as the source package.
- Fix inconsistent behavior between the package header fork flow and the editor fork flow so both send visibility to the API.
- Pass the `is_private` flag to the registry `POST /packages/fork` endpoint so forks are created with the intended visibility.

### Description
- Update the header fork hook `useForkPackageMutation` to accept an object `{ packageId, isPrivate }` and include `is_private` in the POST payload to `/packages/fork`.
- Change the UI call in `src/components/ViewPackagePage/components/package-header.tsx` to call `forkPackage({ packageId, isPrivate })` instead of passing just the id.
- Add `is_private: pkg?.is_private` to the editor fork implementation in `src/hooks/useForkPackageMutation.ts` so the editor flow also preserves visibility.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695e5d52cd188327886f198b11dce2d0)