### PR TITLE
Show org/user handle in GitHub repository selector

### DIFF
--- a/src/components/dialogs/GitHubRepositorySelector.tsx
+++ b/src/components/dialogs/GitHubRepositorySelector.tsx
@@ -118,7 +118,7 @@ export const GitHubRepositorySelector = ({
     const repos = repositoriesData?.repos || []
     const repoOptions = repos.map((repo: any) => ({
       value: repo.full_name,
-      label: repo.unscoped_name,
+      label: repo.full_name,
       isPrivate: repo.private,
       type: "repo" as const,
     }))


### PR DESCRIPTION
### Motivation
- Make the GitHub repository selector show the full repo identifier (including owner/org) so users can see the org or user handle when linking a repo.

### Description
- Change the repository label in the selector from `repo.unscoped_name` to `repo.full_name` in `src/components/dialogs/GitHubRepositorySelector.tsx` so options render as `owner/repo`.

### Testing
- Ran TypeScript typecheck with `bunx tsc --noEmit` which succeeded and ran formatting with `bun run format` which succeeded; an automated Playwright screenshot attempt was executed but the app remained on a loading screen in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699b706ca780832e944a14496825b2b1)