### PR TITLE
Add pinout SVG download button

### DIFF
--- a/src/components/DownloadButtonAndMenu.tsx
+++ b/src/components/DownloadButtonAndMenu.tsx
@@ -19,6 +19,7 @@ import { downloadDsnFile } from "@/lib/download-fns/download-dsn-file-fn"
 import { downloadFabricationFiles } from "@/lib/download-fns/download-fabrication-files"
 import { downloadGltfFromCircuitJson } from "@/lib/download-fns/download-gltf-from-circuit-json"
 import { downloadKicadFiles } from "@/lib/download-fns/download-kicad-files"
+import { downloadPinoutSvg } from "@/lib/download-fns/download-pinout-svg"
 import { downloadPngImage } from "@/lib/download-fns/download-png-utils"
 import { downloadReadableNetlist } from "@/lib/download-fns/download-readable-netlist"
 import { downloadSchematicSvg } from "@/lib/download-fns/download-schematic-svg"
@@ -270,6 +271,17 @@ export function DownloadButtonAndMenu({
               >
                 <Download className="mr-1 h-3 w-3" />
                 <span className="flex-grow mr-6">Assembly SVG</span>
+                {formatBadge("svg", "bg-blue-500")}
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                className="text-xs"
+                onSelect={async () => {
+                  const cj = await getCircuitJson()
+                  downloadPinoutSvg(cj, unscopedName || "circuit")
+                }}
+              >
+                <Download className="mr-1 h-3 w-3" />
+                <span className="flex-grow mr-6">Pinout SVG</span>
                 {formatBadge("svg", "bg-blue-500")}
               </DropdownMenuItem>
               <DropdownMenuItem

--- a/src/lib/download-fns/download-pinout-svg.ts
+++ b/src/lib/download-fns/download-pinout-svg.ts
@@ -1,0 +1,12 @@
+import { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToPinoutSvg } from "circuit-to-svg"
+import { saveAs } from "file-saver"
+
+export const downloadPinoutSvg = (
+  circuitJson: AnyCircuitElement[],
+  fileName: string,
+) => {
+  const svg = convertCircuitJsonToPinoutSvg(circuitJson)
+  const blob = new Blob([svg], { type: "image/svg" })
+  saveAs(blob, fileName + ".svg")
+}


### PR DESCRIPTION
## Summary
- add a dedicated `downloadPinoutSvg` helper using `convertCircuitJsonToPinoutSvg`
- expose `Pinout SVG` in the existing Images download submenu
- keep the existing PCB SVG dialog flow unchanged

## Before
<img width="520" height="399" alt="image" src="https://github.com/user-attachments/assets/a5b4df64-d901-4f6d-a253-5ca34f068e31" />


## After
<img width="520" height="399" alt="image" src="https://github.com/user-attachments/assets/3f551141-be86-4dc5-afda-22d5833cc702" />

## Why
Pinout PNG export was already available, but the download menu did not offer a matching SVG export even though pinout SVG rendering already exists in the repo. This makes the image download options more complete and consistent.

## Impact
Users can now download pinout artwork as SVG directly from the package download menu, which is better for scaling and downstream editing.

## Validation
- `bunx biome check src/components/DownloadButtonAndMenu.tsx src/lib/download-fns/download-pinout-svg.ts`
