### PR TITLE
Show paid order status before checkout expiration

### DIFF
--- a/src/pages/order-detail.tsx
+++ b/src/pages/order-detail.tsx
@@ -91,8 +91,8 @@ const getOrderStatus = (order: Order) => {
   if (order.has_error) return "Needs attention"
   if (getOrderComplete(order)) return "Completed"
   if (order.is_running) return "In progress"
-  if (order.is_stripe_checkout_session_expired) return "Checkout expired"
   if (getPaymentComplete(order)) return "Payment confirmed"
+  if (order.is_stripe_checkout_session_expired) return "Checkout expired"
   return "Awaiting payment"
 }
 


### PR DESCRIPTION
## Summary

Fixes the order detail status pill so paid orders show `Payment confirmed` even when the checkout session is also marked expired.
<img width="1917" height="1046" alt="image" src="https://github.com/user-attachments/assets/2d391eee-8492-42a8-af00-5a6133231750" />

## Why

Some orders can have payment confirmed while the Stripe checkout session later appears expired. The UI was prioritizing the expired checkout flag first, which made a paid order look like checkout had failed.

## Changes

- Prioritize payment-confirmed status before checkout-expired status on the order detail page

## Validation

- Checked the diff is scoped to `src/pages/order-detail.tsx`
