### PR TITLE
Use a relative redirect for /playground so Vercel keeps requests on the current deployment

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -57,7 +57,7 @@
     },
     {
       "source": "/playground",
-      "destination": "https://tscircuit.com/editor?template=blank-circuit-board",
+      "destination": "/editor?template=blank-circuit-board",
       "permanent": false
     }
   ]


### PR DESCRIPTION
## Summary

  This PR updates the /playground redirect in vercel.json to point to /editor?template=blank-circuit-board instead of the absolute
  https://tscircuit.com/editor?... URL.

  ## Why

  Using an absolute production URL forces /playground traffic to leave the current Vercel deployment. Switching to a relative destination keeps the
  redirect on the active environment, which is safer for preview deployments and avoids unintentionally bouncing users to production.

  ## Change

  - Replace the /playground redirect destination with a relative /editor?template=blank-circuit-board path