### PR TITLE
Use release/build versions in package domain target descriptions

### DIFF
--- a/src/components/dialogs/edit-subdomain-dialog.tsx
+++ b/src/components/dialogs/edit-subdomain-dialog.tsx
@@ -26,11 +26,13 @@ export const EditSubdomainDialog = ({
   onOpenChange,
   packageDomainId,
   currentFqdn,
+  targetInfo,
 }: {
   open: boolean
   onOpenChange: (open: boolean) => void
   packageDomainId: string
   currentFqdn: string
+  targetInfo?: { badgeLabel: string; description: string } | null
 }) => {
   const [subdomain, setSubdomain] = useState(extractSubdomain(currentFqdn))
   const updateMutation = useUpdatePackageDomain()
@@ -77,6 +79,16 @@ export const EditSubdomainDialog = ({
           </DialogDescription>
         </DialogHeader>
         <div className="space-y-4">
+          {targetInfo && (
+            <div className="rounded-md border border-gray-200 bg-gray-50 px-3 py-2">
+              <p className="text-xs font-medium text-gray-700">
+                {targetInfo.badgeLabel}
+              </p>
+              <p className="mt-1 text-xs text-gray-600">
+                {targetInfo.description}
+              </p>
+            </div>
+          )}
           <div className="flex items-center gap-0">
             <Input
               value={subdomain}

--- a/src/lib/package-domain-target.test.ts
+++ b/src/lib/package-domain-target.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "bun:test"
+import { getPackageDomainTargetInfo } from "./package-domain-target"
+import type {
+  PackageBuild,
+  PublicPackageDomain,
+} from "fake-snippets-api/lib/db/schema"
+
+const baseDomain: PublicPackageDomain = {
+  package_domain_id: "domain-1",
+  points_to: "package",
+  package_release_id: null,
+  package_build_id: null,
+  package_id: "pkg-1",
+  tag: null,
+  default_main_component_path: null,
+  fully_qualified_domain_name: "pkg.tscircuit.app",
+  created_at: new Date().toISOString(),
+}
+
+describe("getPackageDomainTargetInfo", () => {
+  it("uses release version in description for package_release", () => {
+    const info = getPackageDomainTargetInfo(
+      {
+        ...baseDomain,
+        points_to: "package_release",
+        package_release_id: "release-abc",
+      },
+      {
+        releaseVersionById: {
+          "release-abc": "1.2.3",
+        },
+      },
+    )
+
+    expect(info.description).toBe("Points to release v1.2.3.")
+  })
+
+  it("includes associated release version for package_build", () => {
+    const build: PackageBuild = {
+      package_build_id: "12345678-1234-4123-8123-123456789abc",
+      package_release_id: "release-xyz",
+      created_at: new Date().toISOString(),
+      transpilation_in_progress: false,
+      transpilation_logs: null,
+      circuit_json_build_in_progress: false,
+      circuit_json_build_logs: null,
+      image_generation_in_progress: false,
+      image_generation_logs: null,
+      build_in_progress: false,
+      build_error_last_updated_at: new Date().toISOString(),
+    }
+
+    const info = getPackageDomainTargetInfo(
+      {
+        ...baseDomain,
+        points_to: "package_build",
+        package_build_id: build.package_build_id,
+      },
+      {
+        buildById: {
+          [build.package_build_id]: build,
+        },
+        releaseVersionById: {
+          "release-xyz": "2.0.0",
+        },
+      },
+    )
+
+    expect(info.description).toBe(
+      "Points to build 123456…9abc from release v2.0.0.",
+    )
+  })
+})

--- a/src/lib/package-domain-target.ts
+++ b/src/lib/package-domain-target.ts
@@ -1,0 +1,84 @@
+import type {
+  PackageBuild,
+  PublicPackageDomain,
+} from "fake-snippets-api/lib/db/schema"
+
+type PackageDomainTargetContext = {
+  releaseVersionById?: Record<string, string | null | undefined>
+  buildById?: Record<string, PackageBuild | undefined>
+}
+
+function shortId(value?: string | null): string | null {
+  if (!value) return null
+  return value.length > 10 ? `${value.slice(0, 6)}…${value.slice(-4)}` : value
+}
+
+function formatVersion(version?: string | null): string | null {
+  if (!version) return null
+  return version.startsWith("v") ? version : `v${version}`
+}
+
+export function getPackageDomainTargetInfo(
+  domain: PublicPackageDomain,
+  context: PackageDomainTargetContext = {},
+): {
+  badgeLabel: string
+  description: string
+} {
+  switch (domain.points_to) {
+    case "package":
+      return {
+        badgeLabel: "Latest",
+        description: "Points to the package's latest release.",
+      }
+
+    case "package_release_with_tag":
+      return {
+        badgeLabel: "Tag",
+        description: domain.tag
+          ? `Points to releases tagged "${domain.tag}".`
+          : "Points to releases selected by tag.",
+      }
+
+    case "package_release": {
+      const releaseId = domain.package_release_id
+      const formattedVersion = formatVersion(
+        releaseId ? context.releaseVersionById?.[releaseId] : null,
+      )
+
+      return {
+        badgeLabel: "Release",
+        description: formattedVersion
+          ? `Points to release ${formattedVersion}.`
+          : shortId(releaseId)
+            ? `Points to release ${shortId(releaseId)}.`
+            : "Points to a specific release.",
+      }
+    }
+
+    case "package_build": {
+      const buildId = domain.package_build_id
+      const build = buildId ? context.buildById?.[buildId] : null
+      const releaseVersion = formatVersion(
+        build?.package_release_id
+          ? context.releaseVersionById?.[build.package_release_id]
+          : null,
+      )
+
+      return {
+        badgeLabel: "Build",
+        description: shortId(buildId)
+          ? releaseVersion
+            ? `Points to build ${shortId(buildId)} from release ${releaseVersion}.`
+            : "Points to a specific build and its release."
+          : "Points to a specific build.",
+      }
+    }
+
+    default:
+      return {
+        badgeLabel: "Unknown",
+        description: "Target is not available.",
+      }
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide clearer, human-readable context for package domains by showing the actual release version or associated release for builds instead of opaque IDs.
- Address inline review feedback to rename the helper output field from `details` to `description` for clearer semantics.

### Description
- Add and centralize formatting logic in `src/lib/package-domain-target.ts` by introducing `getPackageDomainTargetInfo(domain, context)` which accepts `releaseVersionById` and `buildById` lookup maps and returns `{ badgeLabel, description }`.
- Prefer real release versions (formatted with a `v` prefix) in `package_release` descriptions and include the associated release version when a `package_build` points to a build.
- Wire the package settings UI to fetch releases and builds and pass the context into `getPackageDomainTargetInfo` in `src/components/package-settings/PackageDomainsList.tsx` so list rows and the edit dialog show richer descriptions.
- Update `EditSubdomainDialog` (`src/components/dialogs/edit-subdomain-dialog.tsx`) to accept and render the precomputed `targetInfo` `description` and `badgeLabel`.
- Add unit tests for the helper in `src/lib/package-domain-target.test.ts` covering both `package_release` and `package_build` description behavior.

### Testing
- Ran `bun test ./src/lib/package-domain-target.test.ts` which passed (2 tests, 0 failures).
- Ran `bunx tsc --noEmit` for TypeScript typecheck which completed successfully.
- Ran `bun run format` to reformat files which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6994e48b9800832eb594ccf4172311a8)