### PR TITLE
Show all package-linked domains in package settings

### DIFF
--- a/src/components/package-settings/PackageDomainsList.tsx
+++ b/src/components/package-settings/PackageDomainsList.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from "react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
-import { usePackageDomains } from "@/hooks/use-package-domains"
+import { useAllPackageLinkedDomains } from "@/hooks/use-package-domains"
 import { EditSubdomainDialog } from "@/components/dialogs/edit-subdomain-dialog"
 import { AddSubdomainDialog } from "@/components/dialogs/add-subdomain-dialog"
 import { Search, CheckCircle2, ExternalLink } from "lucide-react"
@@ -23,12 +23,8 @@ export function PackageDomainsList({
     useState<PublicPackageDomain | null>(null)
   const [showAddDialog, setShowAddDialog] = useState(false)
 
-  const { data: domains = [], isLoading } = usePackageDomains(
-    packageReleaseId
-      ? { package_release_id: packageReleaseId }
-      : packageId
-        ? { package_id: packageId }
-        : null,
+  const { data: domains = [], isLoading } = useAllPackageLinkedDomains(
+    packageId ?? null,
   )
   const { data: releases = [] } = usePackageReleasesByPackageId(
     packageId ?? null,


### PR DESCRIPTION
### Motivation
- The Domains tab should display every FQDN linked to a package, including domains attached to the package itself and to any releases or builds for that package.

### Description
- Added a new hook `useAllPackageLinkedDomains(packageId)` in `src/hooks/use-package-domains.ts` that lists package releases and builds, fetches domains for the package, each release, and each build, deduplicates by `package_domain_id`, and sorts results newest-first.
- Updated `PackageDomainsList` (`src/components/package-settings/PackageDomainsList.tsx`) to use `useAllPackageLinkedDomains` and show all linked domains instead of only querying the latest release or the package alone.
- Domain fetching uses parallel requests (`Promise.all`) and a `Map` to de-duplicate entries, preserving existing UI and domain target resolution logic.

### Testing
- Ran type checking with `bun run typecheck` (`tsc --noEmit`) which succeeded.
- Ran formatting with `bunx biome format --write` for modified files which succeeded.
- Started the dev server with `bun run dev --port 4173` and captured a browser screenshot via a Playwright script; the server started but autoload of some dev packages failed due to network fetch errors (these are unrelated to the new hook logic).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69959d3c31dc83278103b48f3a8cbb5c)