### PR TITLE
Show latest descendant file timestamps for folders in package Files view

### DIFF
--- a/src/components/ViewPackagePage/components/tab-views/files-view-utils.ts
+++ b/src/components/ViewPackagePage/components/tab-views/files-view-utils.ts
@@ -1,0 +1,114 @@
+import type { PackageFile as ApiPackageFile } from "fake-snippets-api/lib/db/schema"
+import { isHiddenFile } from "../../utils/is-hidden-file"
+
+interface PackageFile extends ApiPackageFile {
+  file_content?: string
+  content_text?: string | null
+}
+
+export interface FilesViewDirectoryItem {
+  type: "directory"
+  path: string
+  name: string
+  created_at: string
+}
+
+export interface FilesViewFileItem {
+  type: "file"
+  path: string
+  name: string
+  content: string
+  created_at: string
+}
+
+export const formatFilesViewDate = (dateString: string, now = new Date()) => {
+  const parsedDate = new Date(dateString)
+  if (Number.isNaN(parsedDate.getTime())) return ""
+
+  const diffMs = now.getTime() - parsedDate.getTime()
+  const oneDayMs = 1000 * 60 * 60 * 24
+
+  if (diffMs <= 0) return "today"
+  if (diffMs < oneDayMs) return "today"
+
+  const diffDays = Math.floor(diffMs / oneDayMs)
+  if (diffDays === 1) return "yesterday"
+  if (diffDays < 7) return `${diffDays} days ago`
+  if (diffDays < 30) return `${Math.floor(diffDays / 7)} weeks ago`
+  if (diffDays < 365) return `${Math.floor(diffDays / 30)} months ago`
+  return `${Math.floor(diffDays / 365)} years ago`
+}
+
+const getTimestampValue = (dateString: string) => {
+  const timestamp = new Date(dateString).getTime()
+  return Number.isNaN(timestamp) ? null : timestamp
+}
+
+export const buildFilesViewEntries = ({
+  packageFiles,
+  showHiddenFiles,
+}: {
+  packageFiles: PackageFile[]
+  showHiddenFiles: boolean
+}) => {
+  if (!packageFiles.length) {
+    return {
+      directories: [] as FilesViewDirectoryItem[],
+      files: [] as FilesViewFileItem[],
+    }
+  }
+
+  const visibleFiles = packageFiles.filter(
+    (file) => showHiddenFiles || !isHiddenFile(file.file_path),
+  )
+  const directoryTimestamps = new Map<string, string>()
+
+  const files = visibleFiles.map((file) => {
+    const normalizedPath = file.file_path.replace(/^\/+/, "")
+    const pathParts = normalizedPath.split("/")
+    const fileName = pathParts.pop() || normalizedPath
+
+    let currentPath = ""
+    pathParts.forEach((part) => {
+      currentPath += (currentPath ? "/" : "") + part
+
+      const currentTimestamp = directoryTimestamps.get(currentPath)
+      const nextTimestamp = file.created_at
+      const currentValue =
+        currentTimestamp === undefined ? null : getTimestampValue(currentTimestamp)
+      const nextValue = getTimestampValue(nextTimestamp)
+
+      if (
+        currentTimestamp === undefined ||
+        currentValue === null ||
+        (nextValue !== null && nextValue > currentValue)
+      ) {
+        directoryTimestamps.set(currentPath, nextTimestamp)
+      }
+    })
+
+    return {
+      type: "file" as const,
+      path: file.file_path,
+      name: fileName,
+      content: file.file_content || file.content_text || "",
+      created_at: file.created_at,
+    }
+  })
+
+  const directories = Array.from(directoryTimestamps.entries())
+    .map(([path, created_at]) => {
+      if (!path) return null
+
+      const pathParts = path.split("/")
+      return {
+        type: "directory" as const,
+        path,
+        name: pathParts[pathParts.length - 1] || path,
+        created_at,
+      }
+    })
+    .filter((directory): directory is FilesViewDirectoryItem => directory !== null)
+
+  return { directories, files }
+}

