### PR TITLE
refactor(ui): enhance release handling in sidebar and preview components

### DIFF
--- a/src/components/ViewPackagePage/components/sidebar-releases-section.tsx
+++ b/src/components/ViewPackagePage/components/sidebar-releases-section.tsx
@@ -58,7 +58,7 @@ export default function SidebarReleasesSection() {
             {timeAgo(new Date(packageRelease.created_at))}
           </span>
         </div>
-        {latestBuild && (
+        {latestBuild && packageInfo && (
           <Link
             href={`/${packageInfo?.name}/releases`}
             className="flex items-center gap-2 text-sm text-gray-500 dark:text-[#8b949e]"
@@ -68,9 +68,6 @@ export default function SidebarReleasesSection() {
           </Link>
         )}
       </div>
-      {/* <a href="#" className="text-blue-600 dark:text-[#58a6ff] hover:underline text-sm">
-        Push a new release
-      </a> */}
     </div>
   )
 }

--- a/src/components/preview/index.tsx
+++ b/src/components/preview/index.tsx
@@ -8,7 +8,10 @@ export {
   PackageReleaseOrBuildItemRowSkeleton,
   formatBuildDuration,
 } from "./PackageReleaseOrBuildItemRow"
-import { PackageBuild } from "fake-snippets-api/lib/db/schema"
+import {
+  PackageBuild,
+  PublicPackageRelease,
+} from "fake-snippets-api/lib/db/schema"
 import { Clock, AlertCircle, Loader2, CircleCheck } from "lucide-react"
 
 export interface DropdownAction {
@@ -20,7 +23,7 @@ export interface DropdownAction {
 export type Status = "pending" | "building" | "success" | "error" | "queued"
 
 export const getBuildStatus = (
-  build?: PackageBuild | null,
+  build?: PackageBuild | PublicPackageRelease | null,
 ): {
   status: Status
   label: string
@@ -56,32 +59,6 @@ export const getBuildStatus = (
   ) {
     return { status: "error", label: "Failed" }
   }
-
-  if (
-    build?.build_error ||
-    build?.transpilation_error ||
-    build?.circuit_json_build_error
-  ) {
-    return { status: "error", label: "Failed" }
-  }
-  if (
-    build?.build_in_progress ||
-    build?.transpilation_in_progress ||
-    build?.circuit_json_build_in_progress
-  ) {
-    return { status: "building", label: "Building" }
-  }
-  if (
-    !build?.build_error &&
-    !build?.transpilation_error &&
-    !build?.circuit_json_build_error &&
-    !build?.build_in_progress &&
-    !build?.transpilation_in_progress &&
-    !build?.circuit_json_build_in_progress &&
-    build?.transpilation_completed_at
-  ) {
-    return { status: "success", label: "Ready" }
-  }
   return { status: "queued", label: "Queued" }
 }
 
@@ -99,7 +76,7 @@ export const StatusIcon = ({ status }: { status: string }) => {
 }
 
 export const getBuildErrorMessage = (
-  build?: PackageBuild | null,
+  build?: PackageBuild | PublicPackageRelease | null,
 ): string | null => {
   if (!build) return null
 


### PR DESCRIPTION
- Updated SidebarReleasesSection to conditionally render the link based on packageInfo availability.
- Modified getBuildStatus and getBuildErrorMessage functions to accept PublicPackageRelease type.
- Removed unnecessary latestBuildQueries logic from ReleasesList, simplifying the build status retrieval process.
- Adjusted status label visibility in ReleaseItemRow based on build success.