### PR TITLE
Update 404 message to mention private packages

### DIFF
--- a/src/components/NotFound.tsx
+++ b/src/components/NotFound.tsx
@@ -16,8 +16,7 @@ export function NotFound({ heading = "Page not found" }: { heading?: string }) {
           {heading}
         </h1>
         <p className="text-xl text-muted-foreground mb-8">
-          The page you're looking for doesn't exist or has been moved to another
-          address.
+          The page you're looking for doesn't exist or may be private.
         </p>
         <div className="flex flex-col sm:flex-row gap-4">
           <Link href="/">


### PR DESCRIPTION
### Motivation
- Clarify the 404 page copy so users know a missing page may be private rather than only moved.

### Description
- Replace the text in `src/components/NotFound.tsx` from "moved to another address" to "or may be private".

### Testing
- Ran TypeScript typecheck with `bunx tsc --noEmit`, which succeeded.
- Ran project formatter with `bun run format`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e165b424ac832e90b66c5d7f91c89c)