--- a/src/components/ViewPackagePage/components/tab-views/files-view-utils.ts
+++ b/src/components/ViewPackagePage/components/tab-views/files-view-utils.ts
@@ -75,7 +75,9 @@ export const buildFilesViewEntries = ({
       const currentTimestamp = directoryTimestamps.get(currentPath)
       const nextTimestamp = file.created_at
       const currentValue =
-        currentTimestamp === undefined ? null : getTimestampValue(currentTimestamp)
+        currentTimestamp === undefined
+          ? null
+          : getTimestampValue(currentTimestamp)
       const nextValue = getTimestampValue(nextTimestamp)
 
       if (
@@ -108,7 +110,9 @@ export const buildFilesViewEntries = ({
         created_at,
       }
     })
-    .filter((directory): directory is FilesViewDirectoryItem => directory !== null)
+    .filter(
+      (directory): directory is FilesViewDirectoryItem => directory !== null,
+    )
 
   return { directories, files }
 }

--- a/src/components/ViewPackagePage/components/tab-views/files-view.tsx
+++ b/src/components/ViewPackagePage/components/tab-views/files-view.tsx
@@ -3,10 +3,7 @@ import { useMemo, useState } from "react"
 import { isWithinDirectory } from "../../utils/is-within-directory"
 import HiddenFilesDropdown from "@/components/HiddenFilesDropdown"
 import type { PackageFile as ApiPackageFile } from "fake-snippets-api/lib/db/schema"
-import {
-  buildFilesViewEntries,
-  formatFilesViewDate,
-} from "./files-view-utils"
+import { buildFilesViewEntries, formatFilesViewDate } from "./files-view-utils"
 
 interface PackageFile extends ApiPackageFile {
   file_content?: string

--- a/src/components/ViewPackagePage/components/tab-views/files-view.tsx
+++ b/src/components/ViewPackagePage/components/tab-views/files-view.tsx
@@ -1,23 +1,12 @@
 import { FileText, Folder, Loader2, AlertTriangle } from "lucide-react"
 import { useMemo, useState } from "react"
-import { isHiddenFile } from "../../utils/is-hidden-file"
 import { isWithinDirectory } from "../../utils/is-within-directory"
 import HiddenFilesDropdown from "@/components/HiddenFilesDropdown"
 import type { PackageFile as ApiPackageFile } from "fake-snippets-api/lib/db/schema"
-
-interface Directory {
-  type: "directory"
-  path: string
-  name: string
-}
-
-interface File {
-  type: "file"
-  path: string
-  name: string
-  content: string
-  created_at: string
-}
+import {
+  buildFilesViewEntries,
+  formatFilesViewDate,
+} from "./files-view-utils"
 
 interface PackageFile extends ApiPackageFile {
   file_content?: string
@@ -40,99 +29,21 @@ export default function FilesView({
   const [activeDir, setActiveDir] = useState("")
   const [showHiddenFiles, setShowHiddenFiles] = useState(false)
 
-  // Parse package files to determine directories and files structure
   const { directories, files } = useMemo(() => {
-    if (!packageFiles.length) {
-      return { directories: [], files: [] }
-    }
-
-    const dirs = new Set<string>()
-    const filesList: File[] = []
-
-    packageFiles
-      .filter((file) => showHiddenFiles || !isHiddenFile(file.file_path))
-      .forEach((file) => {
-        // Extract directory path
-        const pathParts = file.file_path.split("/")
-        const fileName = pathParts.pop() || ""
-
-        // Add all parent directories
-        let currentPath = ""
-        pathParts.forEach((part) => {
-          currentPath += (currentPath ? "/" : "") + part
-          // Only add directory if it contains visible files
-          if (
-            showHiddenFiles ||
-            packageFiles.some(
-              (f) =>
-                f.file_path.startsWith(currentPath + "/") &&
-                !isHiddenFile(f.file_path),
-            )
-          ) {
-            dirs.add(currentPath)
-          }
-        })
-
-        filesList.push({
-          type: "file",
-          path: file.file_path,
-          name: fileName,
-          content: file.file_content || file.content_text || "",
-          created_at: file.created_at,
-        })
-      })
-
-    // Convert directories set to array of directory objects
-    const dirsList = Array.from(dirs)
-      .map((path) => {
-        const pathParts = path.split("/")
-        if (!path) return null
-        return {
-          type: "directory",
-          path,
-          name: pathParts[pathParts.length - 1],
-        }
-      })
-      .filter((dir): dir is Directory => dir !== null)
-
-    return {
-      directories: dirsList,
-      files: filesList,
-    }
+    return buildFilesViewEntries({ packageFiles, showHiddenFiles })
   }, [packageFiles, showHiddenFiles])
-  // Format date for display
-  const formatDate = (dateString: string) => {
-    const parsedDate = new Date(dateString)
-    if (Number.isNaN(parsedDate.getTime())) return ""
-
-    const now = new Date()
-    const diffMs = now.getTime() - parsedDate.getTime()
-    const oneDayMs = 1000 * 60 * 60 * 24
-
-    // Treat future dates as today
-    if (diffMs <= 0) return "today"
-
-    if (diffMs < oneDayMs) return "today"
-
-    const diffDays = Math.floor(diffMs / oneDayMs)
-    if (diffDays === 1) return "yesterday"
-    if (diffDays < 7) return `${diffDays} days ago`
-    if (diffDays < 30) return `${Math.floor(diffDays / 7)} weeks ago`
-    if (diffDays < 365) return `${Math.floor(diffDays / 30)} months ago`
-    return `${Math.floor(diffDays / 365)} years ago`
-  }
 
   // Combine directories and files for display
   const items = [
     ...directories.map((dir) => ({
       ...dir,
       message: "", // TODO insert ai description of directory here!
-      time: "",
+      time: formatFilesViewDate(dir.created_at),
     })),
     ...files.map((file) => ({
       ...file,
       message: "", // TODO insert ai description of file here!
-      time: formatDate(file.created_at),
+      time: formatFilesViewDate(file.created_at),
     })),
   ].sort((a, b) => {
     // Sort directories first, then files


### PR DESCRIPTION
## Summary

Add GitHub-style folder timestamps to the package page Files tab.

Folders now display the relative time of the newest visible descendant file, while file rows continue to use the existing `created_at` timestamp from the current API response. This keeps the change frontend-only and avoids any API contract changes.

## What changed

- extract Files tab tree/timestamp derivation into `files-view-utils.ts`
- compute each folder timestamp from the newest visible descendant file
- reuse the same relative date formatter for both files and folders
- preserve existing hidden-file filtering and directory navigation behavior

## Before
<img width="986" height="604" alt="image" src="https://github.com/user-attachments/assets/e471e122-ab3e-4bae-8254-b6a389d87030" />

## After
<img width="902" height="555" alt="image" src="https://github.com/user-attachments/assets/d952cf2c-9446-4710-b0e6-80e9218427ca" />

## Current limitation

This is an approximation of `last updated` because the current API only exposes `created_at`, not a true file modification timestamp.

## Follow-up API improvement

If `api.tscircuit.com` later exposes a true file-level `updated_at` timestamp, this UI can become more accurate without changing the overall folder logic.

That API change would improve this by:

- making file rows show the actual last modified time instead of creation time
- making folder rows reflect the newest real edit anywhere inside the folder
- matching GitHub-style `last updated` behavior more closely
- avoiding misleading older timestamps for frequently edited files

The frontend can then switch from `created_at` to `updated_at ?? created_at` with a small follow-up.
