### PR TITLE
bump @tscircuit/internal-dynamic-import

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -54,7 +54,7 @@
         "@tscircuit/create-snippet-url": "^0.0.14",
         "@tscircuit/eval": "^0.0.955",
         "@tscircuit/fake-stripe": "git+https://github.com/tscircuit/fake-stripe.git#f1a5b40",
-        "@tscircuit/internal-dynamic-import": "^0.0.5",
+        "@tscircuit/internal-dynamic-import": "^0.0.8",
         "@tscircuit/layout": "^0.0.29",
         "@tscircuit/math-utils": "^0.0.36",
         "@tscircuit/mm": "^0.0.8",
@@ -835,7 +835,7 @@
 
     "@tscircuit/infgrid-ijump-astar": ["@tscircuit/infgrid-ijump-astar@0.0.35", "", {}, "sha512-PZx3GyD7mDNEhLJn8+7n8NjrieOvrX03g7Gx1cvwXv9mmgSC4M+yTA0WC4DgOvcRdTnarf0R8xvwtDeJ4tMK9Q=="],
 
-    "@tscircuit/internal-dynamic-import": ["@tscircuit/internal-dynamic-import@0.0.5", "", {}, "sha512-6iwld7fQOa8UWfyjJppAPlryshCpHz5AsTZHOXZMsg0T+4Fmt4YhjdWAXqzfJXHTW2oBQuqXaTbKxoPMc+/ajg=="],
+    "@tscircuit/internal-dynamic-import": ["@tscircuit/internal-dynamic-import@0.0.8", "", {}, "sha512-N5O2usWwQ5gIrpGMNxenIJW/gqXM4B4lq7QRdpdCOX8M6JOHHBMIK3IGBdZuCIAsec6pReHS8uCCfRL9hM3ULA=="],
 
     "@tscircuit/krt-wasm": ["@tscircuit/krt-wasm@0.1.4", "", { "peerDependencies": { "tscircuit": ">=0.0.1686" } }, "sha512-qwVFD8Ocqvd8KxcSLVxbI1X2eOWslWnXzvM5o+sOed29Jzos42eN385yS9VDxqqsPrck39whWosAmUx3JIEh2w=="],
 

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "@tscircuit/assembly-viewer": "^0.0.5",
     "@tscircuit/create-snippet-url": "^0.0.14",
     "@tscircuit/eval": "^0.0.955",
-    "@tscircuit/internal-dynamic-import": "^0.0.5",
+    "@tscircuit/internal-dynamic-import": "^0.0.8",
     "@tscircuit/layout": "^0.0.29",
     "@tscircuit/math-utils": "^0.0.36",
     "@tscircuit/mm": "^0.0.8",


### PR DESCRIPTION
Update @tscircuit/internal-dynamic-import to 0.0.8 so Runframe’s KiCad footprint preview can load kicad-to-circuit-json through the shared dynamic importer.