### PR TITLE
Show specific tag labels on package domain badges

### DIFF
--- a/src/lib/package-domain-target.test.ts
+++ b/src/lib/package-domain-target.test.ts
@@ -18,6 +18,17 @@ const baseDomain: PublicPackageDomain = {
 }
 
 describe("getPackageDomainTargetInfo", () => {
+  it("uses the specific tag as badge label for package_release_with_tag", () => {
+    const info = getPackageDomainTargetInfo({
+      ...baseDomain,
+      points_to: "package_release_with_tag",
+      tag: "latest",
+    })
+
+    expect(info.badgeLabel).toBe("Latest")
+    expect(info.description).toBe('Points to releases tagged "latest".')
+  })
+
   it("uses release version in description for package_release", () => {
     const info = getPackageDomainTargetInfo(
       {

--- a/src/lib/package-domain-target.ts
+++ b/src/lib/package-domain-target.ts
@@ -18,6 +18,11 @@ function formatVersion(version?: string | null): string | null {
   return version.startsWith("v") ? version : `v${version}`
 }
 
+function formatTagLabel(tag?: string | null): string {
+  if (!tag) return "Tag"
+  return tag.charAt(0).toUpperCase() + tag.slice(1)
+}
+
 export function getPackageDomainTargetInfo(
   domain: PublicPackageDomain,
   context: PackageDomainTargetContext = {},
@@ -34,7 +39,7 @@ export function getPackageDomainTargetInfo(
 
     case "package_release_with_tag":
       return {
-        badgeLabel: "Tag",
+        badgeLabel: formatTagLabel(domain.tag),
         description: domain.tag
           ? `Points to releases tagged "${domain.tag}".`
           : "Points to releases selected by tag.",


### PR DESCRIPTION
### Motivation

- Replace the generic `Tag` badge with the actual tag (capitalized) on package domain entries so the package settings domains page shows the specific tag (e.g. `latest` → `Latest`) for `package_release_with_tag` targets.

### Description

- Add `formatTagLabel` helper to format a domain tag (capitalizes first letter and falls back to `Tag`) in `src/lib/package-domain-target.ts`.
- Use `formatTagLabel(domain.tag)` for the `badgeLabel` in the `package_release_with_tag` branch instead of the static `Tag` label.
- Add a unit test in `src/lib/package-domain-target.test.ts` to assert the badge label and description for a tagged release domain.
- Keep existing behavior for other `points_to` variants unchanged (e.g. `Latest`, `Release`, `Build`).

### Testing

- Ran `bun test ./src/lib/package-domain-target.test.ts` and all tests passed (3 pass, 0 fail). 
- Ran `bunx tsc --noEmit` for a TypeScript typecheck and it completed successfully. 
- Ran `bun run format` to apply formatting; formatting completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69975acf7380832e9f9fc3ac3b313d69)