### PR TITLE
Add public_dist_enabled support to fake API and package settings

### DIFF
--- a/bun-tests/fake-snippets-api/routes/packages/update.test.ts
+++ b/bun-tests/fake-snippets-api/routes/packages/update.test.ts
@@ -215,3 +215,41 @@ test("update package without permission", async () => {
     )
   }
 })
+
+test("package has public_dist_enabled disabled by default", async () => {
+  const { axios, db } = await getTestServer()
+
+  const packageResponse = await axios.post("/api/packages/create", {
+    name: "testuser/public-dist-default",
+    description: "Public dist default",
+  })
+
+  expect(packageResponse.status).toBe(200)
+  expect(packageResponse.data.package.public_dist_enabled).toBe(false)
+
+  const packageId = packageResponse.data.package.package_id
+  const createdPackage = db.packages.find((p) => p.package_id === packageId)
+  expect(createdPackage?.public_dist_enabled).toBe(false)
+})
+
+test("update package public_dist_enabled", async () => {
+  const { axios, db } = await getTestServer()
+
+  const packageResponse = await axios.post("/api/packages/create", {
+    name: "testuser/public-dist-update",
+    description: "Public dist update",
+  })
+  const packageId = packageResponse.data.package.package_id
+
+  const response = await axios.post("/api/packages/update", {
+    package_id: packageId,
+    public_dist_enabled: true,
+  })
+
+  expect(response.status).toBe(200)
+  expect(response.data.ok).toBe(true)
+  expect(response.data.package.public_dist_enabled).toBe(true)
+
+  const updatedPackage = db.packages.find((p) => p.package_id === packageId)
+  expect(updatedPackage?.public_dist_enabled).toBe(true)
+})

