### PR TITLE
Fix stale page titles in order workflow pages

### DIFF
--- a/src/pages/my-orders.tsx
+++ b/src/pages/my-orders.tsx
@@ -1,4 +1,5 @@
 import { useQuery } from "react-query"
+import { Helmet } from "react-helmet-async"
 import { useAxios } from "@/hooks/use-axios"
 import { useGlobalStore } from "@/hooks/use-global-store"
 import Header from "@/components/Header"
@@ -104,6 +105,9 @@ export const MyOrdersPage = () => {
 
   return (
     <div className="min-h-screen bg-white flex flex-col">
+      <Helmet>
+        <title>My orders - tscircuit</title>
+      </Helmet>
       <Header />
       <main className="flex-1">
         <section className="container mx-auto px-4 py-8 sm:py-12">

--- a/src/pages/order-cancel.tsx
+++ b/src/pages/order-cancel.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from "react"
+import { Helmet } from "react-helmet-async"
 import { useQuery } from "react-query"
 import { Link } from "wouter"
 import { ArrowLeft, Loader2, PackageCheck, TriangleAlert } from "lucide-react"
@@ -35,6 +36,9 @@ export const OrderCancelPage = () => {
 
   return (
     <div className="min-h-screen bg-white flex flex-col">
+      <Helmet>
+        <title>Order failed - tscircuit</title>
+      </Helmet>
       <Header />
       <main className="flex-1">
         <section className="max-w-3xl mx-auto px-4 py-16">

--- a/src/pages/order-detail.tsx
+++ b/src/pages/order-detail.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from "react"
+import { Helmet } from "react-helmet-async"
 import { useQuery } from "react-query"
 import { Link, useParams } from "wouter"
 import {
@@ -130,6 +131,12 @@ export const OrderDetailPage = () => {
   const submittedRelease = submittedReleaseQuery.data
   const submittedPackage = submittedPackageQuery.data
   const orderTitle = submittedPackage?.name ?? "PCB order"
+  const pageTitle =
+    error || !hasValidOrderId
+      ? "Order not found - tscircuit"
+      : order
+        ? `${orderTitle} order - tscircuit`
+        : "Order tracking - tscircuit"
   const currentStepIndex = order ? getCurrentStepIndex(order) : 0
   const completedStepCount = trackingSteps.filter(
     (step) => step.timestamp,
@@ -148,6 +155,9 @@ export const OrderDetailPage = () => {
 
   return (
     <div className="min-h-screen bg-white flex flex-col">
+      <Helmet>
+        <title>{pageTitle}</title>
+      </Helmet>
       <Header />
       <main className="flex-1">
         <section className="max-w-5xl mx-auto px-4 py-8 sm:py-12">

--- a/src/pages/order-detail.tsx
+++ b/src/pages/order-detail.tsx
@@ -135,7 +135,9 @@ export const OrderDetailPage = () => {
     error || !hasValidOrderId
       ? "Order not found - tscircuit"
       : order
-        ? `${orderTitle} order - tscircuit`
+        ? submittedPackage
+          ? `${submittedPackage.name} order - tscircuit`
+          : "PCB order - tscircuit"
         : "Order tracking - tscircuit"
   const currentStepIndex = order ? getCurrentStepIndex(order) : 0
   const completedStepCount = trackingSteps.filter(

--- a/src/pages/order-success.tsx
+++ b/src/pages/order-success.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from "react"
+import { Helmet } from "react-helmet-async"
 import { useQuery } from "react-query"
 import { Link } from "wouter"
 import {
@@ -42,6 +43,9 @@ export const OrderSuccessPage = () => {
 
   return (
     <div className="min-h-screen bg-white flex flex-col">
+      <Helmet>
+        <title>Order success - tscircuit</title>
+      </Helmet>
       <Header />
       <main className="flex-1">
         <section className="max-w-3xl mx-auto px-4 py-16">


### PR DESCRIPTION
## Summary
- Add explicit Helmet titles to order detail, order success, order cancel, and my orders pages
- Prevent order pages from inheriting stale titles like "Package not found" after client-side navigation
- Use state-aware titles for order detail loading, missing, and loaded states

## Testing
- Ran `bun run typecheck`
