### PR TITLE
Allow editing package domain target from subdomain dialog

### DIFF
--- a/src/components/dialogs/edit-subdomain-dialog.tsx
+++ b/src/components/dialogs/edit-subdomain-dialog.tsx
@@ -7,12 +7,28 @@ import {
 } from "../ui/dialog"
 import { Input } from "../ui/input"
 import { Button } from "../ui/button"
-import { useState, useEffect } from "react"
+import { useMemo, useState, useEffect } from "react"
 import { createUseDialog } from "./create-use-dialog"
 import { useUpdatePackageDomain } from "@/hooks/use-package-domains"
-import { Loader2 } from "lucide-react"
+import { Loader2, Check, ChevronsUpDown } from "lucide-react"
+import type {
+  PublicPackageDomain,
+  PublicPackageRelease,
+} from "fake-snippets-api/lib/db/schema"
+import { Popover, PopoverContent, PopoverTrigger } from "../ui/popover"
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "../ui/command"
+import { cn } from "@/lib/utils"
 
 const DOMAIN_SUFFIX = ".tscircuit.app"
+
+type PointsToTarget = "package" | "package_release"
 
 function extractSubdomain(fqdn: string): string {
   if (fqdn.endsWith(DOMAIN_SUFFIX)) {
@@ -21,27 +37,50 @@ function extractSubdomain(fqdn: string): string {
   return fqdn
 }
 
+function getInitialPointsTo(domain: PublicPackageDomain): PointsToTarget {
+  return domain.points_to === "package_release" ? "package_release" : "package"
+}
+
+function releaseLabel(release: PublicPackageRelease): string {
+  return release.version || release.package_release_id
+}
+
 export const EditSubdomainDialog = ({
   open,
   onOpenChange,
-  packageDomainId,
-  currentFqdn,
+  packageDomain,
   targetInfo,
+  releases,
 }: {
   open: boolean
   onOpenChange: (open: boolean) => void
-  packageDomainId: string
-  currentFqdn: string
+  packageDomain: PublicPackageDomain
   targetInfo?: { badgeLabel: string; description: string } | null
+  releases: PublicPackageRelease[]
 }) => {
-  const [subdomain, setSubdomain] = useState(extractSubdomain(currentFqdn))
+  const [subdomain, setSubdomain] = useState(
+    extractSubdomain(packageDomain.fully_qualified_domain_name || ""),
+  )
+  const [pointsTo, setPointsTo] = useState<PointsToTarget>(
+    getInitialPointsTo(packageDomain),
+  )
+  const [selectedReleaseId, setSelectedReleaseId] = useState<string>(
+    packageDomain.package_release_id || "",
+  )
+  const [releasePickerOpen, setReleasePickerOpen] = useState(false)
+
   const updateMutation = useUpdatePackageDomain()
 
   useEffect(() => {
     if (open) {
-      setSubdomain(extractSubdomain(currentFqdn))
+      setSubdomain(
+        extractSubdomain(packageDomain.fully_qualified_domain_name || ""),
+      )
+      setPointsTo(getInitialPointsTo(packageDomain))
+      setSelectedReleaseId(packageDomain.package_release_id || "")
+      setReleasePickerOpen(false)
     }
-  }, [open, currentFqdn])
+  }, [open, packageDomain])
 
   const normalizedSubdomain = subdomain
     .trim()
@@ -52,20 +91,41 @@ export const EditSubdomainDialog = ({
     ? `${normalizedSubdomain}${DOMAIN_SUFFIX}`
     : ""
 
-  const hasChanged = newFqdn !== currentFqdn
-  const isValid = normalizedSubdomain.length > 0
+  const selectedRelease = useMemo(
+    () =>
+      releases.find(
+        (release) => release.package_release_id === selectedReleaseId,
+      ),
+    [releases, selectedReleaseId],
+  )
+
+  const isValidSubdomain = normalizedSubdomain.length > 0
+  const isValidTarget = pointsTo === "package" || Boolean(selectedReleaseId)
+
+  const hasChanged =
+    newFqdn !== (packageDomain.fully_qualified_domain_name || "") ||
+    pointsTo !== getInitialPointsTo(packageDomain) ||
+    (pointsTo === "package_release" &&
+      selectedReleaseId !== (packageDomain.package_release_id || ""))
 
   const handleSave = () => {
-    if (!isValid || !hasChanged) return
-    updateMutation.mutate(
-      {
-        package_domain_id: packageDomainId,
-        fully_qualified_domain_name: newFqdn,
-      },
-      {
-        onSuccess: () => onOpenChange(false),
-      },
-    )
+    if (!isValidSubdomain || !isValidTarget || !hasChanged) return
+
+    const payload: Parameters<typeof updateMutation.mutate>[0] = {
+      package_domain_id: packageDomain.package_domain_id,
+      fully_qualified_domain_name: newFqdn,
+      points_to: pointsTo,
+      package_id:
+        pointsTo === "package" ? packageDomain.package_id || null : null,
+      package_release_id:
+        pointsTo === "package_release" ? selectedReleaseId : null,
+      package_build_id: null,
+      tag: null,
+    }
+
+    updateMutation.mutate(payload, {
+      onSuccess: () => onOpenChange(false),
+    })
   }
 
   return (
@@ -74,8 +134,8 @@ export const EditSubdomainDialog = ({
         <DialogHeader>
           <DialogTitle>Edit Subdomain</DialogTitle>
           <DialogDescription>
-            Change the subdomain for this domain. Only lowercase letters,
-            numbers, and hyphens are allowed.
+            Update the subdomain and where this domain points. You can target
+            the package latest release or a specific release version.
           </DialogDescription>
         </DialogHeader>
         <div className="space-y-4">
@@ -89,29 +149,125 @@ export const EditSubdomainDialog = ({
               </p>
             </div>
           )}
-          <div className="flex items-center gap-0">
-            <Input
-              value={subdomain}
-              onChange={(e) => setSubdomain(e.target.value)}
-              placeholder="my-board"
-              className="rounded-r-none text-sm"
-              autoComplete="off"
-              disabled={updateMutation.isLoading}
-              onKeyDown={(e) => {
-                if (e.key === "Enter" && isValid && hasChanged) {
-                  handleSave()
-                }
-              }}
-            />
-            <span className="text-sm text-gray-500 bg-gray-50 border border-l-0 border-gray-200 rounded-r-md px-3 py-2 whitespace-nowrap">
-              {DOMAIN_SUFFIX}
-            </span>
+
+          <div className="space-y-2">
+            <p className="text-xs font-medium text-gray-700">Subdomain</p>
+            <div className="flex items-center gap-0">
+              <Input
+                value={subdomain}
+                onChange={(e) => setSubdomain(e.target.value)}
+                placeholder="my-board"
+                className="rounded-r-none text-sm"
+                autoComplete="off"
+                disabled={updateMutation.isLoading}
+                onKeyDown={(e) => {
+                  if (
+                    e.key === "Enter" &&
+                    isValidSubdomain &&
+                    isValidTarget &&
+                    hasChanged
+                  ) {
+                    handleSave()
+                  }
+                }}
+              />
+              <span className="text-sm text-gray-500 bg-gray-50 border border-l-0 border-gray-200 rounded-r-md px-3 py-2 whitespace-nowrap">
+                {DOMAIN_SUFFIX}
+              </span>
+            </div>
+            {subdomain.trim() && normalizedSubdomain !== subdomain.trim() && (
+              <p className="text-xs text-gray-500">
+                Will be normalized to: {normalizedSubdomain}
+              </p>
+            )}
           </div>
-          {subdomain.trim() && normalizedSubdomain !== subdomain.trim() && (
-            <p className="text-xs text-gray-500">
-              Will be normalized to: {normalizedSubdomain}
-            </p>
+
+          <div className="space-y-2">
+            <p className="text-xs font-medium text-gray-700">Points to</p>
+            <div className="grid grid-cols-2 gap-2">
+              <Button
+                type="button"
+                variant={pointsTo === "package" ? "default" : "outline"}
+                size="sm"
+                onClick={() => setPointsTo("package")}
+                disabled={updateMutation.isLoading}
+              >
+                Latest release
+              </Button>
+              <Button
+                type="button"
+                variant={pointsTo === "package_release" ? "default" : "outline"}
+                size="sm"
+                onClick={() => setPointsTo("package_release")}
+                disabled={updateMutation.isLoading}
+              >
+                Specific release
+              </Button>
+            </div>
+          </div>
+
+          {pointsTo === "package_release" && (
+            <div className="space-y-2">
+              <p className="text-xs font-medium text-gray-700">
+                Release version
+              </p>
+              <Popover
+                open={releasePickerOpen}
+                onOpenChange={setReleasePickerOpen}
+              >
+                <PopoverTrigger asChild>
+                  <Button
+                    variant="outline"
+                    role="combobox"
+                    aria-expanded={releasePickerOpen}
+                    className="w-full justify-between"
+                    disabled={updateMutation.isLoading}
+                  >
+                    {selectedRelease
+                      ? releaseLabel(selectedRelease)
+                      : "Select a release..."}
+                    <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+                  </Button>
+                </PopoverTrigger>
+                <PopoverContent className="w-[var(--radix-popover-trigger-width)] p-0">
+                  <Command>
+                    <CommandInput placeholder="Search releases..." />
+                    <CommandList>
+                      <CommandEmpty>No releases found.</CommandEmpty>
+                      <CommandGroup>
+                        {releases.map((release) => (
+                          <CommandItem
+                            key={release.package_release_id}
+                            value={`${release.version || ""} ${release.package_release_id}`}
+                            onSelect={() => {
+                              setSelectedReleaseId(release.package_release_id)
+                              setReleasePickerOpen(false)
+                            }}
+                          >
+                            <Check
+                              className={cn(
+                                "mr-2 h-4 w-4",
+                                selectedReleaseId === release.package_release_id
+                                  ? "opacity-100"
+                                  : "opacity-0",
+                              )}
+                            />
+                            {releaseLabel(release)}
+                          </CommandItem>
+                        ))}
+                      </CommandGroup>
+                    </CommandList>
+                  </Command>
+                </PopoverContent>
+              </Popover>
+              {!isValidTarget && (
+                <p className="text-xs text-red-500">
+                  Please select a release version.
+                </p>
+              )}
+            </div>
           )}
+
           {newFqdn && hasChanged && (
             <p className="text-xs text-gray-500">
               New domain: <span className="font-medium">{newFqdn}</span>
@@ -129,7 +285,12 @@ export const EditSubdomainDialog = ({
             <Button
               size="sm"
               onClick={handleSave}
-              disabled={!isValid || !hasChanged || updateMutation.isLoading}
+              disabled={
+                !isValidSubdomain ||
+                !isValidTarget ||
+                !hasChanged ||
+                updateMutation.isLoading
+              }
             >
               {updateMutation.isLoading && (
                 <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />

--- a/src/components/package-settings/PackageDomainsList.tsx
+++ b/src/components/package-settings/PackageDomainsList.tsx
@@ -167,8 +167,8 @@ export function PackageDomainsList({
           onOpenChange={(open) => {
             if (!open) setEditingDomain(null)
           }}
-          packageDomainId={editingDomain.package_domain_id}
-          currentFqdn={editingDomain.fully_qualified_domain_name || ""}
+          packageDomain={editingDomain}
+          releases={releases}
           targetInfo={getPackageDomainTargetInfo(editingDomain, {
             releaseVersionById,
             buildById,

--- a/src/components/preview/ReleaseDeploymentDetails.tsx
+++ b/src/components/preview/ReleaseDeploymentDetails.tsx
@@ -454,8 +454,8 @@ export function ReleaseDeploymentDetails({
           onOpenChange={(open) => {
             if (!open) setEditingDomain(null)
           }}
-          packageDomainId={editingDomain.package_domain_id}
-          currentFqdn={editingDomain.fully_qualified_domain_name || ""}
+          packageDomain={editingDomain}
+          releases={[]}
         />
       )}
     </div>

--- a/src/hooks/use-package-domains.ts
+++ b/src/hooks/use-package-domains.ts
@@ -3,6 +3,12 @@ import { useQuery, useMutation, useQueryClient } from "react-query"
 import { useAxios } from "./use-axios"
 import { useToast } from "./use-toast"
 
+type PackageDomainPointsTo =
+  | "package_release"
+  | "package_build"
+  | "package_release_with_tag"
+  | "package"
+
 export const usePackageDomains = (
   query: {
     package_release_id?: string | null
@@ -36,11 +42,7 @@ export const useCreatePackageDomain = () => {
 
   return useMutation({
     mutationFn: async (params: {
-      points_to:
-        | "package_release"
-        | "package_build"
-        | "package_release_with_tag"
-        | "package"
+      points_to: PackageDomainPointsTo
       package_release_id?: string
       package_build_id?: string
       package_id?: string
@@ -77,6 +79,11 @@ export const useUpdatePackageDomain = () => {
     mutationFn: async (params: {
       package_domain_id: string
       fully_qualified_domain_name?: string | null
+      points_to?: PackageDomainPointsTo
+      package_release_id?: string | null
+      package_build_id?: string | null
+      package_id?: string | null
+      tag?: string | null
     }) => {
       const { data } = await axios.post("/package_domains/update", params)
       return data.package_domain as PublicPackageDomain


### PR DESCRIPTION
### Motivation
- Enable changing a package domain's target (pointing to the package latest vs a specific release) from the package settings edit-subdomain dialog so users can retarget domains without leaving the settings page.
- Provide a searchable release selector so users can pick a specific package release (version) when retargeting a domain.

### Description
- Updated the Edit Subdomain dialog to accept the full `packageDomain` object and a `releases` list, added UI controls to switch `points_to` between "Latest release" (`package`) and "Specific release" (`package_release`), and implemented a searchable autocomplete release picker using the existing `Command`/`Popover` components (`src/components/dialogs/edit-subdomain-dialog.tsx`).
- Wired `PackageDomainsList` to pass `releases` and the `packageDomain` into the edit dialog so the new retargeting UI is available from the package settings domains list (`src/components/package-settings/PackageDomainsList.tsx`), and updated `ReleaseDeploymentDetails` dialog callsite to the new prop shape.
- Extended `useUpdatePackageDomain`/`useCreatePackageDomain` typing to include `points_to`, `package_release_id`, `package_build_id`, `package_id`, and `tag` and adjusted the update payload construction when saving the dialog (`src/hooks/use-package-domains.ts`).
- Enhanced the fake API `package_domains/update` endpoint to accept, validate, and persist retargeting fields (`points_to`, ids, and `tag`) while enforcing target-specific constraints, and added tests to cover retargeting flows (`fake-snippets-api/routes/api/package_domains/update.ts`).
- Added test cases to verify retargeting from `package` -> `package_release` and back (`bun-tests/fake-snippets-api/routes/package_domains/update.test.ts`).

### Testing
- Ran `bun test bun-tests/fake-snippets-api/routes/package_domains/update.test.ts` and all tests passed (8 pass, 0 fail).
- Ran typechecking with `bunx tsc --noEmit` which completed successfully.
- Ran formatting with `bun run format` which formatted files, followed by a second `bunx tsc --noEmit` to re-check types, both succeeding.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69951b87f76c832eae3594a13b36fc22)