### PR TITLE
fix: update usbCLedFlashlightTemplate to use SmdUsbC #2816

### DIFF
--- a/src/lib/templates/usb-c-led-flashlight-template.ts
+++ b/src/lib/templates/usb-c-led-flashlight-template.ts
@@ -8,7 +8,7 @@ import { SmdUsbC } from "@tsci/seveibar.smd-usb-c"
 export default () => {
   return (
     <board width="12mm" height="30mm" schAutoLayoutEnabled>
-      <SmdUsbC name="USBC" pcbY={-10} />
+      <SmdUsbC name="USBC" pcbY={-10} /> 
       <RedLed name="LED" pcbY={12} />
       <PushButton name="SW1" pcbY={0} />
       <resistor name="R1" footprint="0603" resistance="1k" pcbY={7} />


### PR DESCRIPTION
have updated the usbCLedFlashlightTemplate.ts file to use the correct SmdUsbC component. This replaces the outdated useUsbC hook style which was causing an execution error.

Fixes #2816