### PR TITLE
Show Order button only for tscircuit staff users

### DIFF
--- a/src/components/ViewPackagePage/components/package-header.tsx
+++ b/src/components/ViewPackagePage/components/package-header.tsx
@@ -41,6 +41,7 @@ export default function PackageHeader({
     packageInfo?.owner_github_username ===
     useGlobalStore((s) => s.session?.github_username)
   const isLoggedIn = useGlobalStore((s) => s.session != null)
+  const isTscircuitStaff = useGlobalStore((s) => s.session?.is_tscircuit_staff)
   const [isOrderDialogOpen, setIsOrderDialogOpen] = useState(false)
 
   const { isStarred, starCount, toggleStar } = usePackageStarringByName(
@@ -133,15 +134,17 @@ export default function PackageHeader({
           </div>
 
           <div className="hidden md:flex items-center space-x-2">
-            {/* <Button
-              variant="outline"
-              size="sm"
-              onClick={handleOrderClick}
-              disabled={!packageInfo?.name}
-            >
-              <Package className="w-4 h-4 mr-2" />
-              Order
-            </Button> */}
+            {isTscircuitStaff && (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={handleOrderClick}
+                disabled={!packageInfo?.name}
+              >
+                <Package className="w-4 h-4 mr-2" />
+                Order
+              </Button>
+            )}
 
             <TooltipProvider>
               <Tooltip>
@@ -215,15 +218,17 @@ export default function PackageHeader({
 
           {/* Mobile buttons */}
           <div className="md:hidden flex items-center space-x-2 w-full justify-end pt-2">
-            {/* <Button
-              variant="outline"
-              size="sm"
-              onClick={handleOrderClick}
-              disabled={!packageInfo?.name}
-            >
-              <Package className="w-4 h-4 mr-2" />
-              Order
-            </Button> */}
+            {isTscircuitStaff && (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={handleOrderClick}
+                disabled={!packageInfo?.name}
+              >
+                <Package className="w-4 h-4 mr-2" />
+                Order
+              </Button>
+            )}
             <Button
               variant="outline"
               size="sm"

--- a/src/hooks/use-global-store.ts
+++ b/src/hooks/use-global-store.ts
@@ -9,6 +9,7 @@ export type Store = {
     github_username: string | null
     tscircuit_handle?: string | null
     email?: string
+    is_tscircuit_staff?: boolean
   } | null
   setSession: (session: Store["session"]) => any
   should_onboarding_tips_be_closed: boolean


### PR DESCRIPTION
### Motivation
- Enable the `Order` action only for accounts marked as staff so non-staff users do not see the button.
- Restore the previously-commented `Order` UI so staff can open the order dialog from both desktop and mobile layouts.

### Description
- Added a `isTscircuitStaff` selector from the global session state via `useGlobalStore((s) => s.session?.is_tscircuit_staff)` in `package-header.tsx`.
- Replaced the commented-out `Order` button blocks with conditional rendering `isTscircuitStaff && <Button ...>Order</Button>` in the desktop action row.
- Applied the same conditional rendering for the `Order` button in the mobile buttons row and left the `OrderDialog` behavior unchanged.

### Testing
- No automated tests were run for this UI-only conditional rendering change.
- Verified the file diff locally to ensure only the `Order` button rendering and the session selector were modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f974b1751c8327bd38b8ecae811251)