### PR TITLE
Allow Circuit JSON import before login

### DIFF
--- a/playwright-tests/circuit-json-import.spec.ts
+++ b/playwright-tests/circuit-json-import.spec.ts
@@ -1,133 +1,75 @@
-import { test, expect } from "@playwright/test"
+import { type Page, expect, test } from "@playwright/test"
 import { exampleCircuitJson } from "./exampleCircuitJson"
 
-async function loginToSite(page) {
-  const loginButton = page.getByRole("button", { name: "Log in" })
-  if (await loginButton.isVisible()) {
-    await loginButton.click()
-    await page.waitForLoadState("networkidle")
-  }
+const quickstartUrl = "http://127.0.0.1:5177/quickstart"
+
+const openImportDialog = async (page: Page) => {
+  await page.goto(quickstartUrl)
+  await page.getByRole("button", { name: "Import JSON" }).click()
+  await expect(page.getByRole("dialog")).toBeVisible()
 }
 
-test.beforeEach(async ({ page }) => {
-  await page.goto("http://127.0.0.1:5177/quickstart")
-  await page.waitForTimeout(3000)
-  await loginToSite(page).catch(() => {})
-})
-
-test("should open and close the Circuit Json Import Dialog", async ({
+test("allows anonymous Circuit JSON paste import into the editor", async ({
   page,
 }) => {
-  const importButton = page.locator('button:has-text("Import Circuit JSON")')
+  await openImportDialog(page)
+
+  await page
+    .locator('textarea[placeholder="Paste the Circuit JSON."]')
+    .fill(JSON.stringify(exampleCircuitJson))
+
+  const importButton = page.getByRole("button", { name: "Import" })
+  await expect(importButton).toBeEnabled()
   await importButton.click()
 
-  const dialog = page.getByRole("dialog")
-  await expect(dialog).toBeVisible()
-
-  const closeButton = dialog.getByRole("button", { name: "Close" })
-  await closeButton.click()
-
-  await expect(dialog).not.toBeVisible()
+  await page.waitForURL(
+    /\/editor\?snippet_type=package#data:application\/gzip;base64,/,
+  )
+  await expect(page).toHaveURL(
+    /\/editor\?snippet_type=package#data:application\/gzip;base64,/,
+  )
 })
 
-test("should handle valid Circuit JSON input", async ({ page }) => {
-  const importButton = page.getByRole("button", { name: "Import Circuit JSON" })
-  await importButton.click()
-  const textarea = page.locator(
-    'textarea[placeholder="Paste the Circuit JSON."]',
-  )
-  await textarea.fill(JSON.stringify(exampleCircuitJson))
+test("allows anonymous Circuit JSON file upload into the editor", async ({
+  page,
+}) => {
+  await openImportDialog(page)
 
-  const importDialogButton = page.getByRole("button", { name: "Import" })
-  await importDialogButton.click()
-
-  const successToast = page.locator(
-    'div.text-sm.font-semibold:has-text("Import Successful")',
-  )
-  await successToast.waitFor({ state: "visible", timeout: 5000 })
-  await expect(successToast).toBeVisible()
-})
-
-test("should handle valid Circuit JSON file upload", async ({ page }) => {
-  const importButton = page.locator('button:has-text("Import Circuit JSON")')
-  await importButton.click()
-
-  const fileInput = page.locator('input[type="file"]')
-
-  await fileInput.setInputFiles({
+  await page.locator('input[type="file"]').setInputFiles({
     name: "circuit.json",
     mimeType: "application/json",
-    // @ts-expect-error didnt add node types to tsconfig
     buffer: Buffer.from(JSON.stringify(exampleCircuitJson)),
   })
 
-  const importDialogButton = page.getByRole("button", { name: "Import" })
-  await importDialogButton.click()
-  const successToast = page.locator(
-    'div.text-sm.font-semibold:has-text("Import Successful")',
+  await expect(page.getByText("Selected file:").first()).toBeVisible()
+  await page.getByRole("button", { name: "Import" }).click()
+
+  await expect(page).toHaveURL(
+    /\/editor\?snippet_type=package#data:application\/gzip;base64,/,
   )
-  await successToast.waitFor({ state: "visible", timeout: 5000 })
-  await expect(successToast).toBeVisible()
 })
 
-test("should handle invalid Circuit JSON input", async ({ page }) => {
-  const importButton = page.locator('button:has-text("Import Circuit JSON")')
-  await importButton.click()
+test("keeps import disabled until JSON content or a file is provided", async ({
+  page,
+}) => {
+  await openImportDialog(page)
 
-  const textarea = page.locator(
-    'textarea[placeholder="Paste the Circuit JSON."]',
-  )
-  await textarea.fill("invalid json content")
-
-  const importDialogButton = page.getByRole("button", { name: "Import" })
-  await importDialogButton.click()
-
-  const errorToast = page.locator(
-    'div.text-sm.font-semibold:has-text("Invalid Input")',
-  )
-  await errorToast.waitFor({ state: "visible", timeout: 5000 })
-  await expect(errorToast).toBeVisible()
+  await expect(page.getByRole("button", { name: "Import" })).toBeDisabled()
 })
 
-test("should handle invalid Circuit JSON file upload", async ({ page }) => {
-  const importButton = page.locator('button:has-text("Import Circuit JSON")')
-  await importButton.click()
+test("shows a validation error for invalid Circuit JSON file uploads", async ({
+  page,
+}) => {
+  await openImportDialog(page)
 
-  const fileInput = page.locator('input[type="file"]')
-  await fileInput.setInputFiles({
+  await page.locator('input[type="file"]').setInputFiles({
     name: "circuit.json",
     mimeType: "application/json",
-    // @ts-expect-error didnt add node types to tsconfig
-    buffer: Buffer.from(JSON.stringify({})),
+    buffer: Buffer.from("not valid json"),
   })
 
-  const importDialogButton = page.getByRole("button", { name: "Import" })
-  await importDialogButton.click()
-
-  const errorToast = page.locator(
-    'div.text-sm.font-semibold:has-text("Import Failed")',
-  )
-  await errorToast.waitFor({ state: "visible", timeout: 5000 })
-  await expect(errorToast).toBeVisible()
-})
-
-test("should handle non-JSON file upload", async ({ page }) => {
-  const importButton = page.locator('button:has-text("Import Circuit JSON")')
-  await importButton.click()
-
-  const fileInput = page.locator('input[type="file"]')
-  await fileInput.setInputFiles({
-    name: "circuit.txt",
-    mimeType: "application/text",
-    // @ts-expect-error didnt add node types to tsconfig
-    buffer: Buffer.from(""),
-  })
-
-  const importDialogButton = page.getByRole("button", { name: "Import" })
-  await importDialogButton.click()
-
-  const errorToast = page.locator(
-    'div.pb-4 > p:has-text("Please select a valid JSON file.")',
-  )
-  await expect(errorToast).toBeVisible()
+  await expect(
+    page.getByText("Please select a valid JSON file that can be parsed."),
+  ).toBeVisible()
+  await expect(page.getByRole("button", { name: "Import" })).toBeDisabled()
 })

--- a/src/components/CircuitJsonImportDialog.tsx
+++ b/src/components/CircuitJsonImportDialog.tsx
@@ -1,22 +1,17 @@
-import React, { useState } from "react"
+import { Button } from "@/components/ui/button"
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
+  DialogFooter,
   DialogHeader,
   DialogTitle,
-  DialogFooter,
-  DialogDescription,
 } from "@/components/ui/dialog"
-import { Button } from "@/components/ui/button"
 import { Textarea } from "@/components/ui/textarea"
-import { useAxios } from "@/hooks/use-axios"
 import { useToast } from "@/hooks/use-toast"
-import { useLocation } from "wouter"
-import { useGlobalStore } from "@/hooks/use-global-store"
+import { encodeFsMapToUrlHash } from "@/lib/encodeFsMapToUrlHash"
 import { convertCircuitJsonToTscircuit } from "circuit-json-to-tscircuit"
-import { useCreatePackageMutation } from "@/hooks/use-create-package-mutation"
-import { useCreatePackageReleaseMutation } from "@/hooks/use-create-package-release-mutation"
-import { useCreatePackageFilesMutation } from "@/hooks/use-create-package-files-mutation"
+import React, { useState } from "react"
 
 interface CircuitJsonImportDialogProps {
   open: boolean
@@ -40,29 +35,8 @@ export function CircuitJsonImportDialog({
   const [file, setFile] = useState<File | null>(null)
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
-  const loggedInUser = useGlobalStore((s) => s.session)
   const { toast } = useToast()
-  const axios = useAxios()
-  const [, navigate] = useLocation()
-  const isLoggedIn = useGlobalStore((s) => Boolean(s.session))
-  const createPackageMutation = useCreatePackageMutation()
-  const { mutate: createRelease } = useCreatePackageReleaseMutation({
-    onSuccess: () => {
-      toast({
-        title: "Package released",
-        description: "Your package has been released successfully.",
-      })
-    },
-  })
-
-  const createPackageFilesMutation = useCreatePackageFilesMutation({
-    onSuccess: () => {
-      toast({
-        title: "Package files created",
-        description: "Your package files have been created successfully.",
-      })
-    },
-  })
+  const canImport = Boolean(circuitJson.trim() || file)
 
   const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const selectedFile = e.target.files?.[0]
@@ -72,10 +46,12 @@ export function CircuitJsonImportDialog({
         JSON.parse(fileText)
         setFile(selectedFile)
         setError(null)
-      } catch (e) {
+      } catch {
+        setFile(null)
         setError("Please select a valid JSON file that can be parsed.")
       }
     } else {
+      setFile(null)
       setError("Please select a file.")
     }
   }
@@ -108,12 +84,13 @@ export function CircuitJsonImportDialog({
     }
 
     try {
+      setIsLoading(true)
+      setError(null)
+
       if (file) {
         const fileText = await file.text()
         importedCircuitJson = await parseJson(fileText)
       } else if (isValidJSON(circuitJson)) {
-        setIsLoading(true)
-        setError(null)
         importedCircuitJson = await parseJson(circuitJson)
       } else {
         handleError("Please provide a valid JSON content or file.")
@@ -126,48 +103,17 @@ export function CircuitJsonImportDialog({
           componentName: "Component",
         },
       )
-      console.info(tscircuitComponentContent)
 
-      await createPackageMutation.mutateAsync(
+      const editorUrl = encodeFsMapToUrlHash(
         {
-          description: "Imported from Circuit JSON",
+          "index.tsx": tscircuitComponentContent,
         },
-        {
-          onSuccess: (newPackage) => {
-            handleSuccess("Package has been created successfully.")
-            createRelease(
-              {
-                package_name_with_version: `${newPackage.name}@latest`,
-              },
-              {
-                onSuccess: (release) => {
-                  createPackageFilesMutation
-                    .mutateAsync({
-                      file_path: "index.tsx",
-                      content_text: tscircuitComponentContent,
-                      package_release_id: release.package_release_id,
-                    })
-                    .then(() => {
-                      navigate(`/editor?package_id=${newPackage.package_id}`)
-                    })
-                },
-                onError: (error) => {
-                  setError(error)
-                  handleError("Failed to create package release.")
-                },
-              },
-            )
-          },
-          onError: (error) => {
-            setError(error)
-            handleError("Failed to create package.")
-          },
-          onSettled: () => {
-            setIsLoading(false)
-            onOpenChange(false)
-          },
-        },
+        "package",
       )
+
+      handleSuccess("Circuit JSON imported into the editor.")
+      onOpenChange(false)
+      window.location.assign(editorUrl)
     } catch (error) {
       console.error("Error importing Circuit Json:", error)
       handleError(
@@ -181,7 +127,7 @@ export function CircuitJsonImportDialog({
   const handleKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if ((event.ctrlKey || event.metaKey) && event.key === "Enter") {
       event.preventDefault()
-      if (!isLoading && isLoggedIn && (circuitJson.trim() || file)) {
+      if (!isLoading && canImport) {
         handleImport()
       }
     }
@@ -195,7 +141,7 @@ export function CircuitJsonImportDialog({
       event.target !== document.querySelector("textarea")
     ) {
       event.preventDefault()
-      if (!isLoading && isLoggedIn && (circuitJson.trim() || file)) {
+      if (!isLoading && canImport) {
         handleImport()
       }
     }
@@ -255,12 +201,8 @@ export function CircuitJsonImportDialog({
           {error && <p className="bg-red-100 p-2 mt-2 pre-wrap">{error}</p>}
         </div>
         <DialogFooter>
-          <Button onClick={handleImport} disabled={isLoading || !isLoggedIn}>
-            {!isLoggedIn
-              ? "Must be logged in for JSON import"
-              : isLoading
-                ? "Importing..."
-                : "Import"}
+          <Button onClick={handleImport} disabled={isLoading || !canImport}>
+            {isLoading ? "Importing..." : "Import"}
           </Button>
         </DialogFooter>
       </DialogContent>


### PR DESCRIPTION
Removes the login requirement from Circuit JSON import and opens imported content in the editor as an unsaved URL-backed session instead of creating a package immediately. Also updates Playwright coverage for anonymous paste/file import and validation behavior 