### PR TITLE
Fix editor auth dead-end and unify login redirect handling

### DIFF
--- a/src/components/HeaderLogin.tsx
+++ b/src/components/HeaderLogin.tsx
@@ -14,6 +14,7 @@ import { useState } from "react"
 import { useAxios } from "@/hooks/use-axios"
 import { GithubAvatarWithFallback } from "@/components/GithubAvatarWithFallback"
 import { useListUserOrgs } from "@/hooks/use-list-user-orgs"
+import { getLoginPath } from "@/lib/utils/handle-redirect"
 
 export const HeaderLogin = () => {
   const session = useGlobalStore((s) => s.session)
@@ -28,16 +29,8 @@ export const HeaderLogin = () => {
     (s) => s.openTscircuitHandleRequiredDialog,
   )
 
-  const orgLoginRedirect =
-    typeof window !== "undefined"
-      ? window.location.pathname + window.location.search + window.location.hash
-      : location?.startsWith("/")
-        ? location
-        : `/${location ?? ""}`
-
   const goToOrgLogin = () => {
-    const redirect = orgLoginRedirect || "/"
-    setLocation(`/login?redirect=${encodeURIComponent(redirect)}`)
+    setLocation(getLoginPath(location))
   }
 
   const isLoggedIn = Boolean(session)

--- a/src/components/package-port/EditorNav.tsx
+++ b/src/components/package-port/EditorNav.tsx
@@ -47,6 +47,7 @@ import { useUpdatePackageDescriptionDialog } from "../dialogs/update-package-des
 import { useCreateReleaseDialog } from "@/hooks/use-create-release-dialog"
 import { Tag } from "lucide-react"
 import { CreateReleaseDialog } from "../CreateReleaseDialog"
+import { getLoginPath } from "@/lib/utils/handle-redirect"
 import {
   Tooltip,
   TooltipContent,
@@ -96,7 +97,7 @@ export default function EditorNav({
   viewingVersion?: string
   latestVersion?: string | null
 }) {
-  const [, navigate] = useLocation()
+  const [location, navigate] = useLocation()
   const isLoggedIn = useGlobalStore((s) => Boolean(s.session))
   const session = useGlobalStore((s) => s.session)
   const { Dialog: RenameDialog, openDialog: openRenameDialog } =
@@ -130,7 +131,6 @@ export default function EditorNav({
   const axios = useAxios()
   const { toast } = useToast()
   const qc = useQueryClient()
-
   const { organization } = useOrganization(
     pkg?.owner_org_id
       ? { orgId: String(pkg.owner_org_id) }
@@ -226,6 +226,10 @@ export default function EditorNav({
       })
       throw new Error("Failed to update package visibility")
     }
+  }
+
+  const goToLogin = () => {
+    navigate(getLoginPath(location))
   }
 
   const canManagePackage = useMemo(() => {
@@ -363,9 +367,13 @@ export default function EditorNav({
         </div>
         <div className="flex items-center space-x-1">
           {!isLoggedIn && (
-            <div className="bg-orange-100 text-orange-700 py-1 px-2 text-xs opacity-70">
+            <button
+              type="button"
+              className="bg-orange-100 text-orange-700 py-1 px-2 text-xs opacity-70 rounded-sm transition-opacity hover:opacity-100"
+              onClick={goToLogin}
+            >
               Not logged in, can't save
-            </div>
+            </button>
           )}
           {isViewingOlderVersion && (
             <div className="bg-amber-100 text-amber-700 py-1 px-2 text-xs">

--- a/src/hooks/use-axios.tsx
+++ b/src/hooks/use-axios.tsx
@@ -4,6 +4,7 @@ import { useGlobalStore } from "./use-global-store"
 import { useApiBaseUrl } from "./use-packages-base-api-url"
 import { ToastContent, useToast } from "./use-toast"
 import { useLocation } from "wouter"
+import { getLoginPath } from "@/lib/utils/handle-redirect"
 
 export const useAxios = () => {
   const snippetsBaseApiUrl = useApiBaseUrl()
@@ -44,13 +45,7 @@ export const useAxios = () => {
           (t) => (
             <div
               onClick={() => {
-                const currentPath =
-                  window.location.pathname +
-                  window.location.search +
-                  window.location.hash
-                setLocation(
-                  `/login?redirect=${encodeURIComponent(currentPath || "/")}`,
-                )
+                setLocation(getLoginPath(location))
               }}
               className="cursor-pointer"
             >

--- a/src/lib/utils/handle-redirect.ts
+++ b/src/lib/utils/handle-redirect.ts
@@ -23,6 +23,25 @@ export const getSafeRedirectTarget = (
   return null
 }
 
+const normalizeAppLocation = (location?: string) => {
+  if (!location) return "/"
+  return location.startsWith("/") ? location : `/${location}`
+}
+
+export const getCurrentAppPath = (location?: string) => {
+  const fallbackLocation = normalizeAppLocation(location)
+
+  if (typeof window === "undefined") return fallbackLocation
+
+  return (
+    `${window.location.pathname}${window.location.search}${window.location.hash}` ||
+    fallbackLocation
+  )
+}
+
+export const getLoginPath = (location?: string) =>
+  `/login?redirect=${encodeURIComponent(getCurrentAppPath(location))}`
+
 export const handleRedirect = (
   redirect: string | null,
   fallback: () => void,


### PR DESCRIPTION
## Summary

This PR fixes an auth dead-end in the web editor and unifies login redirect handling across the UI.

Previously, unauthenticated users in the editor saw `Not logged in, can't save`, but that warning was not actionable. On smaller screens, the visible warning could be easier to find than the actual login entry point, leaving users blocked from saving without a clear next step.

This change makes the editor warning directly open the login page and centralizes login redirect path generation so auth entry points consistently preserve the current in-app location.

## Changes

- make the `Not logged in, can't save` warning in the editor clickable
- send users from the editor warning directly to `/login`
- preserve the current path, query string, and hash in the login redirect target
- add shared redirect helpers in `src/lib/utils/handle-redirect.ts`
- reuse the shared login redirect path in:
  - `EditorNav`
  - `HeaderLogin`
  - the 401 auth toast flow in `use-axios`

## Why this matters

- removes a dead-end in the editor save flow
- improves login discoverability, especially on mobile
- keeps users on the same editor context after signing in
- reduces duplicated auth redirect logic across the app

## Root cause

Login redirect path generation was duplicated across multiple auth entry points, and the editor's unauthenticated save warning exposed the blocked state without providing a direct recovery path.

## Validation

- `bun run typecheck`
