### PR TITLE
repro: scoped package release creation fails when using package_name_with_version

### DIFF
--- a/bun-tests/fake-snippets-api/routes/package_releases/create.test.ts
+++ b/bun-tests/fake-snippets-api/routes/package_releases/create.test.ts
@@ -137,6 +137,31 @@ test("create package release - package not found", async () => {
   }
 })
 
+test("create package release using scoped package_name_with_version (e.g. @testuser/pkg@1.0.0)", async () => {
+  const { axios } = await getTestServer()
+
+  // Create a package under testuser namespace
+  const packageResponse = await axios.post("/api/packages/create", {
+    name: "testuser/scoped-pkg",
+    description: "Scoped Package Test",
+  })
+  expect(packageResponse.status).toBe(200)
+  const createdPackage = packageResponse.data.package
+
+  // Try to create a release using a scoped name with a leading '@'
+  // Bug: split("@") on "@testuser/scoped-pkg@1.0.0" produces ["", "testuser/scoped-pkg", "1.0.0"]
+  // so packageName = "" and the DB lookup fails with "Package not found: "
+  const releaseResponse = await axios.post("/api/package_releases/create", {
+    package_name_with_version: `@${createdPackage.name}@1.0.0`,
+  })
+  expect(releaseResponse.status).toBe(200)
+  expect(releaseResponse.data.ok).toBe(true)
+  expect(releaseResponse.data.package_release.package_id).toBe(
+    createdPackage.package_id,
+  )
+  expect(releaseResponse.data.package_release.version).toBe("1.0.0")
+})
+
 test("create package release under org", async () => {
   const { axios } = await getTestServer()
 


### PR DESCRIPTION
Adds a reproduction unit test showing that creating a package release via `/api/package_releases/create` using a scoped `package_name_with_version` (e.g. `@testuser/pkg@1.0.0`) fails with a `404 Package not found: ` error.

## Root Cause

The endpoint splits `package_name_with_version` using `.split("@")`:

```ts
const [packageName, parsedVersion] = package_name_with_version.split("@")
```

For a scoped package like `@testuser/scoped-pkg@1.0.0`, `.split("@")` produces:
```
["", "testuser/scoped-pkg", "1.0.0"]
```

So `packageName = ""` and the DB lookup returns `Package not found: ` (empty name). All scoped package version creation, lookup, and file operations are broken.

This affects:
- `POST /api/package_releases/create`
- `POST /api/package_releases/update`
- `POST /api/package_releases/get`
- `GET/POST /api/package_releases/get_preview_circuit_json`
- `getPackageFileIdFromFileDescriptor` helper

```bash
bun test bun-tests/fake-snippets-api/routes/package_releases/create.test.ts
```