### PR TITLE
Remove AI header link

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -97,11 +97,6 @@ export default function Header() {
                 </HeaderButton>
               </li>
               <li>
-                <a href="https://chat.tscircuit.com">
-                  <Button variant="ghost">AI</Button>
-                </a>
-              </li>
-              <li>
                 <a href="https://docs.tscircuit.com">
                   <Button variant="ghost">Docs</Button>
                 </a>
@@ -162,14 +157,6 @@ export default function Header() {
                   alsoHighlightForUrl="/editor"
                 >
                   Editor
-                </HeaderButton>
-              </li>
-              <li>
-                <HeaderButton
-                  className="w-full justify-start"
-                  href="https://chat.tscircuit.com"
-                >
-                  AI
                 </HeaderButton>
               </li>
               <li>


### PR DESCRIPTION
### Motivation
- Remove the top-level "AI" link that pointed to `https://chat.tscircuit.com` from both the desktop and mobile navigation to avoid exposing that external chat link in the main header.

### Description
- Deleted the `AI` nav items from `src/components/Header.tsx` for the desktop nav and the mobile menu, leaving Dashboard/Editor/Docs (desktop) and Dashboard/Editor/Docs/Search (mobile).

### Testing
- Ran formatting with `bun run format`, typechecking with `bunx tsc --noEmit`, installed Playwright browsers with `bunx playwright install chromium` and `bunx playwright install-deps chromium`, started the dev server with `bun run dev` and captured a verification screenshot via the small Playwright script (produced `/tmp/tscircuit-header-no-ai.png`), all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1df9d70e38832ea84012463be65b6b)