### PR TITLE
Gate recent command palette package fetches on dialog open

### DIFF
--- a/src/components/CmdKMenu.tsx
+++ b/src/components/CmdKMenu.tsx
@@ -230,7 +230,7 @@ const CmdKMenu = () => {
       }
     },
     {
-      enabled: !!currentUserAccountId && !searchQuery,
+      enabled: open && !!currentUserAccountId && !searchQuery,
       retry: false,
       refetchOnWindowFocus: false,
       refetchOnMount: false,


### PR DESCRIPTION
### Summary
This change prevents the command palette from fetching recent packages while it is closed.

### What changed
- Updated the `recentPackages` query in `src/components/CmdKMenu.tsx`
- Added `open &&` to the React Query `enabled` condition

### Why
Previously, the query could run as soon as `CmdKMenu` mounted, as long as the user was logged in and the search input was empty. That meant background network work was happening even if the command palette was never opened.

### Behavior before
- `CmdKMenu` mounted
- Logged-in user with empty search state triggered the recent packages query
- Request could run while the palette was closed

### Behavior after
- `CmdKMenu` mounts without fetching recent packages
- The query only becomes eligible when the command palette is open
- Recent packages are fetched only when the user actually uses the palette

### Impact
- Reduces unnecessary background requests
- Avoids loading palette-only data until it is needed
- Keeps command palette data fetching aligned with user interaction

### Testing
- Verified the query `enabled` condition now requires `open`