### PR TITLE
fix: resolve z-index overlap on profile dropdown menu

### DIFF
--- a/src/components/HeaderLogin.tsx
+++ b/src/components/HeaderLogin.tsx
@@ -75,7 +75,7 @@ export const HeaderLogin = () => {
           </button>
         </DropdownMenuTrigger>
         <DropdownMenuContent
-          className="ml-1 mr-1 md:ml-0 md:mr-1"
+          className="ml-1 mr-1 md:ml-0 md:mr-1 !z-[1000]"
           side="bottom"
           align="end"
           sideOffset={4}


### PR DESCRIPTION
Before: 

<img width="633" height="201" alt="Screenshot 2026-07-04 at 2 41 16 AM" src="https://github.com/user-attachments/assets/e1eddf5c-34af-4b0e-9867-73d01bc8da5b" />


After: 

<img width="654" height="210" alt="Screenshot 2026-07-04 at 2 52 01 AM" src="https://github.com/user-attachments/assets/217a4e00-b4b4-4d14-9276-1918b68e9c07" />

