### PR TITLE
Add My Orders link to profile menu

### DIFF
--- a/src/components/HeaderLogin.tsx
+++ b/src/components/HeaderLogin.tsx
@@ -24,6 +24,7 @@ export const HeaderLogin = () => {
   const { data: organizations } = useListUserOrgs()
   const personalOrg = organizations?.find((org) => org.is_personal_org)
   const nonPersonalOrgs = organizations?.filter((org) => !org.is_personal_org)
+  const isTscircuitStaff = session?.is_tscircuit_staff
   const tscircuitHandleRequiredDialog = useGlobalStore(
     (s) => s.openTscircuitHandleRequiredDialog,
   )
@@ -115,6 +116,17 @@ export const HeaderLogin = () => {
               </span>
             )}
           </DropdownMenuItem>
+          {isTscircuitStaff && (
+            <DropdownMenuItem asChild>
+              <Link
+                href="/my-orders"
+                className="cursor-pointer"
+                onClick={() => setIsOpen(false)}
+              >
+                My Orders
+              </Link>
+            </DropdownMenuItem>
+          )}
           <DropdownMenuItem asChild>
             <Link
               href="/dashboard"


### PR DESCRIPTION
## Summary

Adds a `My Orders` entry to the logged-in profile dropdown directly under `My Profile`.

The link points to `/my-orders` and is shown only when the active session has `is_tscircuit_staff`, for now as this feature is in development.

## Before
<img width="252" height="299" alt="image" src="https://github.com/user-attachments/assets/2a853fc0-cfea-412a-a210-a08496edbb72" />

## After
<img width="252" height="299" alt="image" src="https://github.com/user-attachments/assets/5fae9850-2aae-4559-91ee-bd72ed8ca8a3" />


## Validation

- `bun format`
- `bunx tsc --noEmit`