### PR TITLE
Fix overriding css from the `@tscircuit/order-dialog`

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@tscircuit/fake-snippets",
@@ -56,7 +55,7 @@
         "@tscircuit/internal-dynamic-import": "^0.0.5",
         "@tscircuit/layout": "^0.0.29",
         "@tscircuit/mm": "^0.0.8",
-        "@tscircuit/order-dialog": "git+https://github.com/tscircuit/order-dialog.git#e48e2daba9a0e562c2dda3256fb0c1cd04cd649c",
+        "@tscircuit/order-dialog": "git+https://github.com/tscircuit/order-dialog.git#7d5cdaf",
         "@tscircuit/pcb-viewer": "1.11.368",
         "@tscircuit/prompt-benchmarks": "^0.0.28",
         "@tscircuit/props": "^0.0.499",
@@ -864,7 +863,7 @@
 
     "@tscircuit/ngspice-spice-engine": ["@tscircuit/ngspice-spice-engine@0.0.8", "", { "dependencies": { "eecircuit-engine": "^1.5.6" }, "peerDependencies": { "@tscircuit/props": "*", "circuit-json": "*", "typescript": "^5" } }, "sha512-jubJ8Kgpm9FPRdHBiRBYkf5+B37bqkjDRKpCXOMqS08UZnbS+iCv2k4ACMW+s1zbK0Xa5v+9yjuoHlfKFW1v/Q=="],
 
-    "@tscircuit/order-dialog": ["@tscircuit/order-dialog@github:tscircuit/order-dialog#e48e2da", { "peerDependencies": { "react": "^18.3.0 || ^19.0.0", "react-dom": "^18.3.0 || ^19.0.0" } }, "tscircuit-order-dialog-e48e2da", "sha512-j/lNulvS0i0q+Tq88uLk5BIjDlNCPSwkSILrdVVNaVSJVegtdLKwOvzbfevqUSLFGxctBfg6fsvXEP1QaV0Unw=="],
+    "@tscircuit/order-dialog": ["@tscircuit/order-dialog@github:tscircuit/order-dialog#7d5cdaf", { "peerDependencies": { "react": "^18.3.0 || ^19.0.0", "react-dom": "^18.3.0 || ^19.0.0" } }, "tscircuit-order-dialog-7d5cdaf"],
 
     "@tscircuit/pcb-viewer": ["@tscircuit/pcb-viewer@1.11.368", "", { "dependencies": { "@emotion/css": "^11.11.2", "@tscircuit/alphabet": "^0.0.23", "@tscircuit/math-utils": "^0.0.29", "@vitejs/plugin-react": "^5.0.2", "circuit-json": "^0.0.421", "circuit-to-canvas": "^0.0.98", "circuit-to-svg": "^0.0.337", "color": "^4.2.3", "react-supergrid": "^1.0.10", "react-toastify": "^10.0.5", "transformation-matrix": "^2.13.0", "zustand": "^4.5.2" }, "peerDependencies": { "react": "*", "tscircuit": "*" } }, "sha512-gHkBz4zFMFMqX5ZiL33HCWn7yWV/cYvGr2TJ/JTxMQCa5LYz9wT6SvM/sFu0yevgkr407zqfZOSP3BdJC7qvPQ=="],
 
@@ -1546,7 +1545,7 @@
 
     "he": ["he@1.2.0", "", { "bin": { "he": "bin/he" } }, "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="],
 
-    "high-density-repair02": ["high-density-repair02@github:tscircuit/high-density-repair02#5509821", {}, "tscircuit-high-density-repair02-5509821", "sha512-eZijJpjCTiPeG4qFBiUSu0J1UbuECKycF0snJBywK+0+avjI191Hmyks7NAmn9FS9V8OBWzANWER3VrwlhuHCQ=="],
+    "high-density-repair02": ["high-density-repair02@github:tscircuit/high-density-repair02#5509821", {}, "tscircuit-high-density-repair02-5509821"],
 
     "html-url-attributes": ["html-url-attributes@3.0.1", "", {}, "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ=="],
 

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "@tscircuit/runframe": "^0.0.1928",
     "@tscircuit/schematic-viewer": "^2.0.61",
     "@tscircuit/simple-3d-svg": "^0.0.41",
-    "@tscircuit/order-dialog": "git+https://github.com/tscircuit/order-dialog.git#e48e2daba9a0e562c2dda3256fb0c1cd04cd649c",
+    "@tscircuit/order-dialog": "git+https://github.com/tscircuit/order-dialog.git#7d5cdaf",
     "@types/babel__standalone": "^7.1.7",
     "@types/bun": "^1.1.10",
     "@types/country-list": "^2.1.4",


### PR DESCRIPTION
### Motivation
- Pin `@tscircuit/order-dialog` to commit `7d5cdaf` to pull the intended upstream changes into the workspace.

### Description
- Updated the `@tscircuit/order-dialog` dependency in `package.json` to `git+https://github.com/tscircuit/order-dialog.git#7d5cdaf`.
- Ran `bun i`, which refreshed `bun.lock` to reference the new commit and updated the lockfile entries accordingly.
- Files changed: `package.json` and `bun.lock`.

### Testing
- Ran `bun i`, which completed successfully and saved an updated `bun.lock`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69faeaddc7b48327904695426010b73e)