### PR TITLE
update circuit-json-to-kicad 0.0.34 to 0.0.124

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "circuit-json-to-bom-csv": "^0.0.7",
     "circuit-json-to-gerber": "^0.0.48",
     "circuit-json-to-gltf": "^0.0.91",
-    "circuit-json-to-kicad": "^0.0.34",
+    "circuit-json-to-kicad": "^0.0.124",
     "circuit-json-to-lbrn": "^0.0.23",
     "circuit-json-to-pnp-csv": "^0.0.7",
     "circuit-json-to-readable-netlist": "^0.0.13",


### PR DESCRIPTION
**Motivation**: after successful repro in circuit-json-to-kicad found that courtyard export is working in latest version but not in tscircuit.com. 