### PR TITLE
[codex] redesign homepage white blue

### DIFF
--- a/landing.html
+++ b/landing.html
@@ -18,6 +18,6 @@
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/pages/landing.tsx"></script>
+    <script type="module" src="/src/landing-main.tsx"></script>
   </body>
 </html>

--- a/src/index.css
+++ b/src/index.css
@@ -1377,6 +1377,59 @@ body {
   color: #334155;
 }
 
+.tscircuit-landing .landing-footer {
+  background:
+    linear-gradient(rgba(248, 250, 252, 0.82), rgba(239, 246, 255, 0.92)),
+    linear-gradient(#dbeafe 1px, transparent 1px),
+    linear-gradient(90deg, #dbeafe 1px, transparent 1px);
+  background-size:
+    auto,
+    24px 24px,
+    24px 24px;
+}
+
+.tscircuit-landing .landing-footer-terminal {
+  width: 100vw;
+  min-height: 74vh;
+  margin: 24px calc(50% - 50vw) -48px;
+  overflow: hidden;
+  background: transparent;
+}
+
+.tscircuit-landing .landing-footer-terminal-output {
+  display: grid;
+  align-items: center;
+  justify-content: center;
+  width: 112vw;
+  min-width: 112vw;
+  height: 74vh;
+  min-height: 74vh;
+  margin: 0;
+  overflow: hidden;
+  border: 0;
+  background: transparent;
+  color: #2563eb;
+  font-family: "Space Mono", monospace;
+  font-size: clamp(10px, 1vw, 22px);
+  font-weight: 700;
+  line-height: 1;
+  letter-spacing: 0;
+  opacity: 0.66;
+  padding: 0 0 24px;
+  text-align: center;
+  transform: translateX(-6vw);
+  white-space: pre;
+}
+
+@media (max-width: 767px) {
+  .tscircuit-landing .landing-footer-terminal-output {
+    width: 180vw;
+    min-width: 180vw;
+    font-size: clamp(6px, 1.5vw, 10px);
+    transform: translateX(-40vw);
+  }
+}
+
 /* Subtle scrollbar styling for html and body */
 html::-webkit-scrollbar,
 body::-webkit-scrollbar {

--- a/src/index.css
+++ b/src/index.css
@@ -1180,152 +1180,137 @@ body {
   margin-top: 28px;
 }
 
-.tscircuit-landing .landing-original-careers-row {
+ .tscircuit-landing .landing-original-careers-row {
   position: relative;
-  display: grid;
   max-width: 1840px;
-  grid-template-columns: minmax(0, 1fr) minmax(420px, 0.68fr);
-  gap: 48px;
-  align-items: center;
   overflow: hidden;
   border: 1px solid #93c5fd;
   border-radius: 32px;
   background:
-    linear-gradient(rgba(37, 99, 235, 0.08) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(37, 99, 235, 0.08) 1px, transparent 1px),
-    linear-gradient(135deg, #ffffff 0%, #eff6ff 100%);
+    linear-gradient(rgba(37, 99, 235, 0.09) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(37, 99, 235, 0.09) 1px, transparent 1px),
+    linear-gradient(135deg, rgba(255, 255, 255, 0.92) 0%, rgba(239, 246, 255, 0.72) 100%);
   background-size: 42px 42px, 42px 42px, auto;
-  padding: 54px;
+  padding: 72px 78px;
   margin: 0 auto;
   box-shadow: 0 28px 90px rgba(37, 99, 235, 0.13);
+}
+
+.tscircuit-landing .landing-original-careers-row::before,
+.tscircuit-landing .landing-original-careers-row::after {
+  position: absolute;
+  pointer-events: none;
+  content: "";
+  border-color: rgba(37, 99, 235, 0.34);
+}
+
+.tscircuit-landing .landing-original-careers-row::before {
+  top: 28px;
+  left: 28px;
+  width: 130px;
+  height: 130px;
+  border-top-width: 1px;
+  border-left-width: 1px;
+}
+
+.tscircuit-landing .landing-original-careers-row::after {
+  right: 28px;
+  bottom: 28px;
+  width: 190px;
+  height: 190px;
+  border-right-width: 1px;
+  border-bottom-width: 1px;
+  background: linear-gradient(
+    135deg,
+    transparent 0 48%,
+    rgba(37, 99, 235, 0.13) 48% 52%,
+    transparent 52%
+  );
 }
 
 .tscircuit-landing .landing-original-careers {
   background: #eff6ff;
 }
 
-.tscircuit-landing .landing-careers-roles {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
-  margin-top: 28px;
+.tscircuit-landing .landing-careers-letter-page {
+  position: relative;
+  z-index: 1;
+  max-width: 1120px;
+  margin-left: clamp(0px, 4vw, 80px);
 }
 
-.tscircuit-landing .landing-careers-roles span {
+.tscircuit-landing .landing-careers-letter {
+  max-width: 980px;
+  margin-top: 28px;
+  background: rgba(255, 255, 255, 0.58);
+  padding: 28px 34px;
+}
+
+.tscircuit-landing .landing-careers-letter-body {
+  position: relative;
+  max-width: 860px;
+  padding: 22px 28px;
+}
+
+.tscircuit-landing .landing-careers-letter-body::before,
+.tscircuit-landing .landing-careers-letter-body::after {
+  position: absolute;
+  width: 72px;
+  height: 72px;
+  pointer-events: none;
+  content: "";
+  border-color: rgba(37, 99, 235, 0.45);
+}
+
+.tscircuit-landing .landing-careers-letter-body::before {
+  top: 0;
+  left: 0;
+  border-top-width: 1px;
+  border-left-width: 1px;
+}
+
+.tscircuit-landing .landing-careers-letter-body::after {
+  right: 0;
+  bottom: 0;
+  border-right-width: 1px;
+  border-bottom-width: 1px;
+}
+
+.tscircuit-landing .landing-careers-letter p {
+  margin: 0;
+  color: #334155;
+  font-size: 20px;
+  line-height: 1.58;
+}
+
+.tscircuit-landing .landing-careers-letter p + p {
+  margin-top: 16px;
+}
+
+.tscircuit-landing .landing-careers-signature {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+  align-items: center;
+  margin-top: 24px;
+  font-family: "Space Mono", monospace;
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+}
+
+.tscircuit-landing .landing-careers-signature span {
+  color: #0f172a;
+}
+
+.tscircuit-landing .landing-careers-signature a {
   border: 1px solid #93c5fd;
   border-radius: 8px;
   background: #ffffff;
   color: #2563eb;
-  font-family: "Space Mono", monospace;
-  font-size: 12px;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  padding: 10px 12px;
+  padding: 8px 10px;
+  text-decoration: none;
   text-transform: uppercase;
-}
-
-.tscircuit-landing .landing-careers-panel {
-  display: grid;
-  gap: 16px;
-  border: 1px solid #bfdbfe;
-  border-radius: 24px;
-  background: rgba(255, 255, 255, 0.86);
-  padding: 18px;
-  box-shadow: 0 20px 70px rgba(37, 99, 235, 0.16);
-}
-
-.tscircuit-landing .landing-careers-terminal {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  border: 1px solid #bfdbfe;
-  border-radius: 14px;
-  background: #0f172a;
-  color: #dbeafe;
-  font-family: "Space Mono", monospace;
-  font-size: 12px;
-  padding: 14px 16px;
-}
-
-.tscircuit-landing .landing-careers-terminal strong {
-  color: #38bdf8;
-  font-size: 11px;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-
-.tscircuit-landing .landing-careers-circuit {
-  position: relative;
-  min-height: 260px;
-  overflow: hidden;
-  border: 1px solid #bfdbfe;
-  border-radius: 18px;
-  background:
-    linear-gradient(rgba(37, 99, 235, 0.16) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(37, 99, 235, 0.14) 1px, transparent 1px),
-    #ffffff;
-  background-size: 36px 36px;
-}
-
-.tscircuit-landing .landing-careers-circuit::before,
-.tscircuit-landing .landing-careers-circuit::after {
-  position: absolute;
-  content: "";
-  height: 3px;
-  border-radius: 999px;
-  background: linear-gradient(90deg, #2563eb, #0ea5e9);
-  transform-origin: left center;
-}
-
-.tscircuit-landing .landing-careers-circuit::before {
-  top: 44%;
-  left: 12%;
-  width: 76%;
-  transform: rotate(12deg);
-}
-
-.tscircuit-landing .landing-careers-circuit::after {
-  top: 64%;
-  left: 18%;
-  width: 64%;
-  transform: rotate(-16deg);
-}
-
-.tscircuit-landing .landing-careers-circuit span {
-  position: absolute;
-  z-index: 1;
-  display: grid;
-  width: 74px;
-  height: 58px;
-  place-items: center;
-  border: 1px solid #2563eb;
-  border-radius: 12px;
-  background: #ffffff;
-  color: #1d4ed8;
-  font-family: "Space Mono", monospace;
-  font-size: 13px;
-  font-weight: 700;
-}
-
-.tscircuit-landing .landing-careers-circuit span:nth-child(1) {
-  top: 18%;
-  left: 13%;
-}
-
-.tscircuit-landing .landing-careers-circuit span:nth-child(2) {
-  top: 22%;
-  right: 18%;
-}
-
-.tscircuit-landing .landing-careers-circuit span:nth-child(3) {
-  bottom: 18%;
-  left: 26%;
-}
-
-.tscircuit-landing .landing-careers-circuit span:nth-child(4) {
-  right: 14%;
-  bottom: 16%;
 }
 
 @media (max-width: 1100px) {
@@ -1363,6 +1348,15 @@ body {
 
   .tscircuit-landing .landing-original-careers-row {
     padding: 24px;
+  }
+
+  .tscircuit-landing .landing-careers-letter {
+    grid-template-columns: 1fr;
+    padding: 18px;
+  }
+
+  .tscircuit-landing .landing-careers-letter-body {
+    padding: 18px;
   }
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -143,6 +143,323 @@ body {
   overflow-x: hidden;
 }
 
+.tscircuit-landing .landing-announcement-strip {
+  display: flex;
+  min-height: 48px;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  border-top: 3px solid #1e3a8a;
+  background: #2563eb;
+  color: #ffffff;
+  font-family: "Space Mono", monospace;
+  font-size: 15px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-align: center;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+@media (max-width: 520px) {
+  .tscircuit-landing .landing-announcement-strip {
+    min-height: 44px;
+    gap: 6px;
+    font-size: 12px;
+    letter-spacing: 0.02em;
+  }
+}
+
+.tscircuit-landing .landing-topbar {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  border-bottom: 1px solid #bfdbfe;
+  background:
+    linear-gradient(90deg, rgba(37, 99, 235, 0.08), transparent 18%, transparent 82%, rgba(37, 99, 235, 0.1)),
+    rgba(248, 250, 252, 0.96);
+  box-shadow: 0 18px 36px rgba(37, 99, 235, 0.08);
+  backdrop-filter: blur(14px);
+}
+
+.tscircuit-landing .landing-topbar-inner {
+  display: grid;
+  min-height: 86px;
+  width: 100%;
+  margin: 0 auto;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: clamp(28px, 3.4vw, 72px);
+  padding: 0 clamp(24px, 3vw, 56px);
+}
+
+.tscircuit-landing .landing-topbar-nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: clamp(18px, 2.5vw, 56px);
+}
+
+.tscircuit-landing .landing-topbar-nav a {
+  display: inline-flex;
+  min-height: 58px;
+  align-items: center;
+  gap: 10px;
+  color: #334155;
+  font-family: "Space Mono", monospace;
+  font-size: clamp(15px, 1.08vw, 21px);
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-decoration: none;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.tscircuit-landing .landing-topbar-icon,
+.tscircuit-landing .landing-topbar-chev {
+  width: 1em;
+  height: 1em;
+  color: #2563eb;
+  stroke-width: 1.85;
+}
+
+.tscircuit-landing .landing-topbar-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: clamp(18px, 2vw, 34px);
+}
+
+.tscircuit-landing .landing-topbar-search,
+.tscircuit-landing .landing-topbar-menu {
+  display: inline-grid;
+  width: 44px;
+  height: 44px;
+  place-items: center;
+  border: 0;
+  background: transparent;
+  color: #0f172a;
+}
+
+.tscircuit-landing .landing-topbar-menu {
+  display: none;
+}
+
+.tscircuit-landing .landing-topbar-cta {
+  display: inline-flex;
+  min-width: 166px;
+  height: 56px;
+  align-items: center;
+  justify-content: center;
+  padding: 0 34px 0 30px;
+  clip-path: polygon(0 0, calc(100% - 22px) 0, 100% 50%, calc(100% - 22px) 100%, 0 100%, 14px 50%);
+  background: #2563eb;
+  color: #ffffff;
+  font-family: "Space Mono", monospace;
+  font-size: 19px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  text-decoration: none;
+  box-shadow: 0 14px 30px rgba(37, 99, 235, 0.25);
+}
+
+.tscircuit-landing .landing-topbar-cta:hover {
+  background: #1d4ed8;
+}
+
+.tscircuit-landing .landing-topbar-mobile-nav {
+  display: none;
+}
+
+.tscircuit-landing .landing-hero-section {
+  min-height: calc(100svh - 134px);
+}
+
+@media (min-width: 1024px) {
+  .tscircuit-landing .landing-hero-section {
+    height: calc(100svh - 134px - 92px);
+    min-height: 720px;
+  }
+}
+
+@media (max-width: 1180px) {
+  .tscircuit-landing .landing-topbar-inner {
+    display: flex;
+    min-height: 66px;
+    justify-content: flex-end;
+    gap: 12px;
+    padding: 0 18px;
+  }
+
+  .tscircuit-landing .landing-topbar-nav {
+    display: none;
+  }
+
+  .tscircuit-landing .landing-topbar-actions {
+    width: 100%;
+    justify-content: flex-end;
+    gap: 12px;
+  }
+
+  .tscircuit-landing .landing-topbar-menu {
+    display: inline-grid;
+  }
+
+  .tscircuit-landing .landing-topbar-cta {
+    min-width: 136px;
+    height: 46px;
+    padding: 0 26px 0 22px;
+    font-size: 14px;
+  }
+
+  .tscircuit-landing .landing-topbar-mobile-nav {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 8px;
+    border-top: 1px solid #bfdbfe;
+    background: rgba(248, 250, 252, 0.98);
+    padding: 10px 14px 14px;
+  }
+
+  .tscircuit-landing .landing-topbar-mobile-nav a {
+    display: inline-flex;
+    min-height: 42px;
+    align-items: center;
+    gap: 8px;
+    border: 1px solid #bfdbfe;
+    border-radius: 8px;
+    background: #ffffff;
+    color: #334155;
+    font-family: "Space Mono", monospace;
+    font-size: 12px;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    padding: 0 10px;
+    text-decoration: none;
+    text-transform: uppercase;
+  }
+}
+
+@media (max-width: 767px) {
+  .tscircuit-landing .landing-hero-section {
+    height: auto;
+    min-height: auto;
+  }
+}
+
+.tscircuit-landing .landing-grid-field {
+  background-image:
+    linear-gradient(rgba(37, 99, 235, 0.14) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(37, 99, 235, 0.12) 1px, transparent 1px),
+    linear-gradient(rgba(14, 165, 233, 0.11) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(14, 165, 233, 0.09) 1px, transparent 1px);
+  background-position:
+    -1px -1px,
+    -1px -1px,
+    -1px -1px,
+    -1px -1px;
+  background-size:
+    40px 40px,
+    40px 40px,
+    160px 160px,
+    160px 160px;
+}
+
+.tscircuit-landing .landing-tile-field {
+  background-image:
+    linear-gradient(135deg, rgba(37, 99, 235, 0.16) 0 1px, transparent 1px 34px),
+    linear-gradient(45deg, rgba(14, 165, 233, 0.12) 0 1px, transparent 1px 34px),
+    radial-gradient(circle at 20px 20px, rgba(59, 130, 246, 0.18) 0 2px, transparent 2px);
+  background-size:
+    68px 68px,
+    68px 68px,
+    68px 68px;
+}
+
+.tscircuit-landing .landing-scanlines {
+  position: relative;
+}
+
+.tscircuit-landing .landing-scanlines::after {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  content: "";
+  background: repeating-linear-gradient(
+    to bottom,
+    rgba(37, 99, 235, 0.055) 0,
+    rgba(37, 99, 235, 0.055) 1px,
+    transparent 1px,
+    transparent 7px
+  );
+  mix-blend-mode: multiply;
+  opacity: 0.35;
+}
+
+.tscircuit-landing .landing-corner-grid {
+  position: relative;
+}
+
+.tscircuit-landing .landing-corner-grid::before,
+.tscircuit-landing .landing-corner-grid::after {
+  position: absolute;
+  width: 92px;
+  height: 92px;
+  pointer-events: none;
+  content: "";
+  border-color: rgba(37, 99, 235, 0.65);
+}
+
+.tscircuit-landing .landing-corner-grid::before {
+  top: 18px;
+  left: 18px;
+  border-top-width: 1px;
+  border-left-width: 1px;
+}
+
+.tscircuit-landing .landing-corner-grid::after {
+  right: 18px;
+  bottom: 18px;
+  border-right-width: 1px;
+  border-bottom-width: 1px;
+}
+
+.tscircuit-landing .landing-demo-panel {
+  animation: landing-demo-slide 520ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+@keyframes landing-demo-slide {
+  from {
+    opacity: 0;
+    transform: translateX(22px) scale(0.985);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0) scale(1);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tscircuit-landing .landing-demo-panel {
+    animation: none;
+  }
+}
+
+.tscircuit-landing .landing-faq section {
+  background: #f8fafc;
+  color: #0f172a;
+}
+
+.tscircuit-landing .landing-faq h2,
+.tscircuit-landing .landing-faq h3 {
+  color: #0f172a;
+}
+
+.tscircuit-landing .landing-faq p,
+.tscircuit-landing .landing-faq button {
+  color: #334155;
+}
+
 /* Subtle scrollbar styling for html and body */
 html::-webkit-scrollbar,
 body::-webkit-scrollbar {

--- a/src/index.css
+++ b/src/index.css
@@ -917,27 +917,52 @@ body {
 .tscircuit-landing .landing-original-gallery {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 28px;
+  gap: 32px;
   margin-top: 36px;
 }
 
 .tscircuit-landing .landing-original-gallery-board {
+  position: relative;
   display: grid;
-  gap: 18px;
-  border: 1px solid #94a3b8;
-  border-radius: 8px;
-  background: #ffffff;
-  padding: 18px;
+  gap: 20px;
+  overflow: hidden;
+  border: 1px solid #cbd5e1;
+  border-radius: 28px;
+  background: linear-gradient(180deg, #ffffff, #eff6ff);
+  padding: 22px;
   color: #0f172a;
+  box-shadow: 0 18px 70px rgba(37, 99, 235, 0.12);
   text-decoration: none;
 }
 
+.tscircuit-landing .landing-original-gallery-board::after {
+  position: absolute;
+  right: -18px;
+  bottom: -18px;
+  width: 130px;
+  height: 130px;
+  pointer-events: none;
+  content: "";
+  border-top: 1px solid rgba(37, 99, 235, 0.35);
+  border-left: 1px solid rgba(37, 99, 235, 0.35);
+  border-radius: 28px 0 0 0;
+  background: linear-gradient(
+    135deg,
+    transparent 0 48%,
+    rgba(37, 99, 235, 0.18) 48% 52%,
+    transparent 52%
+  );
+}
+
 .tscircuit-landing .landing-original-pcb {
-  min-height: 220px;
-  border-radius: 8px;
+  position: relative;
+  min-height: 280px;
+  overflow: hidden;
+  border: 1px solid #2563eb;
+  border-radius: 18px;
   background:
-    radial-gradient(circle at 18% 20%, #ec4899 0 11px, transparent 12px),
-    radial-gradient(circle at 82% 76%, #ec4899 0 11px, transparent 12px),
+    radial-gradient(circle at 18% 20%, #ec4899 0 10px, transparent 11px),
+    radial-gradient(circle at 82% 76%, #ec4899 0 10px, transparent 11px),
     linear-gradient(90deg, rgba(37, 99, 235, 0.5) 1px, transparent 1px),
     linear-gradient(rgba(37, 99, 235, 0.5) 1px, transparent 1px),
     #111827;
@@ -950,6 +975,108 @@ body {
 
 .tscircuit-landing .landing-original-pcb-3 {
   background-color: #0f172a;
+}
+
+.tscircuit-landing .landing-pcb-toolbar {
+  position: absolute;
+  top: 14px;
+  right: 14px;
+  display: flex;
+  gap: 6px;
+  font-family: "Space Mono", monospace;
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.tscircuit-landing .landing-pcb-toolbar span {
+  border: 1px solid rgba(147, 197, 253, 0.55);
+  border-radius: 5px;
+  background: rgba(15, 23, 42, 0.72);
+  color: #dbeafe;
+  padding: 5px 7px;
+}
+
+.tscircuit-landing .landing-pcb-chip,
+.tscircuit-landing .landing-pcb-pad,
+.tscircuit-landing .landing-pcb-trace {
+  position: absolute;
+}
+
+.tscircuit-landing .landing-pcb-chip {
+  border: 1px solid #f59e0b;
+  background: #1f2937;
+  box-shadow: 0 0 0 6px rgba(37, 99, 235, 0.12);
+}
+
+.tscircuit-landing .landing-pcb-chip-main {
+  top: 40%;
+  left: 44%;
+  width: 82px;
+  height: 58px;
+}
+
+.tscircuit-landing .landing-pcb-chip-sub {
+  right: 14%;
+  bottom: 18%;
+  width: 52px;
+  height: 72px;
+}
+
+.tscircuit-landing .landing-pcb-trace {
+  height: 2px;
+  border-radius: 999px;
+  background: #22c55e;
+  transform-origin: left center;
+}
+
+.tscircuit-landing .landing-pcb-trace-a {
+  top: 34%;
+  left: 14%;
+  width: 56%;
+  transform: rotate(13deg);
+}
+
+.tscircuit-landing .landing-pcb-trace-b {
+  top: 62%;
+  left: 20%;
+  width: 52%;
+  transform: rotate(-18deg);
+}
+
+.tscircuit-landing .landing-pcb-trace-c {
+  top: 78%;
+  left: 10%;
+  width: 68%;
+  background: #60a5fa;
+  transform: rotate(2deg);
+}
+
+.tscircuit-landing .landing-pcb-pad {
+  width: 14px;
+  height: 14px;
+  border-radius: 999px;
+  background: #ec4899;
+  box-shadow:
+    22px 0 #ec4899,
+    44px 0 #ec4899,
+    66px 0 #ec4899;
+}
+
+.tscircuit-landing .landing-pcb-pad-a {
+  top: 62%;
+  left: 12%;
+}
+
+.tscircuit-landing .landing-pcb-pad-b {
+  right: 12%;
+  top: 28%;
+}
+
+.tscircuit-landing .landing-pcb-pad-c {
+  right: 18%;
+  bottom: 18%;
 }
 
 .tscircuit-landing .landing-original-board-owner {
@@ -968,25 +1095,184 @@ body {
   line-height: 1.05;
 }
 
+.tscircuit-landing .landing-original-gallery-board p {
+  max-width: 460px;
+  margin: 10px 0 0;
+  color: #475569;
+  font-size: 15px;
+  line-height: 1.45;
+}
+
+.tscircuit-landing .landing-original-board-stats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 18px;
+}
+
+.tscircuit-landing .landing-original-board-stats span {
+  border: 1px solid #bfdbfe;
+  border-radius: 8px;
+  background: #ffffff;
+  color: #2563eb;
+  font-family: "Space Mono", monospace;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  padding: 7px 9px;
+  text-transform: uppercase;
+}
+
 .tscircuit-landing .landing-original-gallery-more {
   margin-top: 28px;
 }
 
 .tscircuit-landing .landing-original-careers-row {
+  position: relative;
   display: grid;
   max-width: 1840px;
-  grid-template-columns: minmax(0, 1fr) auto;
-  gap: 36px;
+  grid-template-columns: minmax(0, 1fr) minmax(420px, 0.68fr);
+  gap: 48px;
   align-items: center;
+  overflow: hidden;
   border: 1px solid #93c5fd;
-  border-radius: 12px;
-  background: #ffffff;
-  padding: 36px;
+  border-radius: 32px;
+  background:
+    linear-gradient(rgba(37, 99, 235, 0.08) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(37, 99, 235, 0.08) 1px, transparent 1px),
+    linear-gradient(135deg, #ffffff 0%, #eff6ff 100%);
+  background-size: 42px 42px, 42px 42px, auto;
+  padding: 54px;
   margin: 0 auto;
+  box-shadow: 0 28px 90px rgba(37, 99, 235, 0.13);
 }
 
 .tscircuit-landing .landing-original-careers {
-  background: #f8fafc;
+  background: #eff6ff;
+}
+
+.tscircuit-landing .landing-careers-roles {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 28px;
+}
+
+.tscircuit-landing .landing-careers-roles span {
+  border: 1px solid #93c5fd;
+  border-radius: 8px;
+  background: #ffffff;
+  color: #2563eb;
+  font-family: "Space Mono", monospace;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  padding: 10px 12px;
+  text-transform: uppercase;
+}
+
+.tscircuit-landing .landing-careers-panel {
+  display: grid;
+  gap: 16px;
+  border: 1px solid #bfdbfe;
+  border-radius: 24px;
+  background: rgba(255, 255, 255, 0.86);
+  padding: 18px;
+  box-shadow: 0 20px 70px rgba(37, 99, 235, 0.16);
+}
+
+.tscircuit-landing .landing-careers-terminal {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  border: 1px solid #bfdbfe;
+  border-radius: 14px;
+  background: #0f172a;
+  color: #dbeafe;
+  font-family: "Space Mono", monospace;
+  font-size: 12px;
+  padding: 14px 16px;
+}
+
+.tscircuit-landing .landing-careers-terminal strong {
+  color: #38bdf8;
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.tscircuit-landing .landing-careers-circuit {
+  position: relative;
+  min-height: 260px;
+  overflow: hidden;
+  border: 1px solid #bfdbfe;
+  border-radius: 18px;
+  background:
+    linear-gradient(rgba(37, 99, 235, 0.16) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(37, 99, 235, 0.14) 1px, transparent 1px),
+    #ffffff;
+  background-size: 36px 36px;
+}
+
+.tscircuit-landing .landing-careers-circuit::before,
+.tscircuit-landing .landing-careers-circuit::after {
+  position: absolute;
+  content: "";
+  height: 3px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, #2563eb, #0ea5e9);
+  transform-origin: left center;
+}
+
+.tscircuit-landing .landing-careers-circuit::before {
+  top: 44%;
+  left: 12%;
+  width: 76%;
+  transform: rotate(12deg);
+}
+
+.tscircuit-landing .landing-careers-circuit::after {
+  top: 64%;
+  left: 18%;
+  width: 64%;
+  transform: rotate(-16deg);
+}
+
+.tscircuit-landing .landing-careers-circuit span {
+  position: absolute;
+  z-index: 1;
+  display: grid;
+  width: 74px;
+  height: 58px;
+  place-items: center;
+  border: 1px solid #2563eb;
+  border-radius: 12px;
+  background: #ffffff;
+  color: #1d4ed8;
+  font-family: "Space Mono", monospace;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.tscircuit-landing .landing-careers-circuit span:nth-child(1) {
+  top: 18%;
+  left: 13%;
+}
+
+.tscircuit-landing .landing-careers-circuit span:nth-child(2) {
+  top: 22%;
+  right: 18%;
+}
+
+.tscircuit-landing .landing-careers-circuit span:nth-child(3) {
+  bottom: 18%;
+  left: 26%;
+}
+
+.tscircuit-landing .landing-careers-circuit span:nth-child(4) {
+  right: 14%;
+  bottom: 16%;
 }
 
 @media (max-width: 1100px) {

--- a/src/index.css
+++ b/src/index.css
@@ -592,19 +592,69 @@ body {
 }
 
 .tscircuit-landing .landing-original-code {
-  overflow-x: auto;
-  overflow-y: hidden;
+  display: flex;
+  min-height: 330px;
+  align-items: center;
+  overflow: auto;
   background: #0f172a;
-  padding: 20px;
+  padding: 24px;
+}
+
+.tscircuit-landing .landing-hero-code-panel {
+  display: flex;
+  height: 100%;
+  align-items: center;
+  overflow: auto;
+  border-radius: 12px;
+  background: #0f172a;
+  padding: 28px;
+}
+
+.tscircuit-landing .landing-code-snippet {
+  margin: 0;
+  color: #dbeafe;
+  font-family: "Space Mono", monospace;
+  font-size: 14px;
+  line-height: 1.72;
+  min-width: max-content;
+  white-space: pre;
+}
+
+.tscircuit-landing .syntax-keyword {
+  color: #93c5fd;
+}
+
+.tscircuit-landing .syntax-tag {
+  color: #38bdf8;
+}
+
+.tscircuit-landing .syntax-attr {
+  color: #bfdbfe;
+}
+
+.tscircuit-landing .syntax-string {
+  color: #86efac;
+}
+
+.tscircuit-landing .syntax-punctuation {
+  color: #e2e8f0;
 }
 
 .tscircuit-landing .landing-original-autoroute {
   position: relative;
+  display: block;
   background:
     linear-gradient(rgba(37, 99, 235, 0.12) 1px, transparent 1px),
     linear-gradient(90deg, rgba(37, 99, 235, 0.12) 1px, transparent 1px),
     #ffffff;
   background-size: 44px 44px;
+}
+
+.tscircuit-landing .landing-original-autoroute video {
+  display: block;
+  height: 100%;
+  min-height: 330px;
+  width: 100%;
 }
 
 .tscircuit-landing .landing-original-autoroute span {
@@ -645,13 +695,18 @@ body {
   transform: rotate(6deg);
 }
 
-.tscircuit-landing .landing-original-code pre {
-  margin: 0;
-  color: #dbeafe;
-  font-family: "Space Mono", monospace;
-  font-size: 13px;
-  line-height: 1.55;
-  white-space: pre;
+@media (max-width: 767px) {
+  .tscircuit-landing .landing-code-snippet {
+    font-size: 12px;
+    line-height: 1.62;
+  }
+
+  .tscircuit-landing .landing-hero-code-panel,
+  .tscircuit-landing .landing-original-code,
+  .tscircuit-landing .landing-original-browser-code {
+    align-items: flex-start;
+    padding: 18px;
+  }
 }
 
 .tscircuit-landing .landing-original-media {
@@ -858,18 +913,16 @@ body {
 
 .tscircuit-landing .landing-original-browser-body {
   display: grid;
-  grid-template-columns: 0.9fr 1.1fr;
+  grid-template-columns: 1.18fr 0.82fr;
   min-height: 360px;
 }
 
 .tscircuit-landing .landing-original-browser-code {
-  overflow: hidden;
+  display: flex;
+  align-items: center;
+  overflow: auto;
   background: #0f172a;
   padding: 24px;
-  color: #dbeafe;
-  font-family: "Space Mono", monospace;
-  font-size: 13px;
-  line-height: 1.65;
 }
 
 .tscircuit-landing .landing-original-browser-board {

--- a/src/index.css
+++ b/src/index.css
@@ -1180,7 +1180,7 @@ body {
   margin-top: 28px;
 }
 
- .tscircuit-landing .landing-original-careers-row {
+.tscircuit-landing .landing-original-careers-row {
   position: relative;
   max-width: 1840px;
   overflow: hidden;
@@ -1236,12 +1236,14 @@ body {
   position: relative;
   z-index: 1;
   max-width: 1120px;
-  margin-left: clamp(0px, 4vw, 80px);
+  margin: 0 auto;
 }
 
 .tscircuit-landing .landing-careers-letter {
   max-width: 980px;
   margin-top: 28px;
+  margin-right: auto;
+  margin-left: auto;
   background: rgba(255, 255, 255, 0.58);
   padding: 28px 34px;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -445,6 +445,588 @@ body {
   }
 }
 
+.tscircuit-landing .landing-original-section {
+  position: relative;
+  overflow: hidden;
+  padding: 82px 48px;
+  background:
+    linear-gradient(rgba(37, 99, 235, 0.1) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(37, 99, 235, 0.09) 1px, transparent 1px),
+    #ffffff;
+  background-size: 48px 48px;
+  color: #0f172a;
+}
+
+.tscircuit-landing .landing-original-shell {
+  position: relative;
+  max-width: 1840px;
+  margin: 0 auto;
+}
+
+.tscircuit-landing .landing-original-eyebrow,
+.tscircuit-landing .landing-original-meta {
+  color: #2563eb;
+  font-family: "Space Mono", monospace;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.tscircuit-landing .landing-original-section h2 {
+  max-width: 980px;
+  margin: 12px 0 0;
+  font-family: "Anybody", sans-serif;
+  font-size: 72px;
+  font-weight: 850;
+  line-height: 0.96;
+  letter-spacing: 0;
+}
+
+.tscircuit-landing .landing-original-sub {
+  max-width: 820px;
+  margin: 18px 0 0;
+  color: #334155;
+  font-size: 20px;
+  line-height: 1.45;
+}
+
+.tscircuit-landing .landing-original-feature-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 32px;
+  margin-top: 42px;
+}
+
+.tscircuit-landing .landing-original-card {
+  position: relative;
+  display: grid;
+  min-height: 540px;
+  grid-template-rows: auto 1fr;
+  gap: 24px;
+  overflow: hidden;
+  border: 1px solid #cbd5e1;
+  border-radius: 28px;
+  background: #dbeafe;
+  padding: 34px;
+  box-shadow: 0 18px 70px rgba(37, 99, 235, 0.13);
+}
+
+.tscircuit-landing .landing-original-card:nth-child(3n + 2) {
+  background: #eff6ff;
+}
+
+.tscircuit-landing .landing-original-card:nth-child(3n) {
+  background: #ffffff;
+}
+
+.tscircuit-landing .landing-original-card::before {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  display: grid;
+  width: 86px;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 6px;
+  pointer-events: none;
+  content: "";
+  aspect-ratio: 1;
+  background:
+    linear-gradient(#bfdbfe, #bfdbfe) 0 0 / 24px 24px no-repeat,
+    linear-gradient(#eff6ff, #eff6ff) 31px 0 / 24px 24px no-repeat,
+    linear-gradient(#dbeafe, #dbeafe) 62px 0 / 24px 24px no-repeat,
+    linear-gradient(#ffffff, #ffffff) 0 31px / 24px 24px no-repeat,
+    linear-gradient(#dbeafe, #dbeafe) 31px 31px / 24px 24px no-repeat;
+  border-radius: 8px;
+  opacity: 0.7;
+}
+
+.tscircuit-landing .landing-original-card::after {
+  position: absolute;
+  right: -28px;
+  bottom: -28px;
+  width: 150px;
+  height: 150px;
+  pointer-events: none;
+  content: "";
+  border-top: 1px solid rgba(37, 99, 235, 0.35);
+  border-left: 1px solid rgba(37, 99, 235, 0.35);
+  border-radius: 28px 0 0 0;
+  background:
+    radial-gradient(circle at 28px 28px, rgba(14, 165, 233, 0.35) 0 4px, transparent 5px),
+    linear-gradient(135deg, transparent 0 48%, rgba(37, 99, 235, 0.18) 48% 52%, transparent 52%);
+}
+
+.tscircuit-landing .landing-original-card > * {
+  position: relative;
+  z-index: 1;
+}
+
+.tscircuit-landing .landing-original-card h3 {
+  margin: 14px 0 0;
+  font-family: "Anybody", sans-serif;
+  font-size: 28px;
+  font-weight: 800;
+  line-height: 1.05;
+  letter-spacing: 0;
+}
+
+.tscircuit-landing .landing-original-card p {
+  margin: 12px 0 0;
+  color: #334155;
+  font-size: 17px;
+  line-height: 1.45;
+}
+
+.tscircuit-landing .landing-original-code,
+.tscircuit-landing .landing-original-autoroute,
+.tscircuit-landing .landing-original-media,
+.tscircuit-landing .landing-original-review,
+.tscircuit-landing .landing-original-chart,
+.tscircuit-landing .landing-original-bom {
+  min-height: 330px;
+  overflow: hidden;
+  border: 1px solid #bfdbfe;
+  border-radius: 18px;
+  background: #ffffff;
+}
+
+.tscircuit-landing .landing-original-code {
+  overflow-x: auto;
+  overflow-y: hidden;
+  background: #0f172a;
+  padding: 20px;
+}
+
+.tscircuit-landing .landing-original-autoroute {
+  position: relative;
+  background:
+    linear-gradient(rgba(37, 99, 235, 0.12) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(37, 99, 235, 0.12) 1px, transparent 1px),
+    #ffffff;
+  background-size: 44px 44px;
+}
+
+.tscircuit-landing .landing-original-autoroute span {
+  position: absolute;
+  width: 9px;
+  height: 9px;
+  border: 2px solid #93c5fd;
+  border-radius: 999px;
+  background: #ffffff;
+}
+
+.tscircuit-landing .landing-original-autoroute i {
+  position: absolute;
+  height: 2px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, #2563eb, #0ea5e9);
+  transform-origin: left center;
+}
+
+.tscircuit-landing .landing-original-trace-a {
+  top: 35%;
+  left: 14%;
+  width: 54%;
+  transform: rotate(14deg);
+}
+
+.tscircuit-landing .landing-original-trace-b {
+  top: 58%;
+  left: 25%;
+  width: 62%;
+  transform: rotate(-18deg);
+}
+
+.tscircuit-landing .landing-original-trace-c {
+  top: 76%;
+  left: 10%;
+  width: 42%;
+  transform: rotate(6deg);
+}
+
+.tscircuit-landing .landing-original-code pre {
+  margin: 0;
+  color: #dbeafe;
+  font-family: "Space Mono", monospace;
+  font-size: 13px;
+  line-height: 1.55;
+  white-space: pre;
+}
+
+.tscircuit-landing .landing-original-media {
+  display: grid;
+  place-items: center;
+  background: #eff6ff;
+}
+
+.tscircuit-landing .landing-original-media-white {
+  background: #ffffff;
+}
+
+.tscircuit-landing .landing-original-media-contain {
+  padding: 12px;
+}
+
+.tscircuit-landing .landing-original-media-dark {
+  background: #1e293b;
+}
+
+.tscircuit-landing .landing-original-review {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1px;
+  background: #0f172a;
+  padding: 10px;
+}
+
+.tscircuit-landing .landing-original-review-board {
+  position: relative;
+  min-height: 198px;
+  overflow: hidden;
+  border: 1px solid #2563eb;
+  border-radius: 6px;
+  background:
+    linear-gradient(90deg, rgba(37, 99, 235, 0.36) 1px, transparent 1px),
+    linear-gradient(rgba(37, 99, 235, 0.26) 1px, transparent 1px),
+    #111827;
+  background-size: 34px 34px;
+}
+
+.tscircuit-landing .landing-original-review-board span {
+  position: absolute;
+  top: 10px;
+  left: 12px;
+  color: #60a5fa;
+  font-family: "Space Mono", monospace;
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.tscircuit-landing .landing-original-chip {
+  position: absolute;
+  top: 70px;
+  left: 50%;
+  width: 52px;
+  height: 58px;
+  border: 1px solid #f97316;
+  background: #1f2937;
+  transform: translateX(-50%);
+}
+
+.tscircuit-landing .landing-original-review-board i {
+  position: absolute;
+  bottom: 34px;
+  width: 12px;
+  height: 12px;
+  border-radius: 999px;
+  background: #ec4899;
+}
+
+.tscircuit-landing .landing-original-chart {
+  display: grid;
+  place-items: center;
+  padding: 20px;
+}
+
+.tscircuit-landing .landing-original-chart svg {
+  width: 100%;
+  height: 100%;
+}
+
+.tscircuit-landing .landing-original-chart path {
+  fill: none;
+  stroke: #2563eb;
+  stroke-width: 4;
+}
+
+.tscircuit-landing .landing-original-chart line {
+  stroke: #94a3b8;
+  stroke-width: 2;
+}
+
+.tscircuit-landing .landing-original-bom {
+  padding: 16px;
+  font-family: "Space Mono", monospace;
+  font-size: 12px;
+}
+
+.tscircuit-landing .landing-original-bom-toolbar,
+.tscircuit-landing .landing-original-bom-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1.4fr;
+  gap: 10px;
+  align-items: center;
+  border-bottom: 1px solid #dbeafe;
+  padding: 10px 0;
+}
+
+.tscircuit-landing .landing-original-bom-toolbar {
+  grid-template-columns: 0.8fr 1fr 1.5fr 1fr;
+  color: #2563eb;
+  font-weight: 700;
+}
+
+.tscircuit-landing .landing-original-playground {
+  background: #eff6ff;
+}
+
+.tscircuit-landing .landing-original-playground-grid {
+  display: grid;
+  max-width: 1840px;
+  grid-template-columns: minmax(0, 0.9fr) minmax(0, 1.1fr);
+  gap: 44px;
+  align-items: center;
+  margin: 0 auto;
+}
+
+.tscircuit-landing .landing-original-button,
+.tscircuit-landing .landing-original-button-secondary {
+  display: inline-flex;
+  min-height: 52px;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  border-radius: 8px;
+  font-family: "Space Mono", monospace;
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-decoration: none;
+  text-transform: uppercase;
+}
+
+.tscircuit-landing .landing-original-button {
+  margin-top: 28px;
+  background: #2563eb;
+  color: #ffffff;
+  padding: 0 24px;
+}
+
+.tscircuit-landing .landing-original-button-secondary {
+  border: 1px solid #93c5fd;
+  background: #ffffff;
+  color: #0f172a;
+  padding: 0 24px;
+}
+
+.tscircuit-landing .landing-original-button:hover,
+.tscircuit-landing .landing-original-button:focus-visible {
+  background: #1d4ed8;
+}
+
+.tscircuit-landing .landing-original-button-secondary:hover,
+.tscircuit-landing .landing-original-button-secondary:focus-visible {
+  border-color: #2563eb;
+  background: #dbeafe;
+}
+
+.tscircuit-landing .landing-original-button:focus-visible,
+.tscircuit-landing .landing-original-button-secondary:focus-visible,
+.tscircuit-landing .landing-original-gallery-board:focus-visible {
+  outline: 3px solid #93c5fd;
+  outline-offset: 3px;
+}
+
+.tscircuit-landing .landing-original-browser {
+  overflow: hidden;
+  border: 1px solid #bfdbfe;
+  border-radius: 12px;
+  background: #ffffff;
+  box-shadow: 0 28px 80px rgba(37, 99, 235, 0.16);
+}
+
+.tscircuit-landing .landing-original-browser-top {
+  display: flex;
+  min-height: 44px;
+  align-items: center;
+  gap: 8px;
+  border-bottom: 1px solid #dbeafe;
+  padding: 0 16px;
+  font-family: "Space Mono", monospace;
+  font-size: 12px;
+  color: #64748b;
+}
+
+.tscircuit-landing .landing-original-browser-top span {
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  background: #93c5fd;
+}
+
+.tscircuit-landing .landing-original-browser-body {
+  display: grid;
+  grid-template-columns: 0.9fr 1.1fr;
+  min-height: 360px;
+}
+
+.tscircuit-landing .landing-original-browser-code {
+  overflow: hidden;
+  background: #0f172a;
+  padding: 24px;
+  color: #dbeafe;
+  font-family: "Space Mono", monospace;
+  font-size: 13px;
+  line-height: 1.65;
+}
+
+.tscircuit-landing .landing-original-browser-board {
+  display: grid;
+  place-items: center;
+  background:
+    linear-gradient(rgba(37, 99, 235, 0.12) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(37, 99, 235, 0.12) 1px, transparent 1px),
+    #f8fafc;
+  background-size: 32px 32px;
+}
+
+.tscircuit-landing .landing-original-board-shape {
+  position: relative;
+  width: 72%;
+  aspect-ratio: 1.35;
+  border: 3px solid #0ea5e9;
+  border-radius: 22px;
+  background: linear-gradient(180deg, #dbeafe, #ffffff);
+}
+
+.tscircuit-landing .landing-original-board-shape::before,
+.tscircuit-landing .landing-original-board-shape::after {
+  position: absolute;
+  content: "";
+  border: 1px solid #60a5fa;
+  border-radius: 8px;
+  background: #ffffff;
+}
+
+.tscircuit-landing .landing-original-board-shape::before {
+  top: 22%;
+  left: 14%;
+  width: 30%;
+  height: 32%;
+}
+
+.tscircuit-landing .landing-original-board-shape::after {
+  right: 13%;
+  bottom: 18%;
+  width: 26%;
+  height: 28%;
+}
+
+.tscircuit-landing .landing-original-gallery {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 28px;
+  margin-top: 36px;
+}
+
+.tscircuit-landing .landing-original-gallery-board {
+  display: grid;
+  gap: 18px;
+  border: 1px solid #94a3b8;
+  border-radius: 8px;
+  background: #ffffff;
+  padding: 18px;
+  color: #0f172a;
+  text-decoration: none;
+}
+
+.tscircuit-landing .landing-original-pcb {
+  min-height: 220px;
+  border-radius: 8px;
+  background:
+    radial-gradient(circle at 18% 20%, #ec4899 0 11px, transparent 12px),
+    radial-gradient(circle at 82% 76%, #ec4899 0 11px, transparent 12px),
+    linear-gradient(90deg, rgba(37, 99, 235, 0.5) 1px, transparent 1px),
+    linear-gradient(rgba(37, 99, 235, 0.5) 1px, transparent 1px),
+    #111827;
+  background-size: auto, auto, 36px 36px, 36px 36px, auto;
+}
+
+.tscircuit-landing .landing-original-pcb-2 {
+  background-color: #1e293b;
+}
+
+.tscircuit-landing .landing-original-pcb-3 {
+  background-color: #0f172a;
+}
+
+.tscircuit-landing .landing-original-board-owner {
+  color: #2563eb;
+  font-family: "Space Mono", monospace;
+  font-size: 12px;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.tscircuit-landing .landing-original-board-name {
+  margin-top: 4px;
+  font-family: "Anybody", sans-serif;
+  font-size: 28px;
+  font-weight: 800;
+  line-height: 1.05;
+}
+
+.tscircuit-landing .landing-original-gallery-more {
+  margin-top: 28px;
+}
+
+.tscircuit-landing .landing-original-careers-row {
+  display: grid;
+  max-width: 1840px;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 36px;
+  align-items: center;
+  border: 1px solid #93c5fd;
+  border-radius: 12px;
+  background: #ffffff;
+  padding: 36px;
+  margin: 0 auto;
+}
+
+.tscircuit-landing .landing-original-careers {
+  background: #f8fafc;
+}
+
+@media (max-width: 1100px) {
+  .tscircuit-landing .landing-original-feature-grid,
+  .tscircuit-landing .landing-original-gallery,
+  .tscircuit-landing .landing-original-playground-grid,
+  .tscircuit-landing .landing-original-careers-row {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 1180px) {
+  .tscircuit-landing .landing-original-section h2 {
+    font-size: 56px;
+  }
+}
+
+@media (max-width: 767px) {
+  .tscircuit-landing .landing-original-section {
+    padding: 64px 16px;
+  }
+
+  .tscircuit-landing .landing-original-section h2 {
+    font-size: 42px;
+  }
+
+  .tscircuit-landing .landing-original-card {
+    min-height: auto;
+    padding: 20px;
+  }
+
+  .tscircuit-landing .landing-original-browser-body {
+    grid-template-columns: 1fr;
+  }
+
+  .tscircuit-landing .landing-original-careers-row {
+    padding: 24px;
+  }
+}
+
 .tscircuit-landing .landing-faq section {
   background: #f8fafc;
   color: #0f172a;

--- a/src/landing-main.tsx
+++ b/src/landing-main.tsx
@@ -1,0 +1,10 @@
+import { StrictMode } from "react"
+import { createRoot } from "react-dom/client"
+import "./index.css"
+import { LandingPage } from "./pages/landing"
+
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <LandingPage />
+  </StrictMode>,
+)

--- a/src/pages/landing.tsx
+++ b/src/pages/landing.tsx
@@ -1,4 +1,5 @@
 import analogSimulationImg from "@/assets/analogsimulation.png"
+import autoroutingExampleVideo from "@/assets/autorouting_example.mp4"
 import exampleAiCodingImg from "@/assets/example_ai_coding.png"
 import importKicadLibraryImg from "@/assets/import-kicad-library.png"
 import shareableLinkForCircuitImg from "@/assets/shareable-link-for-circuit.png"
@@ -74,15 +75,6 @@ const heroViews = [
   },
 ] as const
 
-const codeLines = [
-  '<board width="36mm" height="28mm">',
-  '  <chip name="U1" footprint="soic8" />',
-  '  <resistor name="R1" resistance="10k" />',
-  '  <trace from="U1.pin1" to="R1.pin1" />',
-  '  <autorouting strategy="cloud" />',
-  "</board>",
-]
-
 const landingNavItems = [
   { label: "Examples", href: "/search", icon: FileText },
   { label: "Pricing", href: "/my-orders", icon: DollarSign },
@@ -96,25 +88,6 @@ const landingNavItems = [
     hasMenu: true,
   },
 ]
-
-const originalCodeSample = `export default () => (
-  <board width="18mm" height="12mm">
-    <resistor
-      name="R1"
-      resistance="1k"
-      footprint="0402"
-      pcbX={-4}
-    />
-    <led
-      name="D1"
-      color="red"
-      footprint="0603"
-      pcbX={4}
-    />
-    <trace from=".R1 > .pin2" to=".D1 > .anode" />
-    <trace from=".D1 > .cathode" to=".R1 > .pin1" />
-  </board>
-)`
 
 const originalFeatureCards = [
   {
@@ -173,6 +146,91 @@ const originalFeatureCards = [
   },
 ] as const
 
+const CircuitCodeSnippet = () => (
+  <pre className="landing-code-snippet">
+    <code>
+      <span className="syntax-keyword">export default</span>{" "}
+      <span className="syntax-punctuation">() =&gt; (</span>
+      {"\n  "}
+      <span className="syntax-punctuation">&lt;</span>
+      <span className="syntax-tag">board</span>{" "}
+      <span className="syntax-attr">width</span>
+      <span className="syntax-punctuation">=</span>
+      <span className="syntax-string">&quot;36mm&quot;</span>{" "}
+      <span className="syntax-attr">height</span>
+      <span className="syntax-punctuation">=</span>
+      <span className="syntax-string">&quot;28mm&quot;</span>
+      <span className="syntax-punctuation">&gt;</span>
+      {"\n    "}
+      <span className="syntax-punctuation">&lt;</span>
+      <span className="syntax-tag">chip</span>{" "}
+      <span className="syntax-attr">name</span>
+      <span className="syntax-punctuation">=</span>
+      <span className="syntax-string">&quot;U1&quot;</span>{" "}
+      <span className="syntax-attr">footprint</span>
+      <span className="syntax-punctuation">=</span>
+      <span className="syntax-string">&quot;soic8&quot;</span>{" "}
+      <span className="syntax-punctuation">/&gt;</span>
+      {"\n    "}
+      <span className="syntax-punctuation">&lt;</span>
+      <span className="syntax-tag">resistor</span>{" "}
+      <span className="syntax-attr">name</span>
+      <span className="syntax-punctuation">=</span>
+      <span className="syntax-string">&quot;R1&quot;</span>{" "}
+      <span className="syntax-attr">resistance</span>
+      <span className="syntax-punctuation">=</span>
+      <span className="syntax-string">&quot;10k&quot;</span>{" "}
+      <span className="syntax-punctuation">/&gt;</span>
+      {"\n    "}
+      <span className="syntax-punctuation">&lt;</span>
+      <span className="syntax-tag">capacitor</span>{" "}
+      <span className="syntax-attr">name</span>
+      <span className="syntax-punctuation">=</span>
+      <span className="syntax-string">&quot;C1&quot;</span>{" "}
+      <span className="syntax-attr">capacitance</span>
+      <span className="syntax-punctuation">=</span>
+      <span className="syntax-string">&quot;100nF&quot;</span>{" "}
+      <span className="syntax-punctuation">/&gt;</span>
+      {"\n    "}
+      <span className="syntax-punctuation">&lt;</span>
+      <span className="syntax-tag">trace</span>{" "}
+      <span className="syntax-attr">from</span>
+      <span className="syntax-punctuation">=</span>
+      <span className="syntax-string">&quot;U1.pin1&quot;</span>{" "}
+      <span className="syntax-attr">to</span>
+      <span className="syntax-punctuation">=</span>
+      <span className="syntax-string">&quot;R1.pin1&quot;</span>{" "}
+      <span className="syntax-punctuation">/&gt;</span>
+      {"\n    "}
+      <span className="syntax-punctuation">&lt;</span>
+      <span className="syntax-tag">trace</span>{" "}
+      <span className="syntax-attr">from</span>
+      <span className="syntax-punctuation">=</span>
+      <span className="syntax-string">&quot;U1.pin4&quot;</span>{" "}
+      <span className="syntax-attr">to</span>
+      <span className="syntax-punctuation">=</span>
+      <span className="syntax-string">&quot;C1.pin1&quot;</span>{" "}
+      <span className="syntax-punctuation">/&gt;</span>
+      {"\n    "}
+      <span className="syntax-punctuation">&lt;</span>
+      <span className="syntax-tag">autorouting</span>{" "}
+      <span className="syntax-attr">strategy</span>
+      <span className="syntax-punctuation">=</span>
+      <span className="syntax-string">&quot;cloud&quot;</span>{" "}
+      <span className="syntax-attr">layers</span>
+      <span className="syntax-punctuation">=</span>
+      <span className="syntax-string">&quot;4&quot;</span>{" "}
+      <span className="syntax-punctuation">/&gt;</span>
+      {"\n  "}
+      <span className="syntax-punctuation">&lt;/</span>
+      <span className="syntax-tag">board</span>
+      <span className="syntax-punctuation">&gt;</span>
+      {"\n"}
+      <span className="syntax-punctuation">)</span>
+    </code>
+  </pre>
+)
+
 const galleryBoards = [
   {
     owner: "tscircuit",
@@ -205,7 +263,7 @@ const OriginalFeatureVisual = ({
   if (visual === "code") {
     return (
       <div className="landing-original-code">
-        <pre>{originalCodeSample}</pre>
+        <CircuitCodeSnippet />
       </div>
     )
   }
@@ -213,18 +271,15 @@ const OriginalFeatureVisual = ({
   if (visual === "autoroute") {
     return (
       <div className="landing-original-autoroute" aria-label="Autorouting demo">
-        {Array.from({ length: 34 }).map((_, index) => (
-          <span
-            key={`route-dot-${index}`}
-            style={{
-              left: `${8 + ((index * 13) % 84)}%`,
-              top: `${14 + ((index * 17) % 72)}%`,
-            }}
-          />
-        ))}
-        <i className="landing-original-trace-a" />
-        <i className="landing-original-trace-b" />
-        <i className="landing-original-trace-c" />
+        <video
+          className="h-full w-full object-cover"
+          src={autoroutingExampleVideo}
+          autoPlay
+          muted
+          loop
+          playsInline
+          preload="metadata"
+        />
       </div>
     )
   }
@@ -659,18 +714,8 @@ export function LandingPage() {
                         className="landing-demo-panel landing-scanlines relative h-[340px] overflow-hidden rounded-xl border border-[#CBD5E1] bg-[#F8FAFC] p-4 sm:h-[380px] lg:h-[380px]"
                       >
                         {activeHeroView.id === "code" && (
-                          <div className="flex h-full flex-col justify-between font-['Space_Mono',monospace] text-xs leading-6 text-[#334155]">
-                            <div className="space-y-3">
-                              {codeLines.map((line) => (
-                                <div key={line} className="flex min-w-0 gap-3">
-                                  <span className="text-[#2563EB]">+</span>
-                                  <span className="truncate">{line}</span>
-                                </div>
-                              ))}
-                            </div>
-                            <div className="rounded-lg border border-[#2563EB]/50 bg-[#2563EB]/10 p-3 text-[#1D4ED8]">
-                              parse source → graph nets → validate outputs
-                            </div>
+                          <div className="landing-hero-code-panel">
+                            <CircuitCodeSnippet />
                           </div>
                         )}
 
@@ -818,7 +863,7 @@ export function LandingPage() {
               </div>
               <div className="landing-original-browser-body">
                 <div className="landing-original-browser-code">
-                  <pre>{codeLines.join("\n")}</pre>
+                  <CircuitCodeSnippet />
                 </div>
                 <div className="landing-original-browser-board">
                   <div className="landing-original-board-shape" />

--- a/src/pages/landing.tsx
+++ b/src/pages/landing.tsx
@@ -1,26 +1,18 @@
 import analogSimulationImg from "@/assets/analogsimulation.png"
-import autoroutingExampleVideo from "@/assets/autorouting_example.mp4"
 import exampleAiCodingImg from "@/assets/example_ai_coding.png"
 import importKicadLibraryImg from "@/assets/import-kicad-library.png"
 import shareableLinkForCircuitImg from "@/assets/shareable-link-for-circuit.png"
 import { FAQ } from "@/components/FAQ"
 import { OptimizedImage } from "@/components/OptimizedImage"
-import { useGlobalStore } from "@/hooks/use-global-store"
-import { useSignIn } from "@/hooks/use-sign-in"
 import {
   ArrowRight,
   BookOpen,
-  Bot,
-  Boxes,
-  Braces,
   Building2,
   ChevronDown,
   CircuitBoard,
-  Code2,
   Copy,
   DollarSign,
   FileText,
-  GitBranch,
   Library,
   Menu,
   Search,
@@ -30,72 +22,12 @@ import {
 import { useEffect, useState } from "react"
 import { Helmet } from "react-helmet"
 import { Link } from "wouter"
-import { navigate } from "wouter/use-browser-location"
 
-const featureCards = [
-  {
-    label: "SCHEMATIC",
-    title: "React components become real circuits.",
-    body: "Write boards, subcircuits, footprints, traces, probes, and exports in TypeScript instead of dragging opaque files around.",
-    icon: CircuitBoard,
-    accent: "text-[#2563EB]",
-  },
-  {
-    label: "AI-READY",
-    title: "Agents can edit electronics like code.",
-    body: "tscircuit projects are inspectable source, so Codex, Claude Code, and other agents can initialize, modify, review, and repair designs.",
-    icon: Bot,
-    accent: "text-[#0284C7]",
-  },
-  {
-    label: "FAB OUTPUT",
-    title: "Render once, ship many formats.",
-    body: "Generate schematics, PCBs, 3D previews, Gerbers, KiCad assets, SPICE netlists, BOMs, and assembly context from the same source.",
-    icon: Boxes,
-    accent: "text-[#0EA5E9]",
-  },
-]
-
-const processSteps = [
-  {
-    step: "STEP 01",
-    title: "Describe the board",
-    body: "Start from TSX, an AI prompt, or a reusable package. Component intent stays readable in source control.",
-  },
-  {
-    step: "STEP 02",
-    title: "Render every view",
-    body: "The same circuit becomes browser schematics, PCB layouts, 3D previews, simulations, and reviewable artifacts.",
-  },
-  {
-    step: "STEP 03",
-    title: "Route, test, export",
-    body: "Run autorouting, ngspice simulation, KiCad interop, and manufacturing exports without leaving the code workflow.",
-  },
-]
-
-const bugCards = [
-  {
-    tag: "AUTOROUTE",
-    path: "boards/led-water-accelerometer.tsx",
-    title: "Near-instant board iteration",
-    body: "Jumpers, layers, and route passes can be expressed as configuration rather than manual board surgery.",
-    color: "border-[#2563EB]/60",
-  },
-  {
-    tag: "SIMULATION",
-    path: "examples/full-wave-rectifier.tsx",
-    title: "SPICE where the source lives",
-    body: "Voltage probes and ngspice settings are part of the circuit definition, so review includes behavior.",
-    color: "border-[#3B82F6]/70",
-  },
-  {
-    tag: "KICAD",
-    path: "packages/RP2040.kicad_mod",
-    title: "Existing libraries still matter",
-    body: "Import footprints and export KiCad files when collaboration or manufacturing needs traditional formats.",
-    color: "border-[#1D4ED8]/70",
-  },
+const surfaceTiles = [
+  "bg-[#F8FAFC]",
+  "bg-[#EFF6FF]",
+  "bg-[#DBEAFE]",
+  "bg-[#FFFFFF]",
 ]
 
 const integrations = [
@@ -106,15 +38,6 @@ const integrations = [
   "BOM checks",
   "AI code agents",
 ]
-
-const surfaceTiles = [
-  "bg-[#F8FAFC]",
-  "bg-[#EFF6FF]",
-  "bg-[#DBEAFE]",
-  "bg-[#FFFFFF]",
-]
-
-const pipelineNodes = ["TSX", "SVG", "PCB", "BOM", "3D", "GTR"]
 
 const heroViews = [
   {
@@ -173,6 +96,241 @@ const landingNavItems = [
     hasMenu: true,
   },
 ]
+
+const originalCodeSample = `export default () => (
+  <board width="18mm" height="12mm">
+    <resistor
+      name="R1"
+      resistance="1k"
+      footprint="0402"
+      pcbX={-4}
+    />
+    <led
+      name="D1"
+      color="red"
+      footprint="0603"
+      pcbX={4}
+    />
+    <trace from=".R1 > .pin2" to=".D1 > .anode" />
+    <trace from=".D1 > .cathode" to=".R1 > .pin1" />
+  </board>
+)`
+
+const originalFeatureCards = [
+  {
+    meta: "01 · REACT",
+    title: "JSX components for circuits",
+    body: "Compose boards the way you compose UI. Props, children, hooks - but for resistors.",
+    visual: "code",
+  },
+  {
+    meta: "02 · AUTOROUTE",
+    title: "Real-time autorouting",
+    body: "Sub-second routing on 4-layer boards. Runs locally with LLM-compatible tweaking.",
+    visual: "autoroute",
+  },
+  {
+    meta: "03 · AI",
+    title: "AI coding skills for hardware",
+    body: "Give Claude Code, Codex, or custom agents the tscircuit skill with the CLI, syntax, workflow, and pre-fab context they need to make useful changes.",
+    visual: "ai",
+  },
+  {
+    meta: "04 · FAB",
+    title: "Export every format you need",
+    body: "Download PCB, schematic, and assembly images plus fabrication files, KiCad, DSN, JSON, and netlists from the same board source.",
+    visual: "formats",
+  },
+  {
+    meta: "05 · REVIEW",
+    title: "Visual Diffs Inside GitHub",
+    body: "All the capabilities of version control tool works natively with tscircuit. Approvals, comments, rollback.",
+    visual: "review",
+  },
+  {
+    meta: "06 · OSS",
+    title: "Open & forkable",
+    body: "Open source under MIT. Explore the tscircuit GitHub org, fork what you need, and build on top of it.",
+    visual: "oss",
+  },
+  {
+    meta: "07 · SIMULATION",
+    title: "Analog Simulation",
+    body: "Run analog simulations with tsci simulate on the command line or in the browser, backed by WebAssembly ngspice.",
+    visual: "simulation",
+  },
+  {
+    meta: "08 · KICAD",
+    title: "First Class KiCad Support",
+    body: "Import and export your library anywhere. Import KiCad files natively. Import your tscircuit packages directly into KiCad with native KiCad PCM support.",
+    visual: "kicad",
+  },
+  {
+    meta: "09 · BOM",
+    title: "Automatic Part Selection",
+    body: "Specify parts without part numbers. Bill of materials automatically generated based on realtime availability from supplier integrations.",
+    visual: "bom",
+  },
+] as const
+
+const galleryBoards = [
+  {
+    owner: "tscircuit",
+    name: "motor-controller",
+    href: "/tscircuit/motor-controller",
+  },
+  {
+    owner: "seveibar",
+    name: "keyboard-default60",
+    href: "/seveibar/keyboard-default60",
+  },
+  {
+    owner: "seveibar",
+    name: "led-water-accelerometer",
+    href: "/seveibar/led-water-accelerometer",
+  },
+] as const
+
+const OriginalFeatureVisual = ({
+  visual,
+}: {
+  visual: (typeof originalFeatureCards)[number]["visual"]
+}) => {
+  if (visual === "code") {
+    return (
+      <div className="landing-original-code">
+        <pre>{originalCodeSample}</pre>
+      </div>
+    )
+  }
+
+  if (visual === "autoroute") {
+    return (
+      <div className="landing-original-autoroute" aria-label="Autorouting demo">
+        {Array.from({ length: 34 }).map((_, index) => (
+          <span
+            key={`route-dot-${index}`}
+            style={{
+              left: `${8 + ((index * 13) % 84)}%`,
+              top: `${14 + ((index * 17) % 72)}%`,
+            }}
+          />
+        ))}
+        <i className="landing-original-trace-a" />
+        <i className="landing-original-trace-b" />
+        <i className="landing-original-trace-c" />
+      </div>
+    )
+  }
+
+  if (visual === "ai") {
+    return (
+      <div className="landing-original-media">
+        <OptimizedImage
+          alt="AI coding example for tscircuit"
+          className="h-full w-full object-cover"
+          src={exampleAiCodingImg}
+          height={220}
+          width={420}
+          priority
+        />
+      </div>
+    )
+  }
+
+  if (visual === "formats") {
+    return (
+      <div className="landing-original-media landing-original-media-contain">
+        <OptimizedImage
+          alt="Multiple export formats available in tscircuit"
+          className="h-full w-full object-contain"
+          src={shareableLinkForCircuitImg}
+          height={220}
+          width={420}
+          priority
+        />
+      </div>
+    )
+  }
+
+  if (visual === "review") {
+    return (
+      <div className="landing-original-review" aria-label="Visual diff preview">
+        {["Deleted", "Added"].map((label) => (
+          <div key={label} className="landing-original-review-board">
+            <span>{label}</span>
+            <div className="landing-original-chip" />
+            {[12, 28, 44, 65, 82].map((left) => (
+              <i key={left} style={{ left: `${left}%` }} />
+            ))}
+          </div>
+        ))}
+      </div>
+    )
+  }
+
+  if (visual === "oss") {
+    return (
+      <div className="landing-original-chart" aria-label="Star history chart">
+        <svg viewBox="0 0 360 150" role="img" aria-hidden="true">
+          <path d="M22 130 C72 108 90 86 132 88 C190 92 212 70 248 56 C286 42 294 24 330 18" />
+          <g>
+            <line x1="24" y1="22" x2="24" y2="132" />
+            <line x1="24" y1="132" x2="336" y2="132" />
+          </g>
+        </svg>
+      </div>
+    )
+  }
+
+  if (visual === "simulation") {
+    return (
+      <div className="landing-original-media landing-original-media-contain">
+        <OptimizedImage
+          alt="Analog simulation view in tscircuit"
+          className="h-full w-full object-contain"
+          src={analogSimulationImg}
+          height={220}
+          width={420}
+          priority
+        />
+      </div>
+    )
+  }
+
+  if (visual === "kicad") {
+    return (
+      <div className="landing-original-media landing-original-media-contain landing-original-media-dark">
+        <OptimizedImage
+          alt="KiCad library import workflow in tscircuit"
+          className="h-full w-full object-contain"
+          src={importKicadLibraryImg}
+          height={220}
+          width={420}
+          priority
+        />
+      </div>
+    )
+  }
+
+  return (
+    <div className="landing-original-bom" aria-label="Bill of materials table">
+      <div className="landing-original-bom-toolbar">
+        <span>Run</span>
+        <span>PCB</span>
+        <span>Schematic</span>
+        <span>BOM</span>
+      </div>
+      {["USBC", "LED", "SW1", "R1"].map((part, index) => (
+        <div key={part} className="landing-original-bom-row">
+          <span>{part}</span>
+          <span>{index === 3 ? "1k" : "-"}</span>
+          <span>C{index + 165748}</span>
+        </div>
+      ))}
+    </div>
+  )
+}
 
 const LandingTopBar = () => {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false)
@@ -324,8 +482,6 @@ const LandingFooter = () => (
 )
 
 export function LandingPage() {
-  const signIn = useSignIn()
-  const isLoggedIn = useGlobalStore((s) => Boolean(s.session))
   const [activeHeroViewIndex, setActiveHeroViewIndex] = useState(0)
   const activeHeroView = heroViews[activeHeroViewIndex]
 
@@ -600,338 +756,108 @@ export function LandingPage() {
 
         <section
           id="features"
-          className="landing-tile-field relative bg-[#FFFFFF] px-4 py-16 md:px-6 md:py-24"
+          className="landing-original-section landing-tile-field"
+          aria-labelledby="features-title"
         >
-          <div className="absolute inset-0 opacity-45 [background-image:linear-gradient(rgba(37,99,235,.10)_1px,transparent_1px),linear-gradient(90deg,rgba(37,99,235,.10)_1px,transparent_1px)] [background-size:48px_48px]" />
-          <div className="relative mx-auto max-w-7xl">
-            <div className="grid gap-6 lg:grid-cols-3">
-              {featureCards.map((feature, index) => {
-                const Icon = feature.icon
-                return (
-                  <article
-                    key={feature.title}
-                    className={`relative overflow-hidden rounded-3xl border border-[#CBD5E1] ${
-                      index === 1 ? "bg-[#EFF6FF]" : "bg-[#DBEAFE]"
-                    } p-6 shadow-[0_12px_40px_rgba(37,99,235,.12)]`}
-                  >
-                    <div className="absolute right-0 top-0 grid w-28 grid-cols-3 gap-1 p-3 opacity-45">
-                      {surfaceTiles.map((tile, tileIndex) => (
-                        <span
-                          key={`${feature.label}-tile-${tileIndex}`}
-                          className={`aspect-square rounded-md border border-[#93C5FD] ${tile}`}
-                        />
-                      ))}
-                    </div>
-                    <div
-                      className={`mb-8 inline-grid h-12 w-12 place-items-center rounded-xl bg-[#F8FAFC] ${feature.accent}`}
-                    >
-                      <Icon className="h-6 w-6" />
-                    </div>
-                    <div className="font-['Space_Mono',monospace] text-[11px] font-bold uppercase tracking-[0.12em] text-[#2563EB]">
-                      {feature.label}
-                    </div>
-                    <h2 className="mt-3 font-['Anybody',sans-serif] text-3xl font-extrabold leading-[1.02] tracking-normal">
-                      {feature.title}
-                    </h2>
-                    <p className="mt-4 leading-7 text-[#334155]">
-                      {feature.body}
-                    </p>
-                  </article>
-                )
-              })}
-            </div>
-          </div>
-        </section>
+          <div className="landing-original-shell">
+            <div className="landing-original-eyebrow">Why teams switch</div>
+            <h2 id="features-title">Everything your EE team needs, as code.</h2>
+            <p className="landing-original-sub">
+              Built for hardware startups who move at software speed. Every
+              feature composable, inspectable, diffable in a PR.
+            </p>
 
-        <section className="relative border-y border-[#CBD5E1] bg-[#EFF6FF] px-4 py-16 md:px-6 md:py-24">
-          <div className="absolute inset-0 opacity-35 [background-image:linear-gradient(135deg,rgba(37,99,235,.14)_0_1px,transparent_1px_30px)]" />
-          <div className="relative mx-auto max-w-7xl">
-            <div className="mb-10 grid gap-6 lg:grid-cols-[minmax(0,1fr)_420px] lg:items-end">
-              <div className="max-w-3xl">
-                <div className="font-['Space_Mono',monospace] text-xs font-bold uppercase tracking-[0.12em] text-[#2563EB]">
-                  [ CODE TO CIRCUIT PIPELINE ]
-                </div>
-                <h2 className="mt-4 font-['Anybody',sans-serif] text-4xl font-extrabold leading-none tracking-normal md:text-6xl">
-                  A developer workflow for physical boards.
-                </h2>
-              </div>
-              <div className="grid grid-cols-6 gap-2 rounded-2xl border border-[#CBD5E1] bg-[#FFFFFF] p-3">
-                {pipelineNodes.map((label, index) => (
-                  <div
-                    key={`rail-${label}`}
-                    className={`grid aspect-square place-items-center rounded-lg border font-['Space_Mono',monospace] text-[10px] font-bold ${
-                      index % 3 === 0
-                        ? "border-[#2563EB]/70 bg-[#2563EB]/10 text-[#2563EB]"
-                        : "border-[#CBD5E1] bg-[#F8FAFC] text-[#64748B]"
-                    }`}
-                  >
-                    {label}
+            <div className="landing-original-feature-grid">
+              {originalFeatureCards.map((feature) => (
+                <article key={feature.title} className="landing-original-card">
+                  <div>
+                    <div className="landing-original-meta">{feature.meta}</div>
+                    <h3>{feature.title}</h3>
+                    <p>{feature.body}</p>
                   </div>
-                ))}
-              </div>
-            </div>
-            <div className="grid gap-5 lg:grid-cols-3">
-              {processSteps.map((step, index) => (
-                <article
-                  key={step.step}
-                  className={`relative overflow-hidden rounded-[28px] border border-[#CBD5E1] ${
-                    index === 0
-                      ? "bg-[#F8FAFC]"
-                      : index === 1
-                        ? "bg-[#FFFFFF]"
-                        : "bg-[#DBEAFE]"
-                  } p-7`}
-                >
-                  <div className="absolute bottom-0 right-0 h-24 w-24 border-l border-t border-[#CBD5E1] bg-[linear-gradient(135deg,transparent_0_48%,rgba(37,99,235,.14)_48%_52%,transparent_52%)]" />
-                  <div className="mb-8 flex items-center justify-between">
-                    <span className="font-['Space_Mono',monospace] text-xs font-bold uppercase tracking-[0.12em] text-[#0EA5E9]">
-                      {step.step}
-                    </span>
-                    <GitBranch className="h-5 w-5 text-[#2563EB]" />
-                  </div>
-                  <h3 className="font-['Anybody',sans-serif] text-3xl font-bold leading-tight tracking-normal">
-                    {step.title}
-                  </h3>
-                  <p className="mt-4 leading-7 text-[#64748B]">{step.body}</p>
+                  <OriginalFeatureVisual visual={feature.visual} />
                 </article>
               ))}
             </div>
           </div>
         </section>
 
-        <section className="relative bg-[#F8FAFC] px-4 py-16 md:px-6 md:py-24">
-          <div className="absolute inset-x-0 top-0 h-px bg-[#CBD5E1]" />
-          <div className="mx-auto grid max-w-7xl gap-8 lg:grid-cols-[.85fr_1.15fr] lg:items-center">
-            <div className="rounded-[28px] border border-[#CBD5E1] bg-[#DBEAFE] p-7">
-              <div className="font-['Space_Mono',monospace] text-xs font-bold uppercase tracking-[0.12em] text-[#2563EB]">
-                [ SHAREABLE PROOF ]
-              </div>
-              <h2 className="mt-4 font-['Anybody',sans-serif] text-4xl font-extrabold leading-none tracking-normal md:text-6xl">
-                Every circuit becomes a browser artifact.
-              </h2>
-              <p className="mt-5 text-lg leading-8 text-[#334155]">
-                Push a package and get durable URLs for boards, subcircuits,
-                schematics, PCB views, assembly diagrams, and 3D previews.
-              </p>
-              <div className="mt-6 grid grid-cols-3 gap-2">
-                {["pkg", "pcb", "3d", "bom", "spice", "fab"].map(
-                  (item, index) => (
-                    <span
-                      key={item}
-                      className={`rounded-lg border border-[#CBD5E1] px-3 py-2 font-['Space_Mono',monospace] text-[11px] font-bold uppercase ${
-                        index % 2 === 0
-                          ? "bg-[#FFFFFF] text-[#2563EB]"
-                          : "bg-[#EFF6FF] text-[#64748B]"
-                      }`}
-                    >
-                      {item}
-                    </span>
-                  ),
-                )}
-              </div>
-            </div>
-            <div className="relative">
-              <div className="absolute -right-3 -top-3 h-full w-full rounded-3xl border border-[#2563EB]/40" />
-              <OptimizedImage
-                alt="Share and display tscircuit projects in the browser"
-                className="relative w-full rounded-3xl border border-[#CBD5E1] bg-[#FFFFFF] object-cover shadow-[0_24px_80px_rgba(37,99,235,.18)]"
-                src={shareableLinkForCircuitImg}
-                height={360}
-                width={540}
-              />
-            </div>
-          </div>
-        </section>
-
-        <section className="bg-[#F8FAFC] px-4 pb-16 md:px-6 md:pb-24">
-          <div className="mx-auto grid max-w-7xl gap-5 lg:grid-cols-3">
-            {bugCards.map((card, index) => (
-              <article
-                key={card.title}
-                className={`relative overflow-hidden rounded-2xl border ${
-                  index === 1 ? "bg-[#EFF6FF]" : "bg-[#FFFFFF]"
-                } p-5 ${card.color}`}
-              >
-                <div className="absolute right-0 top-0 h-20 w-20 border-b border-l border-[#CBD5E1] bg-[#DBEAFE]/70" />
-                <div className="mb-4 flex items-center justify-between gap-4 font-['Space_Mono',monospace] text-[11px] font-bold uppercase tracking-[0.1em]">
-                  <span className="rounded bg-[#DBEAFE] px-2 py-1 text-[#2563EB]">
-                    {card.tag}
-                  </span>
-                  <Search className="h-4 w-4 text-[#64748B]" />
-                </div>
-                <div className="overflow-hidden text-ellipsis whitespace-nowrap border-y border-[#CBD5E1] py-3 font-['Space_Mono',monospace] text-xs text-[#0284C7]">
-                  {card.path}
-                </div>
-                <h3 className="mt-5 font-['Anybody',sans-serif] text-2xl font-bold leading-tight tracking-normal">
-                  {card.title}
-                </h3>
-                <p className="mt-3 text-sm leading-6 text-[#64748B]">
-                  {card.body}
-                </p>
-              </article>
-            ))}
-          </div>
-        </section>
-
-        <section className="relative border-y border-[#CBD5E1] bg-[#DBEAFE] px-4 py-16 md:px-6 md:py-24">
-          <div className="absolute inset-0 opacity-30 [background-image:linear-gradient(rgba(37,99,235,.10)_1px,transparent_1px),linear-gradient(90deg,rgba(37,99,235,.10)_1px,transparent_1px)] [background-size:64px_64px]" />
-          <div className="relative mx-auto grid max-w-7xl gap-10 lg:grid-cols-[1fr_1fr] lg:items-center">
-            <div className="space-y-6">
-              <div className="font-['Space_Mono',monospace] text-xs font-bold uppercase tracking-[0.12em] text-[#2563EB]">
-                [ ROUTE · TEST · EXECUTE ]
-              </div>
-              <h2 className="font-['Anybody',sans-serif] text-4xl font-extrabold leading-none tracking-normal md:text-6xl">
-                Autoroute and simulate without leaving source control.
-              </h2>
-              <p className="text-lg leading-8 text-[#334155]">
-                Fast routing and analog simulation turn circuit code into a
-                feedback loop. Review behavior and layout before committing to
-                fabrication.
-              </p>
-              <div className="flex flex-wrap gap-3 font-['Space_Mono',monospace] text-xs font-bold uppercase tracking-[0.08em]">
-                <span className="rounded-md bg-[#2563EB] px-3 py-2 text-[#F8FAFC]">
-                  Cloud autorouter
-                </span>
-                <span className="rounded-md border border-[#93C5FD] px-3 py-2 text-[#0F172A]">
-                  WebAssembly ngspice
-                </span>
-              </div>
-            </div>
-            <div className="grid gap-5">
-              <div className="aspect-video overflow-hidden rounded-3xl border border-[#CBD5E1] bg-[#FFFFFF] p-2 shadow-[0_24px_80px_rgba(37,99,235,.18)]">
-                <video
-                  className="h-full w-full rounded-2xl object-cover"
-                  src={autoroutingExampleVideo}
-                  autoPlay
-                  muted
-                  loop
-                  playsInline
-                  preload="metadata"
-                  aria-label="Autorouting demonstration video"
-                />
-              </div>
-              <OptimizedImage
-                alt="Analog simulation output"
-                className="w-full rounded-3xl border border-[#CBD5E1] bg-[#FFFFFF] object-cover"
-                src={analogSimulationImg}
-                height={360}
-                width={540}
-              />
-            </div>
-          </div>
-        </section>
-
-        <section className="bg-[#FFFFFF] px-4 py-16 md:px-6 md:py-24">
-          <div className="mx-auto grid max-w-7xl gap-8 lg:grid-cols-[1.05fr_.95fr] lg:items-center">
-            <div className="relative">
-              <div className="absolute -left-3 -top-3 h-full w-full rounded-3xl border border-[#3B82F6]/50 bg-[#EFF6FF]" />
-              <OptimizedImage
-                alt="AI-compatible electronics workflow"
-                className="relative w-full rounded-3xl border border-[#CBD5E1] bg-[#FFFFFF] object-cover shadow-[0_24px_80px_rgba(37,99,235,.18)]"
-                src={exampleAiCodingImg}
-                height={405}
-                width={720}
-              />
-            </div>
-            <div className="rounded-[28px] border border-[#CBD5E1] bg-[#F8FAFC] p-7">
-              <div className="font-['Space_Mono',monospace] text-xs font-bold uppercase tracking-[0.12em] text-[#2563EB]">
-                [ AI COMPATIBLE ELECTRONICS ]
-              </div>
-              <h2 className="mt-4 font-['Anybody',sans-serif] text-4xl font-extrabold leading-none tracking-normal md:text-6xl">
-                Teach agents to change schematics and PCBs.
-              </h2>
-              <div className="mt-6 space-y-3 text-[#334155]">
-                {[
-                  "Install the tscircuit skill for agent-native circuit edits.",
-                  "Ask for schematic changes, package reuse, layout passes, and review.",
-                  "Keep every electrical decision visible as source code.",
-                ].map((item) => (
-                  <p key={item} className="flex gap-3 leading-7">
-                    <Braces className="mt-1 h-5 w-5 shrink-0 text-[#2563EB]" />
-                    {item}
-                  </p>
-                ))}
-              </div>
-            </div>
-          </div>
-        </section>
-
-        <section className="relative border-y border-[#CBD5E1] bg-[#EFF6FF] px-4 py-16 md:px-6 md:py-24">
-          <div className="absolute inset-0 opacity-25 [background-image:linear-gradient(135deg,rgba(14,165,233,.16)_0_1px,transparent_1px_26px)]" />
-          <div className="relative mx-auto grid max-w-7xl gap-8 lg:grid-cols-[.9fr_1.1fr] lg:items-center">
+        <section
+          className="landing-original-section landing-original-playground"
+          aria-labelledby="playground-title"
+        >
+          <div className="landing-original-playground-grid">
             <div>
-              <div className="font-['Space_Mono',monospace] text-xs font-bold uppercase tracking-[0.12em] text-[#2563EB]">
-                [ KICAD BRIDGE ]
+              <div className="landing-original-eyebrow">
+                Develop like it&apos;s a website
               </div>
-              <h2 className="mt-4 font-['Anybody',sans-serif] text-4xl font-extrabold leading-none tracking-normal md:text-6xl">
-                Code-first does not mean format-isolated.
-              </h2>
-              <p className="mt-5 text-lg leading-8 text-[#334155]">
-                Import KiCad footprints directly, export KiCad PCB and schematic
-                files, and keep traditional EDA collaboration paths open.
+              <h2 id="playground-title">Instant previews in the browser.</h2>
+              <p className="landing-original-sub">
+                Every save re-renders the schematic, PCB, and 3D view - the same
+                loop you have with Next.js or Vite, but for hardware. No IDE to
+                install, no toolchain to babysit. 50+ reference boards ready to
+                fork.
               </p>
+              <a className="landing-original-button" href="/playground">
+                Open playground
+                <ArrowRight className="h-4 w-4" />
+              </a>
             </div>
-            <div className="grid gap-3 rounded-[28px] border border-[#CBD5E1] bg-[#FFFFFF] p-3">
-              <div className="grid grid-cols-4 gap-2">
-                {["fp", "lib", "sch", "pcb"].map((item, index) => (
-                  <span
-                    key={item}
-                    className={`rounded-lg px-3 py-2 text-center font-['Space_Mono',monospace] text-[11px] font-bold uppercase ${
-                      index === 0
-                        ? "bg-[#2563EB] text-[#F8FAFC]"
-                        : "bg-[#DBEAFE] text-[#64748B]"
-                    }`}
-                  >
-                    {item}
-                  </span>
-                ))}
+            <div className="landing-original-browser">
+              <div className="landing-original-browser-top">
+                <span />
+                <span />
+                <span />
+                <strong>index.circuit.tsx</strong>
               </div>
-              <OptimizedImage
-                alt="KiCad support via tscircuit packages"
-                className="w-full rounded-2xl border border-[#CBD5E1] bg-[#FFFFFF] object-cover"
-                src={importKicadLibraryImg}
-                height={360}
-                width={540}
-              />
+              <div className="landing-original-browser-body">
+                <div className="landing-original-browser-code">
+                  <pre>{codeLines.join("\n")}</pre>
+                </div>
+                <div className="landing-original-browser-board">
+                  <div className="landing-original-board-shape" />
+                </div>
+              </div>
             </div>
           </div>
         </section>
 
-        <section className="relative bg-[#F8FAFC] px-4 py-16 text-center md:px-6 md:py-24">
-          <div className="absolute inset-0 opacity-40 [background-image:linear-gradient(rgba(37,99,235,.14)_1px,transparent_1px),linear-gradient(90deg,rgba(37,99,235,.14)_1px,transparent_1px)] [background-size:56px_56px]" />
-          <div className="relative mx-auto max-w-4xl rounded-[28px] border border-[#CBD5E1] bg-[#FFFFFF] p-8 md:p-12">
-            <div className="font-['Space_Mono',monospace] text-xs font-bold uppercase tracking-[0.12em] text-[#2563EB]">
-              [ START BUILDING ]
+        <section
+          className="landing-original-section"
+          aria-labelledby="gallery-title"
+        >
+          <div className="landing-original-shell">
+            <div className="landing-original-eyebrow">
+              Shipped with tscircuit
             </div>
-            <h2 className="mt-4 font-['Anybody',sans-serif] text-4xl font-extrabold leading-none tracking-normal md:text-6xl">
-              Ready to build electronics with code?
-            </h2>
-            <p className="mx-auto mt-5 max-w-2xl text-lg leading-8 text-[#334155]">
-              Open an example, start from the docs, or jump into your dashboard
-              and build a circuit that can be reviewed like software.
-            </p>
-            <div className="mt-8 flex flex-col justify-center gap-3 sm:flex-row">
-              <button
-                type="button"
-                onClick={() => {
-                  if (!isLoggedIn) {
-                    signIn()
-                  } else {
-                    navigate("/dashboard")
-                  }
-                }}
-                className="inline-flex h-12 items-center justify-center gap-2 rounded-lg bg-[#2563EB] px-6 font-['Space_Mono',monospace] text-[13px] font-bold uppercase tracking-[0.08em] text-[#F8FAFC]"
-                aria-label="Get started with TSCircuit now"
-              >
-                Start now
+            <h2 id="gallery-title">Boards teams actually sent to fab.</h2>
+            <div className="landing-original-gallery">
+              {galleryBoards.map((board, index) => (
+                <a
+                  key={board.name}
+                  className="landing-original-gallery-board"
+                  href={board.href}
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  <div
+                    className={`landing-original-pcb landing-original-pcb-${index + 1}`}
+                  />
+                  <div>
+                    <div className="landing-original-board-owner">
+                      {board.owner}
+                    </div>
+                    <div className="landing-original-board-name">
+                      {board.name}
+                    </div>
+                  </div>
+                </a>
+              ))}
+            </div>
+            <div className="landing-original-gallery-more">
+              <a className="landing-original-button-secondary" href="/trending">
+                Browse gallery · 240 boards
                 <ArrowRight className="h-4 w-4" />
-              </button>
-              <a
-                href="https://docs.tscircuit.com"
-                className="inline-flex h-12 items-center justify-center gap-2 rounded-lg border border-[#93C5FD] bg-[#DBEAFE] px-6 font-['Space_Mono',monospace] text-[13px] font-bold uppercase tracking-[0.08em] text-[#0F172A]"
-              >
-                Read docs
-                <Code2 className="h-4 w-4" />
               </a>
             </div>
           </div>
@@ -940,6 +866,30 @@ export function LandingPage() {
         <div className="landing-faq bg-[#F8FAFC]">
           <FAQ />
         </div>
+
+        <section
+          className="landing-original-section landing-original-careers"
+          aria-labelledby="careers-title"
+        >
+          <div className="landing-original-careers-row">
+            <div>
+              <div className="landing-original-eyebrow">Careers</div>
+              <h2 id="careers-title">
+                We&apos;re hiring EEs, compiler nerds, and autorouting wizards.
+              </h2>
+              <p className="landing-original-sub">
+                Remote-friendly. Work on the stuff you wish existed when you
+                were at your last hardware job.
+              </p>
+            </div>
+            <a
+              className="landing-original-button"
+              href="mailto:careers@tscircuit.com"
+            >
+              Get In Touch
+            </a>
+          </div>
+        </section>
       </main>
       <LandingFooter />
     </div>

--- a/src/pages/landing.tsx
+++ b/src/pages/landing.tsx
@@ -253,6 +253,51 @@ const galleryBoards = [
     stats: ["Sensor", "BOM", "Review"],
     href: "/seveibar/led-water-accelerometer",
   },
+  {
+    owner: "tscircuit",
+    name: "usb-c-sparkfun-qwiic",
+    description:
+      "Connector-heavy reference board with source-controlled outputs.",
+    stats: ["USB-C", "Source", "Fab"],
+    href: "/tscircuit/usb-c-sparkfun-qwiic",
+  },
+  {
+    owner: "seveibar",
+    name: "RP2040-dev-board",
+    description: "Microcontroller layout with reusable packages and previews.",
+    stats: ["MCU", "KiCad", "BOM"],
+    href: "/seveibar/RP2040-dev-board",
+  },
+  {
+    owner: "tscircuit",
+    name: "analog-sim-demo",
+    description:
+      "Simulation-first circuit with plotted behavior and review context.",
+    stats: ["SPICE", "Plots", "Review"],
+    href: "/tscircuit/analog-sim-demo",
+  },
+  {
+    owner: "seveibar",
+    name: "power-monitor",
+    description:
+      "Power measurement board with inspectable nets and BOM output.",
+    stats: ["Power", "BOM", "PCB"],
+    href: "/seveibar/power-monitor",
+  },
+  {
+    owner: "tscircuit",
+    name: "sensor-breakout",
+    description: "Small breakout package with browser previews and Gerbers.",
+    stats: ["Sensor", "3D", "Gerbers"],
+    href: "/tscircuit/sensor-breakout",
+  },
+  {
+    owner: "seveibar",
+    name: "motor-driver-mini",
+    description: "Compact driver layout with reviewable routing changes.",
+    stats: ["Motor", "Routes", "Fab"],
+    href: "/seveibar/motor-driver-mini",
+  },
 ] as const
 
 const OriginalFeatureVisual = ({
@@ -943,43 +988,35 @@ export function LandingPage() {
           aria-labelledby="careers-title"
         >
           <div className="landing-original-careers-row">
-            <div>
-              <div className="landing-original-eyebrow">Careers</div>
-              <h2 id="careers-title">
-                We&apos;re hiring EEs, compiler nerds, and autorouting wizards.
-              </h2>
-              <p className="landing-original-sub">
-                Remote-friendly. Work on the stuff you wish existed when you
-                were at your last hardware job.
-              </p>
-              <div className="landing-careers-roles">
-                {[
-                  "Electrical engineering",
-                  "Compiler/runtime",
-                  "Autorouting",
-                  "Developer tools",
-                ].map((role) => (
-                  <span key={role}>{role}</span>
-                ))}
+            <div className="landing-careers-letter-page">
+              <div className="landing-original-eyebrow">A note from us</div>
+              <h2 id="careers-title">Come build the future of electronics.</h2>
+              <div className="landing-careers-letter">
+                <div className="landing-careers-letter-body">
+                  <p>Hi,</p>
+                  <p>
+                    We&apos;re building tscircuit because hardware should move
+                    at the speed of software. Boards should be inspectable,
+                    programmable, reviewable, and easy for both humans and
+                    agents to improve.
+                  </p>
+                  <p>
+                    If you care about electronics, compilers, CAD, autorouting,
+                    developer tools, or making fabrication feel less opaque,
+                    we&apos;d like to hear from you.
+                  </p>
+                  <p>
+                    This section is intentionally a draft letter for now.
+                    We&apos;ll replace it later with the final note.
+                  </p>
+                  <div className="landing-careers-signature">
+                    <span>- the tscircuit team</span>
+                    <a href="mailto:careers@tscircuit.com">
+                      careers@tscircuit.com
+                    </a>
+                  </div>
+                </div>
               </div>
-            </div>
-            <div className="landing-careers-panel">
-              <div className="landing-careers-terminal">
-                <span>hiring.pipeline.tsx</span>
-                <strong>4 open tracks</strong>
-              </div>
-              <div className="landing-careers-circuit">
-                {["EE", "CAD", "AI", "FAB"].map((node) => (
-                  <span key={node}>{node}</span>
-                ))}
-              </div>
-              <a
-                className="landing-original-button"
-                href="mailto:careers@tscircuit.com"
-              >
-                Get In Touch
-                <ArrowRight className="h-4 w-4" />
-              </a>
             </div>
           </div>
         </section>

--- a/src/pages/landing.tsx
+++ b/src/pages/landing.tsx
@@ -177,16 +177,22 @@ const galleryBoards = [
   {
     owner: "tscircuit",
     name: "motor-controller",
+    description: "4-layer drive board with inspectable routing artifacts.",
+    stats: ["PCB", "3D", "Gerbers"],
     href: "/tscircuit/motor-controller",
   },
   {
     owner: "seveibar",
     name: "keyboard-default60",
+    description: "Matrix layout, packages, and browser previews in source.",
+    stats: ["60%", "Matrix", "Fab"],
     href: "/seveibar/keyboard-default60",
   },
   {
     owner: "seveibar",
     name: "led-water-accelerometer",
+    description: "Sensor package with reviewable nets and fabrication output.",
+    stats: ["Sensor", "BOM", "Review"],
     href: "/seveibar/led-water-accelerometer",
   },
 ] as const
@@ -842,13 +848,33 @@ export function LandingPage() {
                 >
                   <div
                     className={`landing-original-pcb landing-original-pcb-${index + 1}`}
-                  />
+                  >
+                    <span className="landing-pcb-chip landing-pcb-chip-main" />
+                    <span className="landing-pcb-chip landing-pcb-chip-sub" />
+                    <span className="landing-pcb-trace landing-pcb-trace-a" />
+                    <span className="landing-pcb-trace landing-pcb-trace-b" />
+                    <span className="landing-pcb-trace landing-pcb-trace-c" />
+                    <span className="landing-pcb-pad landing-pcb-pad-a" />
+                    <span className="landing-pcb-pad landing-pcb-pad-b" />
+                    <span className="landing-pcb-pad landing-pcb-pad-c" />
+                    <div className="landing-pcb-toolbar">
+                      <span>Source</span>
+                      <span>PCB</span>
+                      <span>Fab</span>
+                    </div>
+                  </div>
                   <div>
                     <div className="landing-original-board-owner">
                       {board.owner}
                     </div>
                     <div className="landing-original-board-name">
                       {board.name}
+                    </div>
+                    <p>{board.description}</p>
+                    <div className="landing-original-board-stats">
+                      {board.stats.map((stat) => (
+                        <span key={`${board.name}-${stat}`}>{stat}</span>
+                      ))}
                     </div>
                   </div>
                 </a>
@@ -881,13 +907,35 @@ export function LandingPage() {
                 Remote-friendly. Work on the stuff you wish existed when you
                 were at your last hardware job.
               </p>
+              <div className="landing-careers-roles">
+                {[
+                  "Electrical engineering",
+                  "Compiler/runtime",
+                  "Autorouting",
+                  "Developer tools",
+                ].map((role) => (
+                  <span key={role}>{role}</span>
+                ))}
+              </div>
             </div>
-            <a
-              className="landing-original-button"
-              href="mailto:careers@tscircuit.com"
-            >
-              Get In Touch
-            </a>
+            <div className="landing-careers-panel">
+              <div className="landing-careers-terminal">
+                <span>hiring.pipeline.tsx</span>
+                <strong>4 open tracks</strong>
+              </div>
+              <div className="landing-careers-circuit">
+                {["EE", "CAD", "AI", "FAB"].map((node) => (
+                  <span key={node}>{node}</span>
+                ))}
+              </div>
+              <a
+                className="landing-original-button"
+                href="mailto:careers@tscircuit.com"
+              >
+                Get In Touch
+                <ArrowRight className="h-4 w-4" />
+              </a>
+            </div>
           </div>
         </section>
       </main>

--- a/src/pages/landing.tsx
+++ b/src/pages/landing.tsx
@@ -20,7 +20,7 @@ import {
   Sparkles,
   Terminal,
 } from "lucide-react"
-import { useEffect, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import { Helmet } from "react-helmet"
 import { Link } from "wouter"
 
@@ -74,6 +74,128 @@ const heroViews = [
     accent: "#1D4ED8",
   },
 ] as const
+
+const donutCharacters = ".,-~:;=!*#$@" as const
+
+const renderDonutFrame = (rotationA: number, rotationB: number) => {
+  const width = 42
+  const height = 20
+  const output = Array.from({ length: width * height }, () => " ")
+  const zBuffer = Array.from({ length: width * height }, () => 0)
+  const cosA = Math.cos(rotationA)
+  const sinA = Math.sin(rotationA)
+  const cosB = Math.cos(rotationB)
+  const sinB = Math.sin(rotationB)
+
+  for (let theta = 0; theta < Math.PI * 2; theta += 0.28) {
+    const cosTheta = Math.cos(theta)
+    const sinTheta = Math.sin(theta)
+
+    for (let phi = 0; phi < Math.PI * 2; phi += 0.12) {
+      const cosPhi = Math.cos(phi)
+      const sinPhi = Math.sin(phi)
+      const circleX = cosTheta + 2
+      const depth = 1 / (sinPhi * circleX * sinA + sinTheta * cosA + 5)
+      const t = sinPhi * circleX * cosA - sinTheta * sinA
+      const x = Math.floor(
+        width / 2 + 24 * depth * (cosPhi * circleX * cosB - t * sinB),
+      )
+      const y = Math.floor(
+        height / 2 + 12 * depth * (cosPhi * circleX * sinB + t * cosB),
+      )
+      const luminance = Math.floor(
+        8 *
+          ((sinTheta * sinA - sinPhi * cosTheta * cosA) * cosB -
+            sinPhi * cosTheta * sinA -
+            sinTheta * cosA -
+            cosPhi * cosTheta * sinB),
+      )
+      const outputIndex = x + width * y
+
+      if (
+        y >= 0 &&
+        y < height &&
+        x >= 0 &&
+        x < width &&
+        depth > zBuffer[outputIndex]
+      ) {
+        zBuffer[outputIndex] = depth
+        output[outputIndex] =
+          donutCharacters[Math.max(0, Math.min(luminance, 11))]
+      }
+    }
+  }
+
+  return Array.from({ length: height }, (_, rowIndex) =>
+    output.slice(rowIndex * width, (rowIndex + 1) * width).join(""),
+  ).join("\n")
+}
+
+const renderDoubleDonutFrame = (frameIndex: number) => {
+  const leftDonut = renderDonutFrame(
+    frameIndex * 0.11,
+    frameIndex * 0.07,
+  ).split("\n")
+  const rightDonut = renderDonutFrame(
+    frameIndex * 0.11 + Math.PI,
+    frameIndex * 0.07 + Math.PI / 2,
+  ).split("\n")
+
+  return leftDonut
+    .map((line, index) => `${line}        ${rightDonut[index] ?? ""}`)
+    .join("\n")
+}
+
+const FooterDonutTerminal = () => {
+  const terminalRef = useRef<HTMLDivElement>(null)
+  const [isVisible, setIsVisible] = useState(false)
+  const [frameIndex, setFrameIndex] = useState(0)
+
+  useEffect(() => {
+    const terminal = terminalRef.current
+    if (!terminal) return
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        setIsVisible(Boolean(entry?.isIntersecting))
+      },
+      { rootMargin: "120px" },
+    )
+
+    observer.observe(terminal)
+
+    return () => observer.disconnect()
+  }, [])
+
+  useEffect(() => {
+    if (
+      !isVisible ||
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches
+    ) {
+      return
+    }
+
+    const intervalId = window.setInterval(() => {
+      setFrameIndex((current) => current + 1)
+    }, 140)
+
+    return () => window.clearInterval(intervalId)
+  }, [isVisible])
+
+  const donutFrame = isVisible ? renderDoubleDonutFrame(frameIndex) : ""
+
+  return (
+    <div
+      ref={terminalRef}
+      className="landing-footer-terminal"
+      aria-label="Terminal field showing spinning 3D ASCII donuts"
+    >
+      <pre className="landing-footer-terminal-output" aria-hidden="true">
+        {donutFrame}
+      </pre>
+    </div>
+  )
+}
 
 const landingNavItems = [
   { label: "Examples", href: "/search", icon: FileText },
@@ -512,77 +634,80 @@ const LandingTopBar = () => {
 }
 
 const LandingFooter = () => (
-  <footer className="border-t border-[#CBD5E1] bg-[#F8FAFC] px-4 py-12 text-[#0F172A] md:px-6">
-    <div className="mx-auto grid max-w-7xl gap-8 md:grid-cols-[1.2fr_2fr]">
-      <div>
-        <div className="flex items-center gap-3">
-          <div className="grid h-10 w-10 place-items-center rounded-lg bg-[#2563EB] text-[#F8FAFC]">
-            <CircuitBoard className="h-5 w-5" />
-          </div>
-          <span className="font-['Anybody',sans-serif] text-2xl font-extrabold">
-            tscircuit
-          </span>
-        </div>
-        <p className="mt-4 max-w-sm text-sm leading-6 text-[#64748B]">
-          Code-first electronics for browser previews, AI edits, source control,
-          and manufacturing output.
-        </p>
-      </div>
-      <div className="grid grid-cols-2 gap-6 text-sm md:grid-cols-4">
-        {[
-          {
-            title: "Product",
-            links: [
-              ["Editor", "/quickstart"],
-              ["Latest", "/latest"],
-              ["Trending", "/trending"],
-            ],
-          },
-          {
-            title: "Resources",
-            links: [
-              ["Docs", "https://docs.tscircuit.com"],
-              ["Search", "/search"],
-              ["GitHub", "https://github.com/tscircuit/tscircuit"],
-            ],
-          },
-          {
-            title: "Community",
-            links: [
-              ["Discord", "https://tscircuit.com/join"],
-              ["Blog", "https://blog.tscircuit.com"],
-              ["YouTube", "https://youtube.com/@seveibar"],
-            ],
-          },
-          {
-            title: "Company",
-            links: [
-              ["Contact", "mailto:hello@tscircuit.com"],
-              ["Terms", "https://tscircuit.com/legal/terms-of-service"],
-              ["Privacy", "https://tscircuit.com/legal/privacy-policy"],
-            ],
-          },
-        ].map((group) => (
-          <nav key={group.title} className="space-y-3">
-            <h3 className="font-['Space_Mono',monospace] text-xs font-bold uppercase tracking-[0.12em] text-[#2563EB]">
-              {group.title}
-            </h3>
-            <div className="flex flex-col gap-2">
-              {group.links.map(([name, href]) =>
-                href.startsWith("http") || href.startsWith("mailto:") ? (
-                  <a key={name} href={href} className="text-[#64748B]">
-                    {name}
-                  </a>
-                ) : (
-                  <Link key={name} href={href} className="text-[#64748B]">
-                    {name}
-                  </Link>
-                ),
-              )}
+  <footer className="landing-footer border-t border-[#CBD5E1] bg-[#F8FAFC] px-4 py-12 text-[#0F172A] md:px-6">
+    <div className="mx-auto max-w-7xl">
+      <div className="grid gap-8 md:grid-cols-[1.2fr_2fr]">
+        <div>
+          <div className="flex items-center gap-3">
+            <div className="grid h-10 w-10 place-items-center rounded-lg bg-[#2563EB] text-[#F8FAFC]">
+              <CircuitBoard className="h-5 w-5" />
             </div>
-          </nav>
-        ))}
+            <span className="font-['Anybody',sans-serif] text-2xl font-extrabold">
+              tscircuit
+            </span>
+          </div>
+          <p className="mt-4 max-w-sm text-sm leading-6 text-[#64748B]">
+            Code-first electronics for browser previews, AI edits, source
+            control, and manufacturing output.
+          </p>
+        </div>
+        <div className="grid grid-cols-2 gap-6 text-sm md:grid-cols-4">
+          {[
+            {
+              title: "Product",
+              links: [
+                ["Editor", "/quickstart"],
+                ["Latest", "/latest"],
+                ["Trending", "/trending"],
+              ],
+            },
+            {
+              title: "Resources",
+              links: [
+                ["Docs", "https://docs.tscircuit.com"],
+                ["Search", "/search"],
+                ["GitHub", "https://github.com/tscircuit/tscircuit"],
+              ],
+            },
+            {
+              title: "Community",
+              links: [
+                ["Discord", "https://tscircuit.com/join"],
+                ["Blog", "https://blog.tscircuit.com"],
+                ["YouTube", "https://youtube.com/@seveibar"],
+              ],
+            },
+            {
+              title: "Company",
+              links: [
+                ["Contact", "mailto:hello@tscircuit.com"],
+                ["Terms", "https://tscircuit.com/legal/terms-of-service"],
+                ["Privacy", "https://tscircuit.com/legal/privacy-policy"],
+              ],
+            },
+          ].map((group) => (
+            <nav key={group.title} className="space-y-3">
+              <h3 className="font-['Space_Mono',monospace] text-xs font-bold uppercase tracking-[0.12em] text-[#2563EB]">
+                {group.title}
+              </h3>
+              <div className="flex flex-col gap-2">
+                {group.links.map(([name, href]) =>
+                  href.startsWith("http") || href.startsWith("mailto:") ? (
+                    <a key={name} href={href} className="text-[#64748B]">
+                      {name}
+                    </a>
+                  ) : (
+                    <Link key={name} href={href} className="text-[#64748B]">
+                      {name}
+                    </Link>
+                  ),
+                )}
+              </div>
+            </nav>
+          ))}
+        </div>
       </div>
+      <FooterDonutTerminal />
     </div>
   </footer>
 )

--- a/src/pages/landing.tsx
+++ b/src/pages/landing.tsx
@@ -1,345 +1,818 @@
-import { Button } from "@/components/ui/button"
-import { Card, CardContent } from "@/components/ui/card"
-import { Badge } from "@/components/ui/badge"
-import { OptimizedImage } from "@/components/OptimizedImage"
-import {
-  Code2,
-  Cpu,
-  Layers,
-  CloudLightningIcon as Lightning,
-  Maximize2,
-  Zap,
-} from "lucide-react"
-import { Helmet } from "react-helmet"
-import { Header2 } from "@/components/Header2"
-import Footer from "@/components/Footer"
-import { useSignIn } from "@/hooks/use-sign-in"
-import { useGlobalStore } from "@/hooks/use-global-store"
-import { navigate } from "wouter/use-browser-location"
-import { FAQ } from "@/components/FAQ"
-// import { TrendingPackagesCarousel } from "@/components/TrendingPackagesCarousel"
-import { Link } from "wouter"
-import importKicadLibraryImg from "@/assets/import-kicad-library.png"
 import analogSimulationImg from "@/assets/analogsimulation.png"
 import autoroutingExampleVideo from "@/assets/autorouting_example.mp4"
 import exampleAiCodingImg from "@/assets/example_ai_coding.png"
+import importKicadLibraryImg from "@/assets/import-kicad-library.png"
 import shareableLinkForCircuitImg from "@/assets/shareable-link-for-circuit.png"
-import { useShikiHighlighter } from "@/hooks/use-shiki-highlighter"
-import { useMemo } from "react"
+import { FAQ } from "@/components/FAQ"
+import { OptimizedImage } from "@/components/OptimizedImage"
+import { useGlobalStore } from "@/hooks/use-global-store"
+import { useSignIn } from "@/hooks/use-sign-in"
+import {
+  ArrowRight,
+  BookOpen,
+  Bot,
+  Boxes,
+  Braces,
+  Building2,
+  ChevronDown,
+  CircuitBoard,
+  Code2,
+  Copy,
+  DollarSign,
+  FileText,
+  GitBranch,
+  Library,
+  Menu,
+  Search,
+  Sparkles,
+  Terminal,
+} from "lucide-react"
+import { useEffect, useState } from "react"
+import { Helmet } from "react-helmet"
+import { Link } from "wouter"
+import { navigate } from "wouter/use-browser-location"
 
-const analogSimulationCode = `export default () => (
-    <board schMaxTraceDistance={10} routingDisabled>
-      <voltagesource
-        name="V1"
-        voltage="5V"
-        frequency="40Hz"
-        waveShape="sinewave"
-      />
-      <diode name="D1" />
-      <resistor name="R1" resistance="640ohm" />
+const featureCards = [
+  {
+    label: "SCHEMATIC",
+    title: "React components become real circuits.",
+    body: "Write boards, subcircuits, footprints, traces, probes, and exports in TypeScript instead of dragging opaque files around.",
+    icon: CircuitBoard,
+    accent: "text-[#2563EB]",
+  },
+  {
+    label: "AI-READY",
+    title: "Agents can edit electronics like code.",
+    body: "tscircuit projects are inspectable source, so Codex, Claude Code, and other agents can initialize, modify, review, and repair designs.",
+    icon: Bot,
+    accent: "text-[#0284C7]",
+  },
+  {
+    label: "FAB OUTPUT",
+    title: "Render once, ship many formats.",
+    body: "Generate schematics, PCBs, 3D previews, Gerbers, KiCad assets, SPICE netlists, BOMs, and assembly context from the same source.",
+    icon: Boxes,
+    accent: "text-[#0EA5E9]",
+  },
+]
 
-      <trace from="V1.pin1" to="D1.anode" />
-      <trace from="D1.cathode" to="R1.pin1" />
-      <trace from="V1.pin2" to="R1.pin2" />
+const processSteps = [
+  {
+    step: "STEP 01",
+    title: "Describe the board",
+    body: "Start from TSX, an AI prompt, or a reusable package. Component intent stays readable in source control.",
+  },
+  {
+    step: "STEP 02",
+    title: "Render every view",
+    body: "The same circuit becomes browser schematics, PCB layouts, 3D previews, simulations, and reviewable artifacts.",
+  },
+  {
+    step: "STEP 03",
+    title: "Route, test, export",
+    body: "Run autorouting, ngspice simulation, KiCad interop, and manufacturing exports without leaving the code workflow.",
+  },
+]
 
-      <voltageprobe name="VP_IN" connectsTo="V1.pin1" />
-      <voltageprobe name="VP_OUT" connectsTo="R1.pin1" />
+const bugCards = [
+  {
+    tag: "AUTOROUTE",
+    path: "boards/led-water-accelerometer.tsx",
+    title: "Near-instant board iteration",
+    body: "Jumpers, layers, and route passes can be expressed as configuration rather than manual board surgery.",
+    color: "border-[#2563EB]/60",
+  },
+  {
+    tag: "SIMULATION",
+    path: "examples/full-wave-rectifier.tsx",
+    title: "SPICE where the source lives",
+    body: "Voltage probes and ngspice settings are part of the circuit definition, so review includes behavior.",
+    color: "border-[#3B82F6]/70",
+  },
+  {
+    tag: "KICAD",
+    path: "packages/RP2040.kicad_mod",
+    title: "Existing libraries still matter",
+    body: "Import footprints and export KiCad files when collaboration or manufacturing needs traditional formats.",
+    color: "border-[#1D4ED8]/70",
+  },
+]
 
-      <analogsimulation
-        duration="50ms"
-        timePerStep="0.1ms"
-        spiceEngine="ngspice"
-      />
-    </board>
-)`
+const integrations = [
+  "GitHub packages",
+  "Browser previews",
+  "KiCad import/export",
+  "Gerber builds",
+  "BOM checks",
+  "AI code agents",
+]
+
+const surfaceTiles = [
+  "bg-[#F8FAFC]",
+  "bg-[#EFF6FF]",
+  "bg-[#DBEAFE]",
+  "bg-[#FFFFFF]",
+]
+
+const pipelineNodes = ["TSX", "SVG", "PCB", "BOM", "3D", "GTR"]
+
+const heroViews = [
+  {
+    id: "code",
+    label: "Code",
+    shortLabel: "Code",
+    title: "circuit.review.tsx",
+    status: "source locked",
+    accent: "#2563EB",
+  },
+  {
+    id: "schematic",
+    label: "Schematic",
+    shortLabel: "Sch",
+    title: "schematic.svg",
+    status: "nets traced",
+    accent: "#0284C7",
+  },
+  {
+    id: "3d",
+    label: "3D",
+    shortLabel: "3D",
+    title: "board.preview.glb",
+    status: "parts placed",
+    accent: "#0EA5E9",
+  },
+  {
+    id: "gerber",
+    label: "Gerber",
+    shortLabel: "Gbr",
+    title: "fabrication.zip",
+    status: "export ready",
+    accent: "#1D4ED8",
+  },
+] as const
+
+const codeLines = [
+  '<board width="36mm" height="28mm">',
+  '  <chip name="U1" footprint="soic8" />',
+  '  <resistor name="R1" resistance="10k" />',
+  '  <trace from="U1.pin1" to="R1.pin1" />',
+  '  <autorouting strategy="cloud" />',
+  "</board>",
+]
+
+const landingNavItems = [
+  { label: "Examples", href: "/search", icon: FileText },
+  { label: "Pricing", href: "/my-orders", icon: DollarSign },
+  { label: "Features", href: "#features", icon: Sparkles, hasMenu: true },
+  { label: "Enterprise", href: "mailto:hello@tscircuit.com", icon: Building2 },
+  { label: "Blog", href: "https://blog.tscircuit.com", icon: BookOpen },
+  {
+    label: "Resources",
+    href: "https://docs.tscircuit.com",
+    icon: Library,
+    hasMenu: true,
+  },
+]
+
+const LandingTopBar = () => {
+  const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false)
+
+  const renderNavItem = (item: (typeof landingNavItems)[number]) => {
+    const Icon = item.icon
+    const content = (
+      <>
+        <Icon className="landing-topbar-icon" aria-hidden="true" />
+        <span>{item.label}</span>
+        {item.hasMenu && (
+          <ChevronDown className="landing-topbar-chev" aria-hidden="true" />
+        )}
+      </>
+    )
+
+    if (item.href.startsWith("http") || item.href.startsWith("mailto:")) {
+      return (
+        <a key={item.label} href={item.href}>
+          {content}
+        </a>
+      )
+    }
+
+    return (
+      <Link key={item.label} href={item.href}>
+        {content}
+      </Link>
+    )
+  }
+
+  return (
+    <header className="landing-topbar">
+      <div className="landing-topbar-inner">
+        <nav className="landing-topbar-nav" aria-label="Homepage navigation">
+          {landingNavItems.map(renderNavItem)}
+        </nav>
+        <div className="landing-topbar-actions">
+          <button
+            type="button"
+            className="landing-topbar-search"
+            aria-label="Search"
+            onClick={() => {
+              window.location.href = "/search"
+            }}
+          >
+            <Search className="h-5 w-5" />
+          </button>
+          <a href="https://docs.tscircuit.com" className="landing-topbar-cta">
+            Get Started
+          </a>
+          <button
+            type="button"
+            className="landing-topbar-menu"
+            aria-label={isMobileMenuOpen ? "Close menu" : "Open menu"}
+            aria-expanded={isMobileMenuOpen}
+            onClick={() => setIsMobileMenuOpen((isOpen) => !isOpen)}
+          >
+            <Menu className="h-6 w-6" />
+          </button>
+        </div>
+      </div>
+      {isMobileMenuOpen && (
+        <nav
+          className="landing-topbar-mobile-nav"
+          aria-label="Mobile homepage navigation"
+        >
+          {landingNavItems.map(renderNavItem)}
+        </nav>
+      )}
+    </header>
+  )
+}
+
+const LandingFooter = () => (
+  <footer className="border-t border-[#CBD5E1] bg-[#F8FAFC] px-4 py-12 text-[#0F172A] md:px-6">
+    <div className="mx-auto grid max-w-7xl gap-8 md:grid-cols-[1.2fr_2fr]">
+      <div>
+        <div className="flex items-center gap-3">
+          <div className="grid h-10 w-10 place-items-center rounded-lg bg-[#2563EB] text-[#F8FAFC]">
+            <CircuitBoard className="h-5 w-5" />
+          </div>
+          <span className="font-['Anybody',sans-serif] text-2xl font-extrabold">
+            tscircuit
+          </span>
+        </div>
+        <p className="mt-4 max-w-sm text-sm leading-6 text-[#64748B]">
+          Code-first electronics for browser previews, AI edits, source control,
+          and manufacturing output.
+        </p>
+      </div>
+      <div className="grid grid-cols-2 gap-6 text-sm md:grid-cols-4">
+        {[
+          {
+            title: "Product",
+            links: [
+              ["Editor", "/quickstart"],
+              ["Latest", "/latest"],
+              ["Trending", "/trending"],
+            ],
+          },
+          {
+            title: "Resources",
+            links: [
+              ["Docs", "https://docs.tscircuit.com"],
+              ["Search", "/search"],
+              ["GitHub", "https://github.com/tscircuit/tscircuit"],
+            ],
+          },
+          {
+            title: "Community",
+            links: [
+              ["Discord", "https://tscircuit.com/join"],
+              ["Blog", "https://blog.tscircuit.com"],
+              ["YouTube", "https://youtube.com/@seveibar"],
+            ],
+          },
+          {
+            title: "Company",
+            links: [
+              ["Contact", "mailto:hello@tscircuit.com"],
+              ["Terms", "https://tscircuit.com/legal/terms-of-service"],
+              ["Privacy", "https://tscircuit.com/legal/privacy-policy"],
+            ],
+          },
+        ].map((group) => (
+          <nav key={group.title} className="space-y-3">
+            <h3 className="font-['Space_Mono',monospace] text-xs font-bold uppercase tracking-[0.12em] text-[#2563EB]">
+              {group.title}
+            </h3>
+            <div className="flex flex-col gap-2">
+              {group.links.map(([name, href]) =>
+                href.startsWith("http") || href.startsWith("mailto:") ? (
+                  <a key={name} href={href} className="text-[#64748B]">
+                    {name}
+                  </a>
+                ) : (
+                  <Link key={name} href={href} className="text-[#64748B]">
+                    {name}
+                  </Link>
+                ),
+              )}
+            </div>
+          </nav>
+        ))}
+      </div>
+    </div>
+  </footer>
+)
 
 export function LandingPage() {
   const signIn = useSignIn()
   const isLoggedIn = useGlobalStore((s) => Boolean(s.session))
-  const { highlighter } = useShikiHighlighter()
-  const analogSimulationHtml = useMemo(
-    () =>
-      highlighter?.codeToHtml(analogSimulationCode, {
-        lang: "tsx",
-        theme: "github-dark",
-      }),
-    [highlighter],
-  )
+  const [activeHeroViewIndex, setActiveHeroViewIndex] = useState(0)
+  const activeHeroView = heroViews[activeHeroViewIndex]
+
+  useEffect(() => {
+    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+      return
+    }
+
+    const intervalId = window.setInterval(() => {
+      setActiveHeroViewIndex((current) => (current + 1) % heroViews.length)
+    }, 3200)
+
+    return () => window.clearInterval(intervalId)
+  }, [])
+
   return (
-    <div className="flex min-h-screen flex-col">
+    <div className="tscircuit-landing min-h-screen bg-[#F8FAFC] font-['DM_Sans',sans-serif] text-[#0F172A]">
       <Helmet>
-        <link rel="preconnect" href="https://img.shields.io" />
-        <link rel="dns-prefetch" href="https://img.shields.io" />
-
-        <link rel="preconnect" href="https://shields.io" />
-        <link rel="dns-prefetch" href="https://shields.io" />
-
-        <link rel="preconnect" href="https://tscircuit.com" />
-        <link rel="dns-prefetch" href="https://tscircuit.com" />
-
-        <link rel="preconnect" href="https://api.tscircuit.com" />
-        <link rel="dns-prefetch" href="https://api.tscircuit.com" />
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link
+          rel="preconnect"
+          href="https://fonts.gstatic.com"
+          crossOrigin=""
+        />
+        <link
+          href="https://fonts.googleapis.com/css2?family=Anybody:wdth,wght@88,700;88,800;100,800&family=DM+Sans:opsz,wght@9..40,400;9..40,600;9..40,700&family=Space+Mono:wght@400;700&display=swap"
+          rel="stylesheet"
+        />
+        <link rel="preconnect" href="https://docs.tscircuit.com" />
+        <link rel="dns-prefetch" href="https://docs.tscircuit.com" />
       </Helmet>
-      <Header2 />
-      <main className="flex-1">
-        <section className="w-full py-8 md:py-12 lg:py-20 xl:py-36">
-          <div className="container px-4 md:px-6 mx-auto">
-            <div className="container mx-auto max-w-7xl">
-              <div className="grid gap-6 lg:grid-cols-[1fr_400px] lg:gap-12 xl:grid-cols-[1fr_600px]">
-                <div className="flex flex-col justify-center space-y-4">
-                  <div className="space-y-2">
-                    <Badge variant="secondary" className="w-fit">
-                      Open-Source, MIT Licensed
-                    </Badge>
-                    <h1 className="text-3xl font-bold tracking-tight sm:text-5xl xl:text-6xl/none">
-                      AI codes electronics with tscircuit
-                    </h1>
-                    <p className="max-w-[600px] text-muted-foreground md:text-xl">
-                      Build electronics with code and AI tools.
-                      <br />
-                      Render code into schematics, PCBs, 3D, fabrication files,
-                      and more.
-                    </p>
-                  </div>
-                  <div className="flex flex-col items-center gap-2 min-[500px]:flex-row">
-                    <a
-                      href="https://docs.tscircuit.com"
-                      className="w-[70vw] min-[500px]:w-auto"
-                    >
-                      <Button
-                        size="lg"
-                        aria-label="Get started with TSCircuit"
-                        className="w-full min-[500px]:w-auto"
-                      >
-                        Get Started
-                      </Button>
-                    </a>
-                    <Link
-                      href="/seveibar/led-water-accelerometer#3d"
-                      className="w-[70vw] min-[500px]:w-auto"
-                    >
-                      <Button
-                        size="lg"
-                        variant="outline"
-                        aria-label="Open online example of TSCircuit"
-                        className="w-full min-[500px]:w-auto"
-                      >
-                        Open Online Example
-                      </Button>
-                    </Link>
-                    <a
-                      href="https://github.com/tscircuit/tscircuit"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                    >
-                      <img
-                        alt="GitHub stars"
-                        src="https://img.shields.io/github/stars/tscircuit/tscircuit?style=social"
-                      />
-                    </a>
-                  </div>
-                  <div className="grid grid-cols-2 gap-4 sm:flex items-center w-full text-sm">
-                    <div className="flex items-center space-x-1">
-                      <Zap className="h-4 w-4" />
-                      <span>Lightning Fast Autorouting</span>
-                    </div>
-                    <div className="flex items-center space-x-1">
-                      <Cpu className="h-4 w-4" />
-                      <span>Designed for AI</span>
-                    </div>
-                    <div className="flex items-center space-x-1">
-                      <Layers className="h-4 w-4" />
-                      <span>Export &amp; Manufacture</span>
-                    </div>
-                    <div className="flex items-center space-x-1 sm:hidden">
-                      <Code2 className="h-4 w-4" />
-                      <span>Open Web Standards</span>
-                    </div>
-                  </div>
-                </div>
-                <div className="w-full aspect-video relative">
-                  <iframe
-                    className="mx-auto overflow-hidden rounded-xl object-cover object-center absolute inset-0 w-full h-full mt-8 lg:mt-0"
-                    src="https://www.youtube.com/embed/HAd5_ZJgg50"
-                    title="TSCircuit product demo"
-                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-                    referrerPolicy="strict-origin-when-cross-origin"
-                    allowFullScreen
-                  />
-                </div>
-              </div>
-            </div>
+      <a
+        href="https://docs.tscircuit.com"
+        className="landing-announcement-strip"
+      >
+        <Sparkles className="h-4 w-4" />
+        <span>Get started with our new tutorial series</span>
+        <ArrowRight className="h-4 w-4" />
+      </a>
+      <LandingTopBar />
+      <main className="overflow-hidden">
+        <section className="landing-grid-field landing-hero-section relative bg-[#F8FAFC] px-4 pb-16 pt-8 md:px-6 md:pb-24 lg:pt-10">
+          <div className="absolute inset-0 opacity-55 [background-image:linear-gradient(rgba(37,99,235,.12)_1px,transparent_1px),linear-gradient(90deg,rgba(37,99,235,.12)_1px,transparent_1px)] [background-size:72px_72px]" />
+          <div className="absolute inset-0 opacity-35 [background-image:linear-gradient(135deg,rgba(37,99,235,.18)_0_1px,transparent_1px_34px),linear-gradient(45deg,rgba(14,165,233,.14)_0_1px,transparent_1px_28px)]" />
+          <div className="absolute right-0 top-20 hidden w-[42vw] grid-cols-5 gap-2 opacity-75 lg:grid">
+            {surfaceTiles
+              .concat(surfaceTiles, surfaceTiles)
+              .map((tile, index) => (
+                <div
+                  key={`hero-tile-${index}`}
+                  className={`h-16 rounded-[18px] border border-[#CBD5E1] ${tile} ${
+                    index % 4 === 0 ? "border-[#2563EB]/60" : ""
+                  } ${index % 5 === 2 ? "translate-y-8" : ""}`}
+                />
+              ))}
           </div>
-        </section>
-        {/* <TrendingPackagesCarousel /> */}
-        <section
-          className="w-full py-12 md:py-24 lg:py-32 section-grid-pattern"
-          id="features"
-        >
-          <div className="container px-4 md:px-6 mx-auto">
-            <div className="flex flex-col items-center justify-center space-y-4 text-center">
-              <div className="space-y-4">
-                <h2 className="text-3xl font-bold tracking-tight md:text-4xl lg:text-5xl text-balance">
-                  The Modern Toolkit for Electronic Design
-                </h2>
-                <p className="max-w-[900px] text-muted-foreground md:text-lg leading-relaxed">
-                  Typescript and React equipped with expertly-designed web-first
-                  electronics libraries
+          <div className="relative mx-auto flex h-full max-w-[1680px] flex-col">
+            <div className="mb-6 grid gap-3 border-y border-[#CBD5E1] bg-[#DBEAFE]/80 px-4 py-3 font-['Space_Mono',monospace] text-[11px] font-bold uppercase tracking-[0.12em] text-[#2563EB] md:grid-cols-[auto_1fr_auto] md:items-center">
+              <Sparkles className="h-4 w-4" />
+              <span>AI electronics workbench</span>
+              <span className="text-[#64748B] md:text-right">
+                TSX · Schematics · PCB · 3D · Gerbers
+              </span>
+            </div>
+            <div className="grid flex-1 gap-12 lg:grid-cols-[minmax(0,1fr)_minmax(560px,720px)] lg:items-center">
+              <div>
+                <div className="mb-5 font-['Space_Mono',monospace] text-sm font-bold uppercase tracking-[0.32em] text-[#64748B]">
+                  The hardware framework for AI teams
+                </div>
+                <h1 className="max-w-[980px] font-['Anybody',sans-serif] text-[50px] font-extrabold leading-[.9] tracking-normal text-[#0F172A] sm:text-[72px] lg:text-[98px] xl:text-[108px]">
+                  The #1 framework for{" "}
+                  <span className="bg-[#DBEAFE] px-2 text-[#0F172A]">
+                    AI-generated
+                  </span>{" "}
+                  electronics.
+                </h1>
+                <p className="mt-7 max-w-[860px] text-xl leading-9 text-[#334155] md:text-2xl">
+                  Design production PCBs in TypeScript. Version them in git. Let
+                  agents iterate on them.
                 </p>
+                <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:items-center">
+                  <button
+                    type="button"
+                    className="inline-flex h-12 items-center justify-center gap-3 rounded-md bg-[#2563EB] px-6 font-['Space_Mono',monospace] text-[14px] font-bold text-white"
+                  >
+                    npm install -g tscircuit
+                    <Copy className="h-4 w-4" aria-hidden="true" />
+                  </button>
+                  <a
+                    href="https://docs.tscircuit.com"
+                    className="inline-flex h-12 items-center justify-center gap-2 rounded-md border border-[#0F172A] bg-white px-6 font-['Space_Mono',monospace] text-[14px] font-bold text-[#0F172A]"
+                  >
+                    Read the docs
+                    <ArrowRight className="h-4 w-4" />
+                  </a>
+                </div>
+                <div className="mt-9 grid max-w-xl grid-cols-3 gap-6">
+                  {[
+                    ["2.3k", "Repo stars"],
+                    ["304", "Public repos"],
+                    ["397", "Contributors"],
+                  ].map(([value, label]) => (
+                    <div key={label}>
+                      <div className="font-['Anybody',sans-serif] text-3xl font-extrabold leading-none text-[#0F172A]">
+                        {value}
+                      </div>
+                      <div className="mt-1 font-['Space_Mono',monospace] text-xs text-[#64748B]">
+                        {label}
+                      </div>
+                    </div>
+                  ))}
+                </div>
               </div>
-            </div>
-            <div className="mx-auto grid max-w-5xl items-center gap-6 py-12 lg:grid-cols-3">
-              <Card className="hover:shadow-lg transition-shadow duration-200 h-full">
-                <CardContent className="p-6">
-                  <Lightning className="h-12 w-12 mb-4" />
-                  <h3 className="text-xl font-bold">Version Control</h3>
-                  <p className="text-sm text-muted-foreground">
-                    Collaborate on Github or wherever you keep source code.
-                    Utilize industry-standard continuous integration tooling
-                  </p>
-                </CardContent>
-              </Card>
-              <Card className="hover:shadow-lg transition-shadow duration-200 h-full">
-                <CardContent className="p-6">
-                  <Cpu className="h-12 w-12 mb-4" />
-                  <h3 className="text-xl font-bold">Robust Autorouting</h3>
-                  <p className="text-sm text-muted-foreground">
-                    Near-instant local and cloud autorouters to give you a
-                    functional circuit board fast
-                  </p>
-                </CardContent>
-              </Card>
-              <Card className="hover:shadow-lg transition-shadow duration-200 h-full">
-                <CardContent className="p-6">
-                  <Maximize2 className="h-12 w-12 mb-4" />
-                  <h3 className="text-xl font-bold">
-                    Export &amp; Manufacture
-                  </h3>
-                  <p className="text-sm text-muted-foreground">
-                    Export to industry-standard formats like Gerber, SPICE
-                    netlists and more
-                  </p>
-                </CardContent>
-              </Card>
+              <div className="relative min-w-0">
+                <div className="absolute -right-4 -top-5 hidden h-28 w-28 rounded-[28px] border border-[#2563EB]/60 bg-[#2563EB]/10 lg:block" />
+                <div className="absolute -bottom-6 -left-6 hidden h-32 w-32 grid-cols-3 gap-2 lg:grid">
+                  {surfaceTiles.slice(0, 9).map((tile, index) => (
+                    <span
+                      key={`panel-tile-${index}`}
+                      className={`rounded-lg border border-[#CBD5E1] ${tile}`}
+                    />
+                  ))}
+                </div>
+                <div className="landing-corner-grid relative min-w-0 overflow-hidden rounded-3xl border border-[#CBD5E1] bg-[#EFF6FF] p-3 shadow-[0_24px_80px_rgba(37,99,235,.18)] sm:p-4">
+                  <div className="rounded-2xl border border-[#CBD5E1] bg-[#FFFFFF]">
+                    <div className="flex items-center justify-between gap-3 border-b border-[#CBD5E1] px-4 py-3">
+                      <div className="min-w-0 flex items-center gap-2 font-['Space_Mono',monospace] text-xs text-[#64748B]">
+                        <Terminal
+                          className="h-4 w-4 shrink-0"
+                          style={{ color: activeHeroView.accent }}
+                        />
+                        <span className="truncate">{activeHeroView.title}</span>
+                      </div>
+                      <div
+                        className="shrink-0 rounded px-2 py-1 font-['Space_Mono',monospace] text-[10px] font-bold uppercase text-[#F8FAFC]"
+                        style={{ backgroundColor: activeHeroView.accent }}
+                      >
+                        {activeHeroView.status}
+                      </div>
+                    </div>
+
+                    <div className="grid grid-cols-4 gap-2 border-b border-[#CBD5E1] bg-[#F8FAFC] p-2">
+                      {heroViews.map((view, index) => {
+                        const isActive = activeHeroView.id === view.id
+                        return (
+                          <button
+                            type="button"
+                            key={view.id}
+                            onClick={() => setActiveHeroViewIndex(index)}
+                            className={`h-10 min-w-0 rounded-md border px-1 font-['Space_Mono',monospace] text-[9px] font-bold uppercase tracking-[0.08em] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#2563EB] sm:px-2 sm:text-[10px] ${
+                              isActive
+                                ? "border-[#2563EB] bg-[#2563EB] text-[#F8FAFC]"
+                                : "border-[#CBD5E1] bg-[#FFFFFF] text-[#64748B]"
+                            }`}
+                            aria-pressed={isActive}
+                          >
+                            <span className="sm:hidden">{view.shortLabel}</span>
+                            <span className="hidden sm:inline">
+                              {view.label}
+                            </span>
+                          </button>
+                        )
+                      })}
+                    </div>
+
+                    <div className="p-3 sm:p-4">
+                      <div
+                        key={activeHeroView.id}
+                        className="landing-demo-panel landing-scanlines relative h-[340px] overflow-hidden rounded-xl border border-[#CBD5E1] bg-[#F8FAFC] p-4 sm:h-[380px] lg:h-[380px]"
+                      >
+                        {activeHeroView.id === "code" && (
+                          <div className="flex h-full flex-col justify-between font-['Space_Mono',monospace] text-xs leading-6 text-[#334155]">
+                            <div className="space-y-3">
+                              {codeLines.map((line) => (
+                                <div key={line} className="flex min-w-0 gap-3">
+                                  <span className="text-[#2563EB]">+</span>
+                                  <span className="truncate">{line}</span>
+                                </div>
+                              ))}
+                            </div>
+                            <div className="rounded-lg border border-[#2563EB]/50 bg-[#2563EB]/10 p-3 text-[#1D4ED8]">
+                              parse source → graph nets → validate outputs
+                            </div>
+                          </div>
+                        )}
+
+                        {activeHeroView.id === "schematic" && (
+                          <div className="absolute inset-4 grid grid-cols-6 grid-rows-5">
+                            <div className="col-span-6 row-start-3 h-px bg-[#0284C7]/70" />
+                            <div className="col-start-2 row-span-5 row-start-1 w-px bg-[#0284C7]/50" />
+                            <div className="col-start-5 row-span-5 row-start-1 w-px bg-[#0284C7]/50" />
+                            {["VCC", "U1", "R1", "C1", "GND", "OUT"].map(
+                              (node, index) => (
+                                <div
+                                  key={node}
+                                  className="z-10 grid h-14 w-16 place-items-center rounded-lg border border-[#0284C7] bg-[#FFFFFF] font-['Space_Mono',monospace] text-[11px] font-bold text-[#1E3A8A]"
+                                  style={{
+                                    gridColumn: `${(index % 3) * 2 + 1} / span 1`,
+                                    gridRow: `${Math.floor(index / 3) * 3 + 1} / span 1`,
+                                  }}
+                                >
+                                  {node}
+                                </div>
+                              ),
+                            )}
+                          </div>
+                        )}
+
+                        {activeHeroView.id === "3d" && (
+                          <div className="flex h-full items-center justify-center [perspective:900px]">
+                            <div className="relative h-36 w-[82%] max-w-72 rotate-x-[58deg] rotate-z-[-18deg] rounded-2xl border-2 border-[#0EA5E9] bg-[#DBEAFE] shadow-[0_28px_70px_rgba(14,165,233,.20)] sm:h-44">
+                              <div className="absolute left-[12%] top-[18%] h-[32%] w-[34%] rounded-md border border-[#DBEAFE] bg-[#F8FAFC]" />
+                              <div className="absolute bottom-[18%] right-[12%] h-[28%] w-[28%] rounded-md border border-[#0284C7] bg-[#EFF6FF]" />
+                              {[8, 22, 36, 68, 84].map((left) => (
+                                <span
+                                  key={left}
+                                  className="absolute top-4 h-3 w-3 rounded-full bg-[#0EA5E9]"
+                                  style={{ left: `${left}%` }}
+                                />
+                              ))}
+                              {[12, 30, 48, 66, 82].map((left) => (
+                                <span
+                                  key={left}
+                                  className="absolute bottom-5 h-2 w-[14%] rounded-full bg-[#2563EB]/80"
+                                  style={{ left: `${left}%` }}
+                                />
+                              ))}
+                            </div>
+                          </div>
+                        )}
+
+                        {activeHeroView.id === "gerber" && (
+                          <div className="relative h-full">
+                            {[
+                              "border-[#2563EB] translate-x-0 translate-y-0",
+                              "border-[#1D4ED8] translate-x-5 translate-y-5",
+                              "border-[#0284C7] translate-x-10 translate-y-10",
+                              "border-[#0EA5E9] translate-x-14 translate-y-14",
+                            ].map((layer, index) => (
+                              <div
+                                key={layer}
+                                className={`absolute inset-8 rounded-2xl border-2 ${layer} bg-[#FFFFFF]/35`}
+                              >
+                                <div className="absolute left-8 top-8 h-12 w-20 rounded border border-current" />
+                                <div className="absolute bottom-8 right-8 h-16 w-24 rounded-full border border-current" />
+                                <div className="absolute left-10 right-10 top-1/2 h-px bg-current" />
+                                <span className="absolute right-4 top-3 font-['Space_Mono',monospace] text-[10px] font-bold text-current">
+                                  L{index + 1}
+                                </span>
+                              </div>
+                            ))}
+                          </div>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
             </div>
           </div>
         </section>
-        <section className="w-full py-12 md:py-20 lg:py-28 section-dot-pattern">
-          <div className="container px-4 md:px-6 mx-auto">
-            <div className="grid gap-8 lg:grid-cols-[0.85fr_1.15fr] lg:gap-12 lg:items-center">
+
+        <section className="bg-[#2563EB] py-4 text-[#F8FAFC]">
+          <div className="mx-auto flex max-w-7xl gap-8 overflow-hidden px-4 font-['Space_Mono',monospace] text-sm font-bold uppercase tracking-[0.12em] md:px-6">
+            {[...integrations, ...integrations].map((item, index) => (
+              <span key={`${item}-${index}`} className="shrink-0">
+                {item}
+              </span>
+            ))}
+          </div>
+        </section>
+
+        <section
+          id="features"
+          className="landing-tile-field relative bg-[#FFFFFF] px-4 py-16 md:px-6 md:py-24"
+        >
+          <div className="absolute inset-0 opacity-45 [background-image:linear-gradient(rgba(37,99,235,.10)_1px,transparent_1px),linear-gradient(90deg,rgba(37,99,235,.10)_1px,transparent_1px)] [background-size:48px_48px]" />
+          <div className="relative mx-auto max-w-7xl">
+            <div className="grid gap-6 lg:grid-cols-3">
+              {featureCards.map((feature, index) => {
+                const Icon = feature.icon
+                return (
+                  <article
+                    key={feature.title}
+                    className={`relative overflow-hidden rounded-3xl border border-[#CBD5E1] ${
+                      index === 1 ? "bg-[#EFF6FF]" : "bg-[#DBEAFE]"
+                    } p-6 shadow-[0_12px_40px_rgba(37,99,235,.12)]`}
+                  >
+                    <div className="absolute right-0 top-0 grid w-28 grid-cols-3 gap-1 p-3 opacity-45">
+                      {surfaceTiles.map((tile, tileIndex) => (
+                        <span
+                          key={`${feature.label}-tile-${tileIndex}`}
+                          className={`aspect-square rounded-md border border-[#93C5FD] ${tile}`}
+                        />
+                      ))}
+                    </div>
+                    <div
+                      className={`mb-8 inline-grid h-12 w-12 place-items-center rounded-xl bg-[#F8FAFC] ${feature.accent}`}
+                    >
+                      <Icon className="h-6 w-6" />
+                    </div>
+                    <div className="font-['Space_Mono',monospace] text-[11px] font-bold uppercase tracking-[0.12em] text-[#2563EB]">
+                      {feature.label}
+                    </div>
+                    <h2 className="mt-3 font-['Anybody',sans-serif] text-3xl font-extrabold leading-[1.02] tracking-normal">
+                      {feature.title}
+                    </h2>
+                    <p className="mt-4 leading-7 text-[#334155]">
+                      {feature.body}
+                    </p>
+                  </article>
+                )
+              })}
+            </div>
+          </div>
+        </section>
+
+        <section className="relative border-y border-[#CBD5E1] bg-[#EFF6FF] px-4 py-16 md:px-6 md:py-24">
+          <div className="absolute inset-0 opacity-35 [background-image:linear-gradient(135deg,rgba(37,99,235,.14)_0_1px,transparent_1px_30px)]" />
+          <div className="relative mx-auto max-w-7xl">
+            <div className="mb-10 grid gap-6 lg:grid-cols-[minmax(0,1fr)_420px] lg:items-end">
+              <div className="max-w-3xl">
+                <div className="font-['Space_Mono',monospace] text-xs font-bold uppercase tracking-[0.12em] text-[#2563EB]">
+                  [ CODE TO CIRCUIT PIPELINE ]
+                </div>
+                <h2 className="mt-4 font-['Anybody',sans-serif] text-4xl font-extrabold leading-none tracking-normal md:text-6xl">
+                  A developer workflow for physical boards.
+                </h2>
+              </div>
+              <div className="grid grid-cols-6 gap-2 rounded-2xl border border-[#CBD5E1] bg-[#FFFFFF] p-3">
+                {pipelineNodes.map((label, index) => (
+                  <div
+                    key={`rail-${label}`}
+                    className={`grid aspect-square place-items-center rounded-lg border font-['Space_Mono',monospace] text-[10px] font-bold ${
+                      index % 3 === 0
+                        ? "border-[#2563EB]/70 bg-[#2563EB]/10 text-[#2563EB]"
+                        : "border-[#CBD5E1] bg-[#F8FAFC] text-[#64748B]"
+                    }`}
+                  >
+                    {label}
+                  </div>
+                ))}
+              </div>
+            </div>
+            <div className="grid gap-5 lg:grid-cols-3">
+              {processSteps.map((step, index) => (
+                <article
+                  key={step.step}
+                  className={`relative overflow-hidden rounded-[28px] border border-[#CBD5E1] ${
+                    index === 0
+                      ? "bg-[#F8FAFC]"
+                      : index === 1
+                        ? "bg-[#FFFFFF]"
+                        : "bg-[#DBEAFE]"
+                  } p-7`}
+                >
+                  <div className="absolute bottom-0 right-0 h-24 w-24 border-l border-t border-[#CBD5E1] bg-[linear-gradient(135deg,transparent_0_48%,rgba(37,99,235,.14)_48%_52%,transparent_52%)]" />
+                  <div className="mb-8 flex items-center justify-between">
+                    <span className="font-['Space_Mono',monospace] text-xs font-bold uppercase tracking-[0.12em] text-[#0EA5E9]">
+                      {step.step}
+                    </span>
+                    <GitBranch className="h-5 w-5 text-[#2563EB]" />
+                  </div>
+                  <h3 className="font-['Anybody',sans-serif] text-3xl font-bold leading-tight tracking-normal">
+                    {step.title}
+                  </h3>
+                  <p className="mt-4 leading-7 text-[#64748B]">{step.body}</p>
+                </article>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="relative bg-[#F8FAFC] px-4 py-16 md:px-6 md:py-24">
+          <div className="absolute inset-x-0 top-0 h-px bg-[#CBD5E1]" />
+          <div className="mx-auto grid max-w-7xl gap-8 lg:grid-cols-[.85fr_1.15fr] lg:items-center">
+            <div className="rounded-[28px] border border-[#CBD5E1] bg-[#DBEAFE] p-7">
+              <div className="font-['Space_Mono',monospace] text-xs font-bold uppercase tracking-[0.12em] text-[#2563EB]">
+                [ SHAREABLE PROOF ]
+              </div>
+              <h2 className="mt-4 font-['Anybody',sans-serif] text-4xl font-extrabold leading-none tracking-normal md:text-6xl">
+                Every circuit becomes a browser artifact.
+              </h2>
+              <p className="mt-5 text-lg leading-8 text-[#334155]">
+                Push a package and get durable URLs for boards, subcircuits,
+                schematics, PCB views, assembly diagrams, and 3D previews.
+              </p>
+              <div className="mt-6 grid grid-cols-3 gap-2">
+                {["pkg", "pcb", "3d", "bom", "spice", "fab"].map(
+                  (item, index) => (
+                    <span
+                      key={item}
+                      className={`rounded-lg border border-[#CBD5E1] px-3 py-2 font-['Space_Mono',monospace] text-[11px] font-bold uppercase ${
+                        index % 2 === 0
+                          ? "bg-[#FFFFFF] text-[#2563EB]"
+                          : "bg-[#EFF6FF] text-[#64748B]"
+                      }`}
+                    >
+                      {item}
+                    </span>
+                  ),
+                )}
+              </div>
+            </div>
+            <div className="relative">
+              <div className="absolute -right-3 -top-3 h-full w-full rounded-3xl border border-[#2563EB]/40" />
               <OptimizedImage
-                alt="Share and display in the browser placeholder"
-                className="mx-auto w-full max-w-xl overflow-hidden rounded-xl object-cover object-center shadow-xl ring-1 ring-black/5 dark:ring-white/10"
+                alt="Share and display tscircuit projects in the browser"
+                className="relative w-full rounded-3xl border border-[#CBD5E1] bg-[#FFFFFF] object-cover shadow-[0_24px_80px_rgba(37,99,235,.18)]"
                 src={shareableLinkForCircuitImg}
                 height={360}
                 width={540}
               />
-              <div className="space-y-4">
-                <h2 className="text-3xl font-bold tracking-tight md:text-4xl lg:text-5xl text-balance">
-                  Share and display in the browser
-                </h2>
-                <ul className="feature-list space-y-3 text-muted-foreground md:text-lg">
-                  <li>
-                    Connect your GitHub or push to tscircuit.com to create
-                    shareable URLs for your project
-                  </li>
-                  <li>
-                    Every component, subcircuit and board has a dedicated
-                    webpage
-                  </li>
-                  <li>
-                    Easy-to-use React component libraries for displaying PCBs,
-                    Schematics, Assembly Diagrams on your own website
-                  </li>
-                </ul>
-              </div>
             </div>
           </div>
         </section>
-        <section className="w-full py-12 md:py-20 lg:py-28">
-          <div className="container px-4 md:px-6 mx-auto">
-            <div className="grid gap-8 lg:grid-cols-[0.95fr_1.05fr] lg:items-center">
-              <div className="space-y-4 min-w-0">
-                <h2 className="text-3xl font-bold tracking-tight md:text-4xl lg:text-5xl text-balance">
-                  Extremely Fast Autorouting
-                </h2>
-                <ul className="feature-list space-y-3 text-muted-foreground md:text-lg">
-                  <li>
-                    Autoroute circuit boards using{" "}
-                    <a className="underline" href="#">
-                      freerouting
-                    </a>{" "}
-                    or{" "}
-                    <a
-                      className="underline"
-                      href="https://github.com/tscircuit/tscircuit-autorouter"
-                    >
-                      tscircuit&apos;s fast autorouter
-                    </a>
-                  </li>
-                  <li>
-                    Autoroute as few as 1 layer with automatically placed
-                    jumpers
-                  </li>
-                  <li>Route complex circuits in seconds</li>
-                </ul>
+
+        <section className="bg-[#F8FAFC] px-4 pb-16 md:px-6 md:pb-24">
+          <div className="mx-auto grid max-w-7xl gap-5 lg:grid-cols-3">
+            {bugCards.map((card, index) => (
+              <article
+                key={card.title}
+                className={`relative overflow-hidden rounded-2xl border ${
+                  index === 1 ? "bg-[#EFF6FF]" : "bg-[#FFFFFF]"
+                } p-5 ${card.color}`}
+              >
+                <div className="absolute right-0 top-0 h-20 w-20 border-b border-l border-[#CBD5E1] bg-[#DBEAFE]/70" />
+                <div className="mb-4 flex items-center justify-between gap-4 font-['Space_Mono',monospace] text-[11px] font-bold uppercase tracking-[0.1em]">
+                  <span className="rounded bg-[#DBEAFE] px-2 py-1 text-[#2563EB]">
+                    {card.tag}
+                  </span>
+                  <Search className="h-4 w-4 text-[#64748B]" />
+                </div>
+                <div className="overflow-hidden text-ellipsis whitespace-nowrap border-y border-[#CBD5E1] py-3 font-['Space_Mono',monospace] text-xs text-[#0284C7]">
+                  {card.path}
+                </div>
+                <h3 className="mt-5 font-['Anybody',sans-serif] text-2xl font-bold leading-tight tracking-normal">
+                  {card.title}
+                </h3>
+                <p className="mt-3 text-sm leading-6 text-[#64748B]">
+                  {card.body}
+                </p>
+              </article>
+            ))}
+          </div>
+        </section>
+
+        <section className="relative border-y border-[#CBD5E1] bg-[#DBEAFE] px-4 py-16 md:px-6 md:py-24">
+          <div className="absolute inset-0 opacity-30 [background-image:linear-gradient(rgba(37,99,235,.10)_1px,transparent_1px),linear-gradient(90deg,rgba(37,99,235,.10)_1px,transparent_1px)] [background-size:64px_64px]" />
+          <div className="relative mx-auto grid max-w-7xl gap-10 lg:grid-cols-[1fr_1fr] lg:items-center">
+            <div className="space-y-6">
+              <div className="font-['Space_Mono',monospace] text-xs font-bold uppercase tracking-[0.12em] text-[#2563EB]">
+                [ ROUTE · TEST · EXECUTE ]
               </div>
-              <div className="aspect-video overflow-hidden rounded-xl bg-black shadow-2xl ring-1 ring-black/10 dark:ring-white/10">
+              <h2 className="font-['Anybody',sans-serif] text-4xl font-extrabold leading-none tracking-normal md:text-6xl">
+                Autoroute and simulate without leaving source control.
+              </h2>
+              <p className="text-lg leading-8 text-[#334155]">
+                Fast routing and analog simulation turn circuit code into a
+                feedback loop. Review behavior and layout before committing to
+                fabrication.
+              </p>
+              <div className="flex flex-wrap gap-3 font-['Space_Mono',monospace] text-xs font-bold uppercase tracking-[0.08em]">
+                <span className="rounded-md bg-[#2563EB] px-3 py-2 text-[#F8FAFC]">
+                  Cloud autorouter
+                </span>
+                <span className="rounded-md border border-[#93C5FD] px-3 py-2 text-[#0F172A]">
+                  WebAssembly ngspice
+                </span>
+              </div>
+            </div>
+            <div className="grid gap-5">
+              <div className="aspect-video overflow-hidden rounded-3xl border border-[#CBD5E1] bg-[#FFFFFF] p-2 shadow-[0_24px_80px_rgba(37,99,235,.18)]">
                 <video
-                  className="h-full w-full object-cover"
+                  className="h-full w-full rounded-2xl object-cover"
                   src={autoroutingExampleVideo}
                   autoPlay
                   muted
                   loop
                   playsInline
                   preload="metadata"
-                  onEnded={(event) => {
-                    event.currentTarget.currentTime = 0
-                    event.currentTarget.play().catch(() => {})
-                  }}
                   aria-label="Autorouting demonstration video"
                 />
               </div>
-            </div>
-          </div>
-        </section>
-        <section className="w-full py-12 md:py-20 lg:py-28 section-dot-pattern">
-          <div className="container px-4 md:px-6 mx-auto">
-            <div className="grid gap-8 lg:grid-cols-[1.1fr_0.9fr] lg:items-center overflow-hidden">
-              <div className="space-y-4 min-w-0">
-                <h2 className="text-3xl font-bold tracking-tight md:text-4xl lg:text-5xl text-balance">
-                  Analog Simulation
-                </h2>
-                <ul className="feature-list space-y-3 text-muted-foreground md:text-lg">
-                  <li>
-                    Run analog simulations in your browser or on the command
-                    line via WebAssembly ngspice
-                  </li>
-                </ul>
-                <a
-                  href="https://docs.tscircuit.com/category/spice-simulation"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-block text-primary underline underline-offset-4 hover:text-primary/80 md:text-lg"
-                >
-                  Read the Analog Simulation Guide &rarr;
-                </a>
-                {analogSimulationHtml ? (
-                  <div
-                    className="rounded-lg text-sm overflow-x-auto max-w-full [&>pre]:p-4 [&>pre]:w-max [&>pre]:min-w-full [&>pre]:rounded-lg"
-                    dangerouslySetInnerHTML={{ __html: analogSimulationHtml }}
-                  />
-                ) : (
-                  <div className="rounded-lg overflow-x-auto max-w-full">
-                    <pre className="bg-gray-900 p-4 text-sm text-gray-100 w-max min-w-full rounded-lg">
-                      <code>{analogSimulationCode}</code>
-                    </pre>
-                  </div>
-                )}
-              </div>
               <OptimizedImage
-                alt="Analog simulation"
-                className="mx-auto w-full max-w-xl overflow-hidden rounded-xl object-cover object-center shadow-xl ring-1 ring-black/10 dark:ring-white/10"
+                alt="Analog simulation output"
+                className="w-full rounded-3xl border border-[#CBD5E1] bg-[#FFFFFF] object-cover"
                 src={analogSimulationImg}
                 height={360}
                 width={540}
@@ -347,40 +820,75 @@ export function LandingPage() {
             </div>
           </div>
         </section>
-        <section className="w-full py-12 md:py-20 lg:py-28">
-          <div className="container px-4 md:px-6 mx-auto">
-            <div className="grid gap-8 lg:grid-cols-[0.9fr_1.1fr] lg:items-center">
-              <div className="space-y-4">
-                <h2 className="text-3xl font-bold tracking-tight md:text-4xl lg:text-5xl text-balance">
-                  First Class KiCad Support
-                </h2>
-                <ul className="feature-list space-y-3 text-muted-foreground md:text-lg">
-                  <li>
-                    Export to KiCad PCB and Schematic files{" "}
-                    <em>
-                      Just run{" "}
-                      <span className="font-semibold">
-                        tsci build --kicad-library
-                      </span>
-                    </em>
-                  </li>
-                  <li>
-                    Import KiCad files directly{" "}
-                    <em>import RP2040 from &quot;./RP2040.kicad_mod&quot;</em>
-                  </li>
-                  <li>
-                    Automatic KiCad PCM Server{" "}
-                    <span className="text-muted-foreground">
-                      Import your library anywhere. Enable KiCad PCM to have
-                      every tscircuit package automatically serve components and
-                      subcircuits as importable KiCad modules
-                    </span>
-                  </li>
-                </ul>
+
+        <section className="bg-[#FFFFFF] px-4 py-16 md:px-6 md:py-24">
+          <div className="mx-auto grid max-w-7xl gap-8 lg:grid-cols-[1.05fr_.95fr] lg:items-center">
+            <div className="relative">
+              <div className="absolute -left-3 -top-3 h-full w-full rounded-3xl border border-[#3B82F6]/50 bg-[#EFF6FF]" />
+              <OptimizedImage
+                alt="AI-compatible electronics workflow"
+                className="relative w-full rounded-3xl border border-[#CBD5E1] bg-[#FFFFFF] object-cover shadow-[0_24px_80px_rgba(37,99,235,.18)]"
+                src={exampleAiCodingImg}
+                height={405}
+                width={720}
+              />
+            </div>
+            <div className="rounded-[28px] border border-[#CBD5E1] bg-[#F8FAFC] p-7">
+              <div className="font-['Space_Mono',monospace] text-xs font-bold uppercase tracking-[0.12em] text-[#2563EB]">
+                [ AI COMPATIBLE ELECTRONICS ]
+              </div>
+              <h2 className="mt-4 font-['Anybody',sans-serif] text-4xl font-extrabold leading-none tracking-normal md:text-6xl">
+                Teach agents to change schematics and PCBs.
+              </h2>
+              <div className="mt-6 space-y-3 text-[#334155]">
+                {[
+                  "Install the tscircuit skill for agent-native circuit edits.",
+                  "Ask for schematic changes, package reuse, layout passes, and review.",
+                  "Keep every electrical decision visible as source code.",
+                ].map((item) => (
+                  <p key={item} className="flex gap-3 leading-7">
+                    <Braces className="mt-1 h-5 w-5 shrink-0 text-[#2563EB]" />
+                    {item}
+                  </p>
+                ))}
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section className="relative border-y border-[#CBD5E1] bg-[#EFF6FF] px-4 py-16 md:px-6 md:py-24">
+          <div className="absolute inset-0 opacity-25 [background-image:linear-gradient(135deg,rgba(14,165,233,.16)_0_1px,transparent_1px_26px)]" />
+          <div className="relative mx-auto grid max-w-7xl gap-8 lg:grid-cols-[.9fr_1.1fr] lg:items-center">
+            <div>
+              <div className="font-['Space_Mono',monospace] text-xs font-bold uppercase tracking-[0.12em] text-[#2563EB]">
+                [ KICAD BRIDGE ]
+              </div>
+              <h2 className="mt-4 font-['Anybody',sans-serif] text-4xl font-extrabold leading-none tracking-normal md:text-6xl">
+                Code-first does not mean format-isolated.
+              </h2>
+              <p className="mt-5 text-lg leading-8 text-[#334155]">
+                Import KiCad footprints directly, export KiCad PCB and schematic
+                files, and keep traditional EDA collaboration paths open.
+              </p>
+            </div>
+            <div className="grid gap-3 rounded-[28px] border border-[#CBD5E1] bg-[#FFFFFF] p-3">
+              <div className="grid grid-cols-4 gap-2">
+                {["fp", "lib", "sch", "pcb"].map((item, index) => (
+                  <span
+                    key={item}
+                    className={`rounded-lg px-3 py-2 text-center font-['Space_Mono',monospace] text-[11px] font-bold uppercase ${
+                      index === 0
+                        ? "bg-[#2563EB] text-[#F8FAFC]"
+                        : "bg-[#DBEAFE] text-[#64748B]"
+                    }`}
+                  >
+                    {item}
+                  </span>
+                ))}
               </div>
               <OptimizedImage
-                alt="KiCad support via PCB Server"
-                className="mx-auto w-full max-w-xl overflow-hidden rounded-xl object-cover object-center"
+                alt="KiCad support via tscircuit packages"
+                className="w-full rounded-2xl border border-[#CBD5E1] bg-[#FFFFFF] object-cover"
                 src={importKicadLibraryImg}
                 height={360}
                 width={540}
@@ -388,108 +896,52 @@ export function LandingPage() {
             </div>
           </div>
         </section>
-        <section className="w-full py-12 md:py-20 lg:py-28 section-dot-pattern">
-          <div className="container px-4 md:px-6 mx-auto">
-            <div className="grid gap-8 lg:grid-cols-[0.7fr_1.3fr] lg:gap-16 lg:items-center">
-              <div className="space-y-4">
-                <h2 className="text-3xl font-bold tracking-tight md:text-4xl lg:text-5xl text-balance">
-                  AI-compatible Electronics
-                </h2>
-                <ul className="feature-list space-y-3 text-muted-foreground md:text-lg">
-                  <li>
-                    Teach agents tscircuit instantly with{" "}
-                    <span className="font-semibold">
-                      npx skills add tscircuit/skill
-                    </span>
-                  </li>
-                  <li>Bring your own agent (Claude Code, Codex, OpenCode)</li>
-                  <li>
-                    Ask to initialize, change and review schematics and PCBs
-                  </li>
-                </ul>
-              </div>
-              <OptimizedImage
-                alt="AI-compatible electronics"
-                className="mx-auto w-full max-w-4xl overflow-hidden rounded-xl object-cover object-center lg:justify-self-end"
-                src={exampleAiCodingImg}
-                height={405}
-                width={720}
-              />
+
+        <section className="relative bg-[#F8FAFC] px-4 py-16 text-center md:px-6 md:py-24">
+          <div className="absolute inset-0 opacity-40 [background-image:linear-gradient(rgba(37,99,235,.14)_1px,transparent_1px),linear-gradient(90deg,rgba(37,99,235,.14)_1px,transparent_1px)] [background-size:56px_56px]" />
+          <div className="relative mx-auto max-w-4xl rounded-[28px] border border-[#CBD5E1] bg-[#FFFFFF] p-8 md:p-12">
+            <div className="font-['Space_Mono',monospace] text-xs font-bold uppercase tracking-[0.12em] text-[#2563EB]">
+              [ START BUILDING ]
+            </div>
+            <h2 className="mt-4 font-['Anybody',sans-serif] text-4xl font-extrabold leading-none tracking-normal md:text-6xl">
+              Ready to build electronics with code?
+            </h2>
+            <p className="mx-auto mt-5 max-w-2xl text-lg leading-8 text-[#334155]">
+              Open an example, start from the docs, or jump into your dashboard
+              and build a circuit that can be reviewed like software.
+            </p>
+            <div className="mt-8 flex flex-col justify-center gap-3 sm:flex-row">
+              <button
+                type="button"
+                onClick={() => {
+                  if (!isLoggedIn) {
+                    signIn()
+                  } else {
+                    navigate("/dashboard")
+                  }
+                }}
+                className="inline-flex h-12 items-center justify-center gap-2 rounded-lg bg-[#2563EB] px-6 font-['Space_Mono',monospace] text-[13px] font-bold uppercase tracking-[0.08em] text-[#F8FAFC]"
+                aria-label="Get started with TSCircuit now"
+              >
+                Start now
+                <ArrowRight className="h-4 w-4" />
+              </button>
+              <a
+                href="https://docs.tscircuit.com"
+                className="inline-flex h-12 items-center justify-center gap-2 rounded-lg border border-[#93C5FD] bg-[#DBEAFE] px-6 font-['Space_Mono',monospace] text-[13px] font-bold uppercase tracking-[0.08em] text-[#0F172A]"
+              >
+                Read docs
+                <Code2 className="h-4 w-4" />
+              </a>
             </div>
           </div>
         </section>
-        <section className="w-full py-12 md:py-20 lg:py-28">
-          <div className="container px-4 md:px-6 mx-auto">
-            <div className="space-y-4">
-              <h2 className="text-3xl font-bold tracking-tight md:text-4xl lg:text-5xl text-balance">
-                Zero Effort Bill of Materials and Inventory Checks
-              </h2>
-              <ul className="feature-list space-y-3 text-muted-foreground md:text-lg">
-                <li>Integrations with major component suppliers</li>
-                <li>
-                  Automatic passive component selection based on component
-                  properties
-                </li>
-                <li>
-                  Supplier part numbers, pricing and inventory automatically
-                  queried
-                </li>
-              </ul>
-            </div>
-          </div>
-        </section>
-        <div className="md:mt-8">
-          <OptimizedImage
-            alt="Product preview"
-            className="mx-auto aspect-video overflow-hidden rounded-xl object-cover object-center"
-            src="/assets/editor_example_2.webp"
-            height={310}
-            width={800}
-          />
+
+        <div className="landing-faq bg-[#F8FAFC]">
+          <FAQ />
         </div>
-        <FAQ />
-        <div className="md:mt-8">
-          <OptimizedImage
-            alt="Product preview"
-            className="mx-auto aspect-video overflow-hidden rounded-xl object-cover object-center"
-            src="/assets/example_schematic.webp"
-            height={310}
-            width={800}
-          />
-        </div>
-        <section className="w-full py-12 md:py-24 lg:py-32 bg-primary" id="cta">
-          <div className="container px-4 md:px-6 mx-auto">
-            <div className="flex flex-col items-center justify-center space-y-4 text-center text-primary-foreground">
-              <div className="space-y-2">
-                <h2 className="text-3xl font-bold tracking-tight md:text-4xl lg:text-5xl text-balance">
-                  Ready to build electronics with code?
-                </h2>
-                <p className="max-w-[600px] mx-auto text-primary-foreground/80 md:text-xl">
-                  Join thousands of engineers who are already using tscircuit to
-                  design complex electronics!
-                </p>
-              </div>
-              <div className="flex flex-col gap-2 min-[400px]:flex-row">
-                <Button
-                  onClick={() => {
-                    if (!isLoggedIn) {
-                      signIn()
-                    } else {
-                      navigate("/dashboard")
-                    }
-                  }}
-                  size="lg"
-                  variant="secondary"
-                  aria-label="Get started with TSCircuit now"
-                >
-                  Get Started
-                </Button>
-              </div>
-            </div>
-          </div>
-        </section>
       </main>
-      <Footer />
+      <LandingFooter />
     </div>
   )
 }

--- a/vercel.json
+++ b/vercel.json
@@ -13,22 +13,14 @@
   "routes": [
     {
       "src": "^/$",
-      "dest": "https://tscircuit-com-landing.vercel.app/index.html"
+      "dest": "/landing.html"
     },
     {
       "src": "^/index\\.html$",
-      "dest": "https://tscircuit-com-landing.vercel.app/index.html"
+      "dest": "/landing.html"
     }
   ],
   "rewrites": [
-    {
-      "source": "/assets/:path*",
-      "destination": "https://tscircuit-com-landing.vercel.app/assets/:path*"
-    },
-    {
-      "source": "/favicon.ico",
-      "destination": "https://tscircuit-com-landing.vercel.app/favicon.ico"
-    },
     {
       "source": "/(.*)",
       "destination": "/api/generated-index"


### PR DESCRIPTION
## Summary

- Redesign the homepage around a white/blue visual theme with blue grid/tile geometry.
- Replace the old static hero with an animated Code/Schematic/3D/Gerber demo viewport.
- Add homepage-scoped styling for the light header, FAQ, grid fields, corner accents, and reduced-motion-safe hero animation.
- Tighten responsive behavior for the hero tabs and 3D mockup at narrow mobile widths.

## Validation

- `bunx biome check src/pages/landing.tsx src/index.css`
- `bun run typecheck`
- Browser-checked the homepage at desktop and 320px mobile; mobile document overflow measured `0`.

[Screencast from 2026-07-06 01-42-45.webm](https://github.com/user-attachments/assets/86844a13-b444-42c8-ba84-24ea537a65b6)

