### PR TITLE
Remove release creation timestamp on release detail page

### DIFF
--- a/src/pages/release-detail.tsx
+++ b/src/pages/release-detail.tsx
@@ -14,8 +14,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip"
-import { Calendar, GitBranch, RefreshCw } from "lucide-react"
-import { formatTimeAgo } from "@/lib/utils/formatTimeAgo"
+import { GitBranch, RefreshCw } from "lucide-react"
 import { PackageBreadcrumb } from "@/components/PackageBreadcrumb"
 import { usePackageReleaseDbImages } from "@/hooks/use-package-release-db-images"
 import { Skeleton } from "@/components/ui/skeleton"
@@ -155,12 +154,6 @@ export default function ReleaseDetailPage() {
             {/* Header Content */}
             <div className="flex flex-wrap items-center justify-between gap-3 mt-4">
               <div className="flex flex-wrap items-center gap-4 text-sm text-gray-600">
-                <div className="flex items-center gap-1">
-                  <Calendar className="w-4 h-4" />
-                  <span>
-                    Created {formatTimeAgo(packageRelease.created_at)}
-                  </span>
-                </div>{" "}
                 {packageRelease.is_pr_preview && (
                   <TooltipProvider>
                     <Tooltip>


### PR DESCRIPTION
### Motivation
- Remove the `Created <time duration> ago` text from the release detail header so release pages no longer show the relative creation timestamp.

### Description
- Deleted the timestamp JSX from `src/pages/release-detail.tsx` that rendered `Created {formatTimeAgo(packageRelease.created_at)}`.
- Removed the now-unused `Calendar` and `formatTimeAgo` imports from the same file.
- Kept existing PR preview badge and rebuild button logic unchanged.

### Testing
- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695fbfff177883278e5e09150333388a)