### PR TITLE
Enable STEP/STP downloads in editor

### DIFF
--- a/src/hooks/useOptimizedPackageFilesLoader.ts
+++ b/src/hooks/useOptimizedPackageFilesLoader.ts
@@ -3,6 +3,7 @@ import { usePackageFiles } from "@/hooks/use-package-files"
 import { useApiBaseUrl } from "@/hooks/use-packages-base-api-url"
 import type { Package } from "fake-snippets-api/lib/db/schema"
 import { useMemo, useState } from "react"
+import { isDownloadOnlyPackageFile } from "@/lib/is-download-only-package-file"
 import { useQueries, useQuery } from "react-query"
 import { useGlobalStore } from "./use-global-store"
 
@@ -86,7 +87,10 @@ export function useOptimizedPackageFilesLoader(
       let content: string
       let isBinary = false
       let fileDownloadUrl: string | undefined
-      if (packageFile?.is_text === false) {
+      const isDownloadOnlyFile = isDownloadOnlyPackageFile(
+        priorityFileData.file_path,
+      )
+      if (packageFile?.is_text === false || isDownloadOnlyFile) {
         const downloadUrl = `${apiBaseUrl}/package_files/download?package_file_id=${priorityFileData.package_file_id}`
         const binaryResponse = await fetch(downloadUrl, {
           headers: sessionToken
@@ -96,13 +100,20 @@ export function useOptimizedPackageFilesLoader(
             : {},
         })
         const blob = await binaryResponse.blob()
-        const text = await blob.text()
-        if (isTextContent(text)) {
-          content = text
-        } else {
+
+        if (isDownloadOnlyFile) {
           content = blobToBlobUrl(blob)
           isBinary = true
           fileDownloadUrl = downloadUrl
+        } else {
+          const text = await blob.text()
+          if (isTextContent(text)) {
+            content = text
+          } else {
+            content = blobToBlobUrl(blob)
+            isBinary = true
+            fileDownloadUrl = downloadUrl
+          }
         }
       } else {
         content = packageFile?.content_text ?? ""
@@ -143,7 +154,8 @@ export function useOptimizedPackageFilesLoader(
           let content: string
           let isBinary = false
           let fileDownloadUrl: string | undefined
-          if (packageFile?.is_text === false) {
+          const isDownloadOnlyFile = isDownloadOnlyPackageFile(file.file_path)
+          if (packageFile?.is_text === false || isDownloadOnlyFile) {
             const downloadUrl = `${apiBaseUrl}/package_files/download?package_file_id=${file.package_file_id}`
             const binaryResponse = await fetch(downloadUrl, {
               headers: sessionToken
@@ -153,13 +165,20 @@ export function useOptimizedPackageFilesLoader(
                 : {},
             })
             const blob = await binaryResponse.blob()
-            const text = await blob.text()
-            if (isTextContent(text)) {
-              content = text
-            } else {
+
+            if (isDownloadOnlyFile) {
               content = blobToBlobUrl(blob)
               isBinary = true
               fileDownloadUrl = downloadUrl
+            } else {
+              const text = await blob.text()
+              if (isTextContent(text)) {
+                content = text
+              } else {
+                content = blobToBlobUrl(blob)
+                isBinary = true
+                fileDownloadUrl = downloadUrl
+              }
             }
           } else {
             content = packageFile?.content_text ?? ""

--- a/src/lib/is-download-only-package-file.test.ts
+++ b/src/lib/is-download-only-package-file.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "bun:test"
+import { isDownloadOnlyPackageFile } from "./is-download-only-package-file"
+
+describe("isDownloadOnlyPackageFile", () => {
+  it("marks STEP files as download-only assets", () => {
+    expect(isDownloadOnlyPackageFile("assets/model.step")).toBe(true)
+    expect(isDownloadOnlyPackageFile("assets/model.STP")).toBe(true)
+  })
+
+  it("does not mark editable source files as download-only", () => {
+    expect(isDownloadOnlyPackageFile("index.tsx")).toBe(false)
+    expect(isDownloadOnlyPackageFile("dist/circuit.json")).toBe(false)
+  })
+})

--- a/src/lib/is-download-only-package-file.ts
+++ b/src/lib/is-download-only-package-file.ts
@@ -1,0 +1,9 @@
+export const DOWNLOAD_ONLY_PACKAGE_FILE_EXTENSIONS = new Set(["step", "stp"])
+
+export function isDownloadOnlyPackageFile(filePath: string): boolean {
+  const extension = filePath.split(".").pop()?.toLowerCase()
+
+  if (!extension) return false
+
+  return DOWNLOAD_ONLY_PACKAGE_FILE_EXTENSIONS.has(extension)
+}


### PR DESCRIPTION
### Motivation
- STEP (`.step`/`.stp`) package files should be downloadable from the `/editor` UI rather than attempted to be opened as editable text. 
- Centralize the download-only classification so non-editable CAD assets are handled consistently and can expose a download URL.

### Description
- Add a helper `isDownloadOnlyPackageFile` in `src/lib/is-download-only-package-file.ts` to classify `.step` and `.stp` files as download-only. 
- Update `useOptimizedPackageFilesLoader` (`src/hooks/useOptimizedPackageFilesLoader.ts`) to treat download-only files like binaries by fetching them as blobs, creating a blob URL for display, and exposing a `downloadUrl`/`isBinary` flag for the editor UI. 
- Apply the same behavior for both the priority file load and remaining file loads so clicking STEP assets in `/editor` results in a download link. 
- Add a focused unit test `src/lib/is-download-only-package-file.test.ts` covering STEP/STP detection and ensuring regular source files are not marked download-only.

### Testing
- Ran the unit test with `bun test ./src/lib/is-download-only-package-file.test.ts` and it passed. 
- Ran `bun run format` to format files successfully. 
- Ran `bunx tsc --noEmit` (typecheck) but it timed out in this environment (attempted with a timeout wrapper).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69be2fde6cf0832e9bde803b9d66507c)