### PR TITLE
Remove automatic polling for release/build detail

### DIFF
--- a/src/hooks/use-rebuild-package-release-mutation.ts
+++ b/src/hooks/use-rebuild-package-release-mutation.ts
@@ -24,6 +24,8 @@ export const useRebuildPackageReleaseMutation = ({
           description: "The package build has been queued for rebuild.",
         })
         queryClient.invalidateQueries(["packageRelease"])
+        queryClient.invalidateQueries(["packageBuild"])
+        queryClient.invalidateQueries(["packageBuilds"])
         onSuccess?.(pkgRelease)
       },
       onError: (error: any) => {


### PR DESCRIPTION
### Motivation
- Continuous polling on the release detail page caused unnecessary background refetches and the UI should only refresh build data when an explicit rebuild is triggered.
- The `usePackageBuild` hook exposed a `refetchInterval` option that enabled conditional polling which is no longer desired for the release detail view.

### Description
- Removed the `refetchInterval` option from the `usePackageBuild` hook in `src/hooks/use-package-builds.ts` so the hook no longer supports automatic polling.
- Stopped passing a `refetchInterval` to `usePackageReleaseByIdOrVersion` and `usePackageBuild` in `src/pages/release-detail.tsx` to disable polling on that page.
- Ensured the rebuild flow triggers fresh data by invalidating `packageBuild` and `packageBuilds` caches in `src/hooks/use-rebuild-package-release-mutation.ts` so a rebuild causes an immediate refetch.

### Testing
- No automated tests were run for this change.
- Changes were committed locally and the diff was verified to include the removal of `refetchInterval` usage and the added cache invalidations.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696661a8f3e8832798c0f8ad788f08e3)