### PR TITLE
Fix root route to perform HTTP redirect to landing app

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -12,15 +12,16 @@
   ],
   "rewrites": [
     {
-      "source": "/",
-      "destination": "https://tscircuit-com-landing.vercel.app"
-    },
-    {
       "source": "/(.*)",
       "destination": "/api/generated-index"
     }
   ],
   "redirects": [
+    {
+      "source": "/",
+      "destination": "https://tscircuit-com-landing.vercel.app",
+      "permanent": false
+    },
     {
       "source": "/community/join-redirect",
       "destination": "https://discord.gg/V7FGE5ZCbA",


### PR DESCRIPTION
### Motivation
- The site root was configured as a `rewrite`, which proxied the landing app content while keeping the browser URL at `tscircuit.com/`, so users were not redirected to the landing app URL.  
- The intended behavior is an HTTP redirect from `/` to `https://tscircuit-com-landing.vercel.app` so the browser navigates to the landing app address.

### Description
- Updated `vercel.json` to remove the `/` rule from `rewrites` and add an equivalent entry under `redirects` as `{ "source": "/", "destination": "https://tscircuit-com-landing.vercel.app", "permanent": false }`.  
- Kept the existing catch-all rewrite `"/(.*)" -> "/api/generated-index"` for all other routes.  
- Ensured `permanent` is `false` so the redirect returns an HTTP 3xx (non-permanent) response.

### Testing
- Verified the configuration file with `cat vercel.json` and confirmed the `redirects` entry is present; command succeeded.  
- Inspected the diff with `git diff -- vercel.json` to confirm the `/` rewrite was removed and a redirect was added; command succeeded.  
- Printed the file with `nl -ba vercel.json` to validate the final JSON structure and ordering; command succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e6b43e4aac8327b715d6bc77cca48d)