### PR TITLE
fix: the rewrite is fixed now and shows the new landing page

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -22,6 +22,14 @@
   ],
   "rewrites": [
     {
+      "source": "/assets/:path*",
+      "destination": "https://tscircuit-com-landing.vercel.app/assets/:path*"
+    },
+    {
+      "source": "/favicon.ico",
+      "destination": "https://tscircuit-com-landing.vercel.app/favicon.ico"
+    },
+    {
       "source": "/(.*)",
       "destination": "/api/generated-index"
     }

--- a/vercel.json
+++ b/vercel.json
@@ -22,12 +22,8 @@
   ],
   "rewrites": [
     {
-      "source": "/assets/:path*",
-      "destination": "https://tscircuit-com-landing.vercel.app/assets/:path*"
-    },
-    {
-      "source": "/favicon.ico",
-      "destination": "https://tscircuit-com-landing.vercel.app/favicon.ico"
+      "source": "/(.*)",
+      "destination": "/api/generated-index"
     }
   ],
   "redirects": [

--- a/vercel.json
+++ b/vercel.json
@@ -10,11 +10,17 @@
       ]
     }
   ],
-  "rewrites": [
+  "routes": [
     {
-      "source": "/",
-      "destination": "https://tscircuit-com-landing.vercel.app/"
+      "src": "^/$",
+      "dest": "https://tscircuit-com-landing.vercel.app/index.html"
     },
+    {
+      "src": "^/index\\.html$",
+      "dest": "https://tscircuit-com-landing.vercel.app/index.html"
+    }
+  ],
+  "rewrites": [
     {
       "source": "/assets/:path*",
       "destination": "https://tscircuit-com-landing.vercel.app/assets/:path*"

--- a/vercel.json
+++ b/vercel.json
@@ -22,10 +22,6 @@
     {
       "source": "/favicon.ico",
       "destination": "https://tscircuit-com-landing.vercel.app/favicon.ico"
-    },
-    {
-      "source": "/(.*)",
-      "destination": "/api/generated-index"
     }
   ],
   "redirects": [

--- a/vercel.json
+++ b/vercel.json
@@ -13,7 +13,15 @@
   "rewrites": [
     {
       "source": "/",
-      "destination": "https://tscircuit-com-landing.vercel.app"
+      "destination": "https://tscircuit-com-landing.vercel.app/"
+    },
+    {
+      "source": "/assets/:path*",
+      "destination": "https://tscircuit-com-landing.vercel.app/assets/:path*"
+    },
+    {
+      "source": "/favicon.ico",
+      "destination": "https://tscircuit-com-landing.vercel.app/favicon.ico"
     },
     {
       "source": "/(.*)",


### PR DESCRIPTION
This pull request updates the `vercel.json` configuration to improve routing and asset handling for the deployment. The main focus is on ensuring that requests to the root path and specific static assets are correctly forwarded to the landing page and its resources.

Routing improvements:

* Added new `routes` entries so that requests to `/` and `/index.html` are explicitly redirected to the landing page (`index.html`) hosted on `tscircuit-com-landing.vercel.app`.

Asset and static file handling:

* Updated `rewrites` to forward requests for `/assets/:path*` and `/favicon.ico` to their corresponding resources on the landing page domain, ensuring static assets and the favicon are served correctly.