### PR TITLE
Remove the external Create with AI footer link

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -42,13 +42,6 @@ export default function Footer() {
                     {item.name}
                   </Link>
                 ))}
-              <a
-                href="https://chat.tscircuit.com"
-                className="hover:underline w-fit"
-                target="_blank"
-              >
-                Create with AI
-              </a>
             </footer>
           </div>
 


### PR DESCRIPTION
This PR removes the footer link that pointed to https://chat.tscircuit.com.

Changes:
- Delete the "Create with AI" footer link from src/components/Footer.tsx

## Before
<img width="1489" height="380" alt="image" src="https://github.com/user-attachments/assets/282a8710-2811-4c04-9286-54b5443a31d2" />

## After
<img width="1489" height="380" alt="image" src="https://github.com/user-attachments/assets/62962038-00d7-49d2-bab5-e5dfc5de1f0d" />

Verification:
- Confirmed there are no remaining chat.tscircuit.com references in the repo.
