### PR TITLE
Handle node_modules @tsci CAD asset paths in 3D viewer resolution

### DIFF
--- a/src/components/ViewPackagePage/components/tab-views/3d-view.tsx
+++ b/src/components/ViewPackagePage/components/tab-views/3d-view.tsx
@@ -32,7 +32,8 @@ const getPackageFileLookupParams = ({
   )
 
   if (externalPackageMatch) {
-    const [, externalAuthor, externalPackageName, filePath] = externalPackageMatch
+    const [, externalAuthor, externalPackageName, filePath] =
+      externalPackageMatch
     return {
       package_name_with_version: `${externalAuthor}/${externalPackageName}@latest`,
       file_path: filePath,
@@ -42,14 +43,14 @@ const getPackageFileLookupParams = ({
   if (releaseId) {
     return {
       package_release_id: releaseId,
-      file_path: assetUrl,
+      file_path: normalizedAssetUrl,
     }
   }
 
   if (author && packageName) {
     return {
       package_name_with_version: `${author}/${packageName}@${version || "latest"}`,
-      file_path: assetUrl,
+      file_path: normalizedAssetUrl,
     }
   }
 
@@ -152,7 +153,10 @@ function useModelBlobUrls(circuitJson: AnyCircuitElement[] | null) {
   ])
 
   const resolveStaticAsset = useCallback(
-    (assetPath: string) => blobUrlMap[assetPath] ?? assetPath,
+    (assetPath: string) =>
+      blobUrlMap[assetPath] ??
+      blobUrlMap[normalizeAssetPath(assetPath)] ??
+      assetPath,
     [blobUrlMap],
   )
 


### PR DESCRIPTION
### Motivation
- CAD asset URLs in circuit JSON may point into `node_modules/@tsci/...` (for example `./node_modules/@tsci/imrishabh18.library/...`) and must be fetched from the package registry rather than treated as same-package files. 
- The resolver needs to normalize an optional `./` prefix and map external `@tsci` package paths into `package_files/download` lookup parameters so `CadViewer` can load those assets.

### Description
- Added `NODE_MODULES_TSCI_PACKAGE_ASSET_REGEX` to detect `node_modules/@tsci/...` style asset references and `normalizeAssetPath` to strip a leading `./`.
- Implemented `getPackageFileLookupParams` which returns a `Record<string,string> | null` describing the correct lookup params for `package_files/download` for external `@tsci` assets, `package_release_id` lookups, or current-author package lookups.
- Updated the asset fetch loop to use `getPackageFileLookupParams`, construct `URLSearchParams` from its return value, and skip assets without lookup params.
- Store fetched blob URLs in the map under both the original `assetUrl` and the normalized path (without `./`) so `resolveStaticAsset` can resolve either form passed to the `CadViewer`.

### Testing
- Ran TypeScript type-checking with `bun run typecheck`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6988da96d9b083279f76105fcf24c2c9)