### PR TITLE
Consider editor fully loaded when package metadata and priority file are ready

### DIFF
--- a/src/hooks/useFileManagement.ts
+++ b/src/hooks/useFileManagement.ts
@@ -316,8 +316,10 @@ export function useFileManagement({
   ])
 
   const isFullyLoaded = useMemo(() => {
-    return !isLoadingPackageFilesWithContent && !isLoadingPackageFiles
-  }, [isLoadingPackageFilesWithContent, isLoadingPackageFiles])
+    // Consider the editor interactive once metadata and the priority file are ready.
+    // Remaining files continue streaming in the background.
+    return !isLoadingPackageFiles && isPriorityFileFetched
+  }, [isLoadingPackageFiles, isPriorityFileFetched])
 
   const fsMap = useMemo(() => {
     const map = localFiles.reduce(


### PR DESCRIPTION
### Motivation
- Improve perceived editor interactivity by treating the editor as ready once package metadata and the priority file are available, allowing remaining files to stream in the background.

### Description
- Update `isFullyLoaded` to return `!isLoadingPackageFiles && isPriorityFileFetched` and add a clarifying comment that remaining files continue streaming in the background.
- Remove dependence on `isLoadingPackageFilesWithContent` from the `isFullyLoaded` logic and adjust the hook dependency array to `[isLoadingPackageFiles, isPriorityFileFetched]`.

### Testing
- Ran the test suite and type-checking (`tsc`) against the modified code and all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f3f4b01ac0832780844d3864a137ae)