### PR TITLE
fix: update home links to point to https://tscircuit.com/

### DIFF
--- a/src/components/ContentLoadingErrorPage.tsx
+++ b/src/components/ContentLoadingErrorPage.tsx
@@ -40,7 +40,7 @@ export const ContentLoadingErrorPage = ({
           )}
         </div>
         <div className="space-y-3">
-          <Link href="/">
+          <Link href="https://tcircuit.com/">
             <button className="w-full sm:w-auto inline-flex items-center justify-center px-6 py-2 border border-transparent text-base font-medium rounded-lg text-white bg-blue-600 hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600 transition-colors duration-200">
               Return Home
             </button>

--- a/src/components/ContentLoadingErrorPage.tsx
+++ b/src/components/ContentLoadingErrorPage.tsx
@@ -40,7 +40,7 @@ export const ContentLoadingErrorPage = ({
           )}
         </div>
         <div className="space-y-3">
-          <Link href="https://tcircuit.com/">
+          <Link href="https://tscircuit.com/">
             <button className="w-full sm:w-auto inline-flex items-center justify-center px-6 py-2 border border-transparent text-base font-medium rounded-lg text-white bg-blue-600 hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600 transition-colors duration-200">
               Return Home
             </button>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -76,7 +76,7 @@ export default function Header() {
     <header className="px-4 py-3">
       <div className="flex items-center">
         <Link
-          href="https://tcircuit.com/"
+          href="https://tscircuit.com/"
           className="text-lg font-semibold whitespace-nowrap select-none"
         >
           <span className="bg-blue-500 px-2 py-1 rounded-md text-white">

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -76,7 +76,7 @@ export default function Header() {
     <header className="px-4 py-3">
       <div className="flex items-center">
         <Link
-          href="/"
+          href="https://tcircuit.com/"
           className="text-lg font-semibold whitespace-nowrap select-none"
         >
           <span className="bg-blue-500 px-2 py-1 rounded-md text-white">

--- a/src/components/Header2.tsx
+++ b/src/components/Header2.tsx
@@ -60,7 +60,7 @@ export const Header2 = () => {
       <header className="sticky top-0 z-50 w-full border-b bg-white md:bg-white/80 md:backdrop-blur supports-[backdrop-filter]:md:bg-white/60">
         <div className="container mx-auto flex h-16 items-center justify-between px-2 md:px-6">
           <Link
-            href="https://tcircuit.com/"
+            href="https://tscircuit.com/"
             className="flex select-none items-center"
           >
             <span className="bg-blue-500 px-2 py-1 rounded-md text-white text-sm font-semibold sm:text-base">

--- a/src/components/Header2.tsx
+++ b/src/components/Header2.tsx
@@ -59,7 +59,7 @@ export const Header2 = () => {
     <>
       <header className="sticky top-0 z-50 w-full border-b bg-white md:bg-white/80 md:backdrop-blur supports-[backdrop-filter]:md:bg-white/60">
         <div className="container mx-auto flex h-16 items-center justify-between px-2 md:px-6">
-          <Link href="/" className="flex select-none items-center">
+          <Link href="https://tcircuit.com/" className="flex select-none items-center">
             <span className="bg-blue-500 px-2 py-1 rounded-md text-white text-sm font-semibold sm:text-base">
               tscircuit
             </span>

--- a/src/components/Header2.tsx
+++ b/src/components/Header2.tsx
@@ -59,7 +59,10 @@ export const Header2 = () => {
     <>
       <header className="sticky top-0 z-50 w-full border-b bg-white md:bg-white/80 md:backdrop-blur supports-[backdrop-filter]:md:bg-white/60">
         <div className="container mx-auto flex h-16 items-center justify-between px-2 md:px-6">
-          <Link href="https://tcircuit.com/" className="flex select-none items-center">
+          <Link
+            href="https://tcircuit.com/"
+            className="flex select-none items-center"
+          >
             <span className="bg-blue-500 px-2 py-1 rounded-md text-white text-sm font-semibold sm:text-base">
               tscircuit
             </span>

--- a/src/components/HeaderLogin.tsx
+++ b/src/components/HeaderLogin.tsx
@@ -159,7 +159,7 @@ export const HeaderLogin = () => {
           </DropdownMenuItem>
           <DropdownMenuItem asChild>
             <Link
-              href="/"
+              href="https://tcircuit.com/"
               className="cursor-pointer"
               onClick={(e) => {
                 e.preventDefault()

--- a/src/components/HeaderLogin.tsx
+++ b/src/components/HeaderLogin.tsx
@@ -159,7 +159,7 @@ export const HeaderLogin = () => {
           </DropdownMenuItem>
           <DropdownMenuItem asChild>
             <Link
-              href="https://tcircuit.com/"
+              href="https://tscircuit.com/"
               className="cursor-pointer"
               onClick={(e) => {
                 e.preventDefault()

--- a/src/components/NotFound.tsx
+++ b/src/components/NotFound.tsx
@@ -19,7 +19,7 @@ export function NotFound({ heading = "Page not found" }: { heading?: string }) {
           The page you're looking for doesn't exist or may be private.
         </p>
         <div className="flex flex-col sm:flex-row gap-4">
-          <Link href="https://tcircuit.com/">
+          <Link href="https://tscircuit.com/">
             <Button size="lg" className="bg-blue-500 hover:bg-blue-600 w-full">
               Return Home
             </Button>

--- a/src/components/NotFound.tsx
+++ b/src/components/NotFound.tsx
@@ -19,7 +19,7 @@ export function NotFound({ heading = "Page not found" }: { heading?: string }) {
           The page you're looking for doesn't exist or may be private.
         </p>
         <div className="flex flex-col sm:flex-row gap-4">
-          <Link href="/">
+          <Link href="https://tcircuit.com/">
             <Button size="lg" className="bg-blue-500 hover:bg-blue-600 w-full">
               Return Home
             </Button>


### PR DESCRIPTION
Updates the header logo, account menu home link, not-found page, and content-loading error page so “Home” navigation consistently routes users to
  https://tscircuit.com/ instead of the app-local / path.

  This fixes confusing navigation from embedded or nested app routes where returning home should take users to the main tscircuit site.