### PR TITLE
refactor: replace trace with capacitor connection in blank board template

### DIFF
--- a/src/lib/templates/blank-circuit-board-template.ts
+++ b/src/lib/templates/blank-circuit-board-template.ts
@@ -12,8 +12,8 @@ export default () => (
       capacitance="1000pF"
       footprint="0402"
       name="C1"
+      connections={{ pin1: "R1.pin1" }}
     />
-    <trace from=".R1 > .pin1" to=".C1 > .pin1" />
   </board>
 )
 `.trim(),


### PR DESCRIPTION
### Motivation
- Use the component-level `connections` prop to express the net between `R1.pin1` and `C1.pin1` instead of an explicit `<trace />` element in the blank board template.

### Description
- Updated `src/lib/templates/blank-circuit-board-template.ts` to add `connections={{ pin1: "R1.pin1" }}` on the `C1` capacitor and removed the explicit `<trace from=".R1 > .pin1" to=".C1 > .pin1" />` line.

### Testing
- Ran TypeScript typecheck with `bunx tsc --noEmit`, which completed successfully.
- Ran formatter with `bun run format`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a3271d6f64832e94a18961f6824781)