--- a/fake-snippets-api/lib/db/db-client.ts
+++ b/fake-snippets-api/lib/db/db-client.ts
@@ -395,6 +395,7 @@ const initializer = combine(databaseSchema.parse({}), (set, get) => ({
       is_unlisted: false,
       latest_package_release_id: `package_release_${nextId}`,
       latest_package_release_fs_sha: null,
+      public_dist_enabled: false,
     }
 
     // Create package release

--- a/fake-snippets-api/lib/db/schema.ts
+++ b/fake-snippets-api/lib/db/schema.ts
@@ -461,6 +461,7 @@ export const packageSchema = z.object({
     .default("files")
     .optional(),
   allow_pr_previews: z.boolean().default(false).optional(),
+  public_dist_enabled: z.boolean().default(false).optional(),
   is_starred: z.boolean().default(false).optional(),
   latest_pcb_preview_image_url: z.string().nullable().optional(),
   latest_sch_preview_image_url: z.string().nullable().optional(),

--- a/fake-snippets-api/lib/public-mapping/public-map-package.ts
+++ b/fake-snippets-api/lib/public-mapping/public-map-package.ts
@@ -28,6 +28,7 @@ export const publicMapPackage = (internalPackage: {
   latest_package_release_fs_sha: string | null
   github_repo_full_name?: string | null
   allow_pr_previews?: boolean
+  public_dist_enabled?: boolean
   latest_pcb_preview_image_url?: string | null
   latest_sch_preview_image_url?: string | null
   latest_cad_preview_image_url?: string | null
@@ -51,6 +52,7 @@ export const publicMapPackage = (internalPackage: {
         ? true
         : (internalPackage.is_unlisted ?? false),
     allow_pr_previews: Boolean(internalPackage.allow_pr_previews),
+    public_dist_enabled: Boolean(internalPackage.public_dist_enabled),
     latest_pcb_preview_image_url:
       internalPackage.latest_pcb_preview_image_url ?? null,
     latest_sch_preview_image_url:

--- a/fake-snippets-api/routes/api/packages/create.ts
+++ b/fake-snippets-api/routes/api/packages/create.ts
@@ -125,6 +125,7 @@ export default withRouteSpec({
     is_unlisted: is_private === true ? true : (is_unlisted ?? false),
     ai_usage_instructions: "placeholder ai usage instructions",
     default_view: "files",
+    public_dist_enabled: false,
   })
 
   if (!newPackage) {

--- a/fake-snippets-api/routes/api/packages/update.ts
+++ b/fake-snippets-api/routes/api/packages/update.ts
@@ -23,6 +23,7 @@ export default withRouteSpec({
       is_unlisted: z.boolean().optional(),
       default_view: z.enum(["files", "3d", "pcb", "schematic"]).optional(),
       allow_pr_previews: z.boolean().optional(),
+      public_dist_enabled: z.boolean().optional(),
     })
     .transform((data) => ({
       ...data,
@@ -43,6 +44,7 @@ export default withRouteSpec({
     github_repo_full_name,
     default_view,
     allow_pr_previews,
+    public_dist_enabled,
   } = req.jsonBody
 
   const packageIndex = ctx.db.packages.findIndex(
@@ -105,6 +107,8 @@ export default withRouteSpec({
     default_view: default_view ?? existingPackage.default_view,
     updated_at: new Date().toISOString(),
     allow_pr_previews: allow_pr_previews ?? existingPackage.allow_pr_previews,
+    public_dist_enabled:
+      public_dist_enabled ?? existingPackage.public_dist_enabled,
   })
 
   if (!updatedPackage) {

--- a/src/pages/package-settings.tsx
+++ b/src/pages/package-settings.tsx
@@ -186,6 +186,7 @@ export default function PackageSettingsPage() {
     defaultView: "files",
     githubRepoFullName: null as string | null,
     allowPrPreviews: false,
+    publicDistEnabled: false,
   })
 
   const [showDeleteDialog, setShowDeleteDialog] = useState(false)
@@ -222,6 +223,7 @@ export default function PackageSettingsPage() {
       defaultView: packageInfo.default_view || "files",
       githubRepoFullName: packageInfo.github_repo_full_name || null,
       allowPrPreviews: packageInfo.allow_pr_previews ?? false,
+      publicDistEnabled: packageInfo.public_dist_enabled ?? false,
     }
   }, [packageInfo, packageRelease, currentLicense])
 
@@ -345,6 +347,8 @@ export default function PackageSettingsPage() {
         updatePayload.is_private = formData.visibility === "private"
       if (fieldName === "defaultView")
         updatePayload.default_view = formData.defaultView
+      if (fieldName === "publicDistEnabled")
+        updatePayload.public_dist_enabled = formData.publicDistEnabled
       if (fieldName === "github") {
         updatePayload.github_repo_full_name =
           formData.githubRepoFullName === "unlink//repo"
@@ -451,6 +455,9 @@ export default function PackageSettingsPage() {
   const hasGithubChanged =
     initialFormData &&
     formData.githubRepoFullName !== initialFormData.githubRepoFullName
+  const hasPublicDistEnabledChanged =
+    initialFormData &&
+    formData.publicDistEnabled !== initialFormData.publicDistEnabled
 
   return (
     <div className="min-h-screen bg-white">
@@ -723,6 +730,48 @@ export default function PackageSettingsPage() {
                   </Select>
                 </SettingCard>
 
+                <SettingCard
+                  title="Public Dist"
+                  description="Enable users to install this package without authorization"
+                  onSave={() => saveField("publicDistEnabled")}
+                  saveDisabled={
+                    !hasPublicDistEnabledChanged ||
+                    savingField === "publicDistEnabled"
+                  }
+                  footer={
+                    <Button
+                      size="sm"
+                      onClick={() => saveField("publicDistEnabled")}
+                      disabled={
+                        !hasPublicDistEnabledChanged ||
+                        savingField === "publicDistEnabled"
+                      }
+                    >
+                      {savingField === "publicDistEnabled" && (
+                        <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+                      )}
+                      Save
+                    </Button>
+                  }
+                >
+                  <Select
+                    value={formData.publicDistEnabled ? "enabled" : "disabled"}
+                    onValueChange={(value) =>
+                      setFormData((prev) => ({
+                        ...prev,
+                        publicDistEnabled: value === "enabled",
+                      }))
+                    }
+                  >
+                    <SelectTrigger className="w-full sm:w-48 text-sm">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="disabled">Disabled</SelectItem>
+                      <SelectItem value="enabled">Enabled</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </SettingCard>
                 <SettingCard
                   title="Default View"
                   description="The default tab shown when someone visits your package page."


### PR DESCRIPTION
### Motivation
- Expose a `public_dist_enabled` package property so the fake API and frontend can indicate whether a package's `dist` is installable without authorization.
- Allow maintainers to enable/disable this flag from the package settings UI and persist changes via `/packages/update`.

### Description
- Added `public_dist_enabled` to the package schema in `fake-snippets-api/lib/db/schema.ts` and included it in public mapping at `fake-snippets-api/lib/public-mapping/public-map-package.ts` so API responses include the property.
- Extended package creation paths to default `public_dist_enabled` to `false` (in `fake-snippets-api/routes/api/packages/create.ts` and snippet-backed package creation in `fake-snippets-api/lib/db/db-client.ts`).
- Updated `/api/packages/update` to accept `public_dist_enabled` in request validation and persist it when updating a package (in `fake-snippets-api/routes/api/packages/update.ts`).
- Added a new "Public Dist" setting to the Package Settings page (`src/pages/package-settings.tsx`) with the description "Enable users to install this package without authorization" and wired save behavior to send `public_dist_enabled` via the existing `/packages/update` endpoint.
- Added unit tests (`bun-tests/fake-snippets-api/routes/packages/update.test.ts`) that verify the default value and update behavior of `public_dist_enabled` on the fake API.

### Testing
- Ran `bun test bun-tests/fake-snippets-api/routes/packages/update.test.ts` and all tests passed (10 tests, 0 failures). 
- Ran typecheck with `bunx tsc --noEmit` and it completed successfully with no errors.
- Ran formatting with `bun run format` which completed successfully.
- Attempted to capture a UI screenshot via Playwright while running the dev server, but the browser process crashed (Chromium SIGSEGV) in this environment so no screenshot was produced; this did not affect the automated tests which passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b3af03cc0c832e8e64c6b73c9cd3f0)