### PR TITLE
Fix logged-in login redirect to dashboard

### DIFF
--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -10,7 +10,7 @@ const LoginContent = () => {
   // const { handleLogout: handleSignOut, isSigningOut } = useLogout()
 
   if (session) {
-    return <Redirect to={`/settings`} />
+    return <Redirect to={`/dashboard`} />
     // return (
     //   <main className="flex-1 flex items-center justify-center px-4 py-12 bg-gradient-to-b from-white to-gray-50">
     //     <div className="w-full max-w-2xl">


### PR DESCRIPTION
## Summary
- Redirect authenticated users visiting `/login` to `/dashboard` instead of `/settings`

## Testing
- Not run (not requested)