### PR TITLE
Preserve  package view hash links while circuit JSON is loading

### DIFF
--- a/src/components/ViewPackagePage/components/repo-page-content.tsx
+++ b/src/components/ViewPackagePage/components/repo-page-content.tsx
@@ -142,6 +142,15 @@ export default function RepoPageContent({
 
     if (hashView && availableViewSet.has(hashView)) {
       setActiveView(hashView)
+    } else if (
+      hashView &&
+      circuitDependentViews.has(hashView) &&
+      isCircuitJsonLoading
+    ) {
+      // Preserve explicit circuit-dependent links like #schematic until the
+      // preview circuit JSON query finishes and we can verify availability.
+      setActiveView(hashView)
+      return
     } else if (defaultView && availableViewSet.has(defaultView)) {
       setActiveView(defaultView)
       window.location.hash = defaultView


### PR DESCRIPTION
This PR preserves explicit package view hashes like `#schematic` during initial page load instead of rewriting them to the files view.

What changed:
- Added a small initial-view resolver in the package page.
- Kept circuit-dependent hash views active while preview circuit JSON is still loading.
- Only syncs the URL hash when the app is selecting a fallback/default view.

Why:
- Share links to package views should stay stable and open the intended tab.
- The previous initialization path could treat a valid `#schematic` link as unavailable before the circuit JSON query finished.

Impact:
- Users can share `#schematic`, `#pcb`, and similar package-view links without the app rewriting them on load.
- The package page now behaves more predictably during asynchronous loading.

Validation:
- `bun run typecheck`
