### PR TITLE
Replace landing hero image with YouTube video embed

### DIFF
--- a/src/pages/landing.tsx
+++ b/src/pages/landing.tsx
@@ -116,11 +116,13 @@ export function LandingPage() {
                   </div>
                 </div>
                 <div className="w-full aspect-video relative">
-                  <OptimizedImage
-                    alt="Product preview"
+                  <iframe
                     className="mx-auto overflow-hidden rounded-xl object-cover object-center absolute inset-0 w-full h-full mt-8 lg:mt-0"
-                    src="/assets/editor_example_1_more_square.webp"
-                    priority={true}
+                    src="https://www.youtube.com/embed/HAd5_ZJgg50"
+                    title="TSCircuit product demo"
+                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                    referrerPolicy="strict-origin-when-cross-origin"
+                    allowFullScreen
                   />
                 </div>
               </div>


### PR DESCRIPTION
### Motivation
- Swap the static hero image for an embedded YouTube demo so the landing hero presents a video preview of the product.

### Description
- Replace the `OptimizedImage` hero in `src/pages/landing.tsx` with an `iframe` embedding `https://www.youtube.com/embed/HAd5_ZJgg50` while preserving the existing layout and styling.

### Testing
- Started the dev server and captured a screenshot of the landing page (`artifacts/landing-video.png`), ran `bunx tsc --noEmit` which passed, and ran `bun run format` which passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6985384c58a0832e93c4973e8f485644)