### PR TITLE
Server render package pages

### DIFF
--- a/api/generated-index.js
+++ b/api/generated-index.js
@@ -4,6 +4,12 @@ import { readFileSync } from "fs"
 import { join, dirname } from "path"
 import { fileURLToPath } from "url"
 import he from "he"
+import {
+  injectPackagePageContent,
+  parsePackagePageRoute,
+  renderPackagePageContent,
+  serializeForInlineScript,
+} from "../server/package-page-ssr.js"
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
 
@@ -64,6 +70,7 @@ function getHtmlWithModifiedSeoTags({
   canonicalUrl,
   imageUrl,
   ssrPackageData,
+  ssrContent,
 }) {
   const seoStartTag = "<!-- SEO_START -->"
   const seoEndTag = "<!-- SEO_END -->"
@@ -102,20 +109,52 @@ function getHtmlWithModifiedSeoTags({
       package: packageData,
       packageRelease,
       packageFiles,
+      packageFile,
+      packageReleases,
+      packageBuilds,
+      packageBuild,
+      route,
     } = ssrPackageData
 
     const assignments = []
     if (packageData) {
-      assignments.push(`window.SSR_PACKAGE = ${JSON.stringify(packageData)};`)
+      assignments.push(
+        `window.SSR_PACKAGE = ${serializeForInlineScript(packageData)};`,
+      )
     }
     if (packageRelease) {
       assignments.push(
-        `window.SSR_PACKAGE_RELEASE = ${JSON.stringify(packageRelease)};`,
+        `window.SSR_PACKAGE_RELEASE = ${serializeForInlineScript(packageRelease)};`,
       )
     }
     if (packageFiles) {
       assignments.push(
-        `window.SSR_PACKAGE_FILES = ${JSON.stringify(packageFiles)};`,
+        `window.SSR_PACKAGE_FILES = ${serializeForInlineScript(packageFiles)};`,
+      )
+    }
+    if (packageFile) {
+      assignments.push(
+        `window.SSR_PACKAGE_FILE = ${serializeForInlineScript(packageFile)};`,
+      )
+    }
+    if (packageReleases) {
+      assignments.push(
+        `window.SSR_PACKAGE_RELEASES = ${serializeForInlineScript(packageReleases)};`,
+      )
+    }
+    if (packageBuilds) {
+      assignments.push(
+        `window.SSR_PACKAGE_BUILDS = ${serializeForInlineScript(packageBuilds)};`,
+      )
+    }
+    if (packageBuild) {
+      assignments.push(
+        `window.SSR_PACKAGE_BUILD = ${serializeForInlineScript(packageBuild)};`,
+      )
+    }
+    if (route) {
+      assignments.push(
+        `window.SSR_PACKAGE_ROUTE = ${serializeForInlineScript(route)};`,
       )
     }
 
@@ -131,7 +170,7 @@ function getHtmlWithModifiedSeoTags({
     }
   }
 
-  return modifiedHtml
+  return injectPackagePageContent(modifiedHtml, ssrContent)
 }
 
 export async function handleUserProfile(req, res) {
@@ -169,6 +208,258 @@ async function handleDatasheetPage(req, res) {
     title: `${chipName} Datasheet - tscircuit`,
     description: `View the ${chipName} datasheet on tscircuit.`,
     canonicalUrl: `${BASE_URL}/datasheets/${he.encode(chipName)}`,
+  })
+
+  res.setHeader("Content-Type", "text/html; charset=utf-8")
+  res.setHeader("Cache-Control", cacheControlHeader)
+  res.setHeader("Vary", "Accept-Encoding")
+  res.status(200).send(html)
+}
+
+async function requestJsonOrNull(request) {
+  try {
+    return await request.json()
+  } catch (error) {
+    if (error?.response?.status === 404 || String(error).includes("404")) {
+      return null
+    }
+    throw error
+  }
+}
+
+async function fetchPackageRelease(route) {
+  const getRelease = async (query) => {
+    const response = await requestJsonOrNull(
+      ky.post(`${REGISTRY_URL}/package_releases/get`, {
+        searchParams: {
+          include_logs: true,
+          include_ai_review: true,
+        },
+        json: query,
+      }),
+    )
+    return response?.package_release ?? null
+  }
+
+  if (route.releaseId) {
+    const releaseById = await getRelease({
+      package_release_id: route.releaseId,
+    })
+    if (releaseById) return releaseById
+
+    return getRelease({
+      package_name_with_version: `${route.packageNameWithScope}@${route.releaseId}`,
+    })
+  }
+
+  if (route.version) {
+    return getRelease({
+      package_name_with_version: `${route.packageNameWithScope}@${route.version}`,
+    })
+  }
+
+  return getRelease({
+    package_name: route.packageNameWithScope,
+    is_latest: true,
+  })
+}
+
+async function fetchPackagePageData(route, packageInfo) {
+  const packageRelease = await fetchPackageRelease(route).catch((error) => {
+    console.warn("Failed to fetch package release for SSR:", error)
+    return null
+  })
+
+  const releasesResponse = await requestJsonOrNull(
+    ky.post(`${REGISTRY_URL}/package_releases/list`, {
+      json: { package_id: packageInfo.package_id },
+    }),
+  ).catch((error) => {
+    console.warn("Failed to fetch package releases for SSR:", error)
+    return null
+  })
+  const packageReleases = releasesResponse?.package_releases ?? []
+
+  let packageFiles = []
+  if (packageRelease?.package_release_id) {
+    const filesResponse = await requestJsonOrNull(
+      ky.get(`${REGISTRY_URL}/package_files/list`, {
+        searchParams: {
+          package_release_id: packageRelease.package_release_id,
+        },
+      }),
+    ).catch((error) => {
+      console.warn("Failed to fetch package files for SSR:", error)
+      return null
+    })
+    packageFiles = filesResponse?.package_files ?? []
+  }
+
+  let primaryFile = null
+  if (packageRelease?.package_release_id) {
+    let primaryFileMetadata = null
+    if (route.kind === "file") {
+      primaryFileMetadata = packageFiles.find(
+        (file) =>
+          String(file.file_path || "").replace(/^\/+/, "") === route.filePath,
+      )
+    } else if (route.kind === "package") {
+      primaryFileMetadata = packageFiles.find((file) =>
+        ["readme.md", "readme"].includes(
+          String(file.file_path || "")
+            .replace(/^\/+/, "")
+            .toLowerCase(),
+        ),
+      )
+    }
+
+    if (primaryFileMetadata || route.kind === "file") {
+      const searchParams = primaryFileMetadata?.package_file_id
+        ? { package_file_id: primaryFileMetadata.package_file_id }
+        : {
+            package_release_id: packageRelease.package_release_id,
+            file_path: route.filePath,
+          }
+      const fileResponse = await requestJsonOrNull(
+        ky.get(`${REGISTRY_URL}/package_files/get`, { searchParams }),
+      ).catch((error) => {
+        console.warn("Failed to fetch primary package file for SSR:", error)
+        return null
+      })
+      primaryFile = fileResponse?.package_file ?? null
+    }
+  }
+
+  let packageBuilds = []
+  if (route.kind === "builds" && packageRelease?.package_release_id) {
+    const buildsResponse = await requestJsonOrNull(
+      ky.get(`${REGISTRY_URL}/package_builds/list`, {
+        searchParams: {
+          package_release_id: packageRelease.package_release_id,
+        },
+      }),
+    ).catch((error) => {
+      console.warn("Failed to fetch package builds for SSR:", error)
+      return null
+    })
+    packageBuilds = buildsResponse?.package_builds ?? []
+  }
+
+  let packageBuild = null
+  const buildId =
+    route.kind === "build"
+      ? route.buildId
+      : route.kind === "release"
+        ? packageRelease?.latest_package_build_id
+        : null
+  if (buildId) {
+    const buildResponse = await requestJsonOrNull(
+      ky.get(`${REGISTRY_URL}/package_builds/get`, {
+        searchParams: {
+          package_build_id: buildId,
+          include_logs: true,
+        },
+      }),
+    ).catch((error) => {
+      console.warn("Failed to fetch package build for SSR:", error)
+      return null
+    })
+    packageBuild = buildResponse?.package_build ?? null
+  }
+
+  return {
+    route,
+    packageInfo,
+    packageRelease,
+    packageFiles,
+    primaryFile,
+    packageReleases,
+    packageBuilds,
+    packageBuild,
+  }
+}
+
+const getPackagePageTitle = (route, packageInfo, packageRelease) => {
+  const packageTitle = packageInfo.name
+  if (route.kind === "file")
+    return `${route.filePath} - ${packageTitle} - tscircuit`
+  if (route.kind === "directory") {
+    return `${route.filePath || "Files"} - ${packageTitle} - tscircuit`
+  }
+  if (route.kind === "releases") return `${packageTitle} Releases - tscircuit`
+  if (route.kind === "release" || route.kind === "preview") {
+    return `${packageTitle} Release ${packageRelease?.version || route.releaseId} - tscircuit`
+  }
+  if (route.kind === "builds") return `${packageTitle} Builds - tscircuit`
+  if (route.kind === "build")
+    return `${packageTitle} Build ${route.buildId} - tscircuit`
+  if (route.kind === "settings") return `${packageTitle} Settings - tscircuit`
+  return `${packageTitle} - tscircuit`
+}
+
+async function handlePackagePage(req, res, route) {
+  const packageDetails = await requestJsonOrNull(
+    ky.get(`${REGISTRY_URL}/packages/get`, {
+      searchParams: { name: route.packageNameWithScope },
+    }),
+  )
+
+  const canonicalPath = req.url.split("?")[0]
+  if (!packageDetails?.package) {
+    const html = getHtmlWithModifiedSeoTags({
+      title: "Package Not Found - tscircuit",
+      description: he.encode(
+        `The package ${route.packageNameWithScope} could not be found.`,
+      ),
+      canonicalUrl: `${BASE_URL}${canonicalPath}`,
+      ssrContent: `<style>#loader{display:none}</style><main data-ssr-package-page="not-found"><h1>Package Not Found</h1><p>The package ${he.encode(
+        route.packageNameWithScope,
+      )} could not be found.</p></main>`,
+    })
+    res.setHeader("Content-Type", "text/html; charset=utf-8")
+    res.setHeader("Cache-Control", cacheControlHeader)
+    res.setHeader("Vary", "Accept-Encoding")
+    res.status(404).send(html)
+    return
+  }
+
+  const packageInfo = packageDetails.package
+  const data = await fetchPackagePageData(route, packageInfo)
+  const description = he.encode(
+    `${
+      packageInfo.description ||
+      packageInfo.ai_description ||
+      `A tscircuit package created by ${route.author}`
+    } ${packageInfo.ai_usage_instructions ?? ""}`.trim(),
+  )
+  const title = he.encode(
+    getPackagePageTitle(route, packageInfo, data.packageRelease),
+  )
+  const allowedViews = ["schematic", "pcb", "assembly", "3d"]
+  const defaultView = packageInfo.default_view || "3d"
+  const thumbnailView = allowedViews.includes(defaultView) ? defaultView : "3d"
+  const imageUrl = `${REGISTRY_URL}/packages/images/${encodeURIComponent(
+    route.author,
+  )}/${encodeURIComponent(route.packageName)}/${thumbnailView}.png?fs_sha=${encodeURIComponent(
+    packageInfo.latest_package_release_fs_sha || "",
+  )}`
+  const ssrContent = renderPackagePageContent(data)
+  const html = getHtmlWithModifiedSeoTags({
+    title,
+    description,
+    canonicalUrl: `${BASE_URL}${canonicalPath}`,
+    imageUrl,
+    ssrContent,
+    ssrPackageData: {
+      package: packageInfo,
+      packageRelease: data.packageRelease,
+      packageFiles: data.packageFiles,
+      packageFile: route.kind === "file" ? data.primaryFile : null,
+      packageReleases: data.packageReleases,
+      packageBuilds: data.packageBuilds,
+      packageBuild: data.packageBuild,
+      route,
+    },
   })
 
   res.setHeader("Content-Type", "text/html; charset=utf-8")
@@ -656,6 +947,12 @@ export default async function handler(req, res) {
     res.setHeader("Cache-Control", cacheControlHeader)
     res.setHeader("Vary", "Accept-Encoding")
     res.status(200).send(htmlContent)
+    return
+  }
+
+  const packageRoute = parsePackagePageRoute(req.url)
+  if (packageRoute) {
+    await handlePackagePage(req, res, packageRoute)
     return
   }
 

--- a/bun-tests/package-page-ssr.test.js
+++ b/bun-tests/package-page-ssr.test.js
@@ -1,0 +1,153 @@
+import { describe, expect, test } from "bun:test"
+import {
+  injectPackagePageContent,
+  parsePackagePageRoute,
+  renderPackagePageContent,
+  serializeForInlineScript,
+} from "../server/package-page-ssr.js"
+
+describe("parsePackagePageRoute", () => {
+  test.each([
+    ["/alice/board", "package"],
+    ["/alice/board/tree/src/components", "directory"],
+    ["/alice/board/blob/src/index.tsx", "file"],
+    ["/alice/board/releases", "releases"],
+    ["/alice/board/releases/v1.2.3", "release"],
+    ["/alice/board/releases/v1.2.3/preview", "preview"],
+    ["/alice/board/releases/v1.2.3/builds", "builds"],
+    ["/alice/board/releases/v1.2.3/builds/build-1", "build"],
+    ["/alice/board/settings", "settings"],
+    ["/view-package/alice/board", "package"],
+  ])("recognizes %s as a %s page", (url, kind) => {
+    expect(parsePackagePageRoute(url)?.kind).toBe(kind)
+  })
+
+  test("decodes file paths and preserves the selected version", () => {
+    expect(
+      parsePackagePageRoute(
+        "/alice/board/blob/docs/USB%20C%20%231.md?version=1.2.3",
+      ),
+    ).toMatchObject({
+      author: "alice",
+      packageName: "board",
+      kind: "file",
+      filePath: "docs/USB C #1.md",
+      version: "1.2.3",
+    })
+  })
+
+  test("does not treat application and organization routes as packages", () => {
+    expect(parsePackagePageRoute("/datasheets/LM555")).toBeNull()
+    expect(parsePackagePageRoute("/orgs/invite")).toBeNull()
+    expect(parsePackagePageRoute("/alice/settings")).toBeNull()
+  })
+})
+
+const baseData = {
+  route: {
+    author: "alice",
+    packageName: "board",
+    packageNameWithScope: "alice/board",
+    kind: "package",
+    version: null,
+  },
+  packageInfo: {
+    name: "alice/board",
+    description: "A useful board",
+    ai_usage_instructions: "Import the Board component.",
+    latest_version: "1.0.0",
+  },
+  packageRelease: {
+    package_release_id: "release-1",
+    version: "1.0.0",
+  },
+  packageFiles: [
+    { package_file_id: "file-1", file_path: "README.md" },
+    { package_file_id: "file-2", file_path: "src/index.tsx" },
+  ],
+  primaryFile: {
+    package_file_id: "file-1",
+    file_path: "README.md",
+    content_text: "# Board\nUse <Board />",
+  },
+  packageReleases: [],
+  packageBuilds: [],
+  packageBuild: null,
+}
+
+describe("renderPackagePageContent", () => {
+  test("renders package metadata, files, and README content", () => {
+    const html = renderPackagePageContent(baseData)
+
+    expect(html).toContain("alice/board")
+    expect(html).toContain("A useful board")
+    expect(html).toContain("src")
+    expect(html).toContain("# Board")
+    expect(html).toContain("Use &lt;Board /&gt;")
+  })
+
+  test("renders the selected file content without allowing HTML injection", () => {
+    const html = renderPackagePageContent({
+      ...baseData,
+      route: {
+        ...baseData.route,
+        kind: "file",
+        filePath: "src/index.tsx",
+      },
+      primaryFile: {
+        file_path: "src/index.tsx",
+        content_text: '<script>alert("nope")</script>',
+      },
+    })
+
+    expect(html).toContain("src/index.tsx")
+    expect(html).toContain(
+      "&lt;script&gt;alert(&quot;nope&quot;)&lt;/script&gt;",
+    )
+    expect(html).not.toContain('<script>alert("nope")</script>')
+  })
+
+  test("renders release and build lists", () => {
+    const releasesHtml = renderPackagePageContent({
+      ...baseData,
+      route: { ...baseData.route, kind: "releases" },
+      packageReleases: [
+        {
+          package_release_id: "release-2",
+          version: "2.0.0",
+          status: "success",
+        },
+      ],
+    })
+    const buildsHtml = renderPackagePageContent({
+      ...baseData,
+      route: {
+        ...baseData.route,
+        kind: "builds",
+        releaseId: "release-1",
+      },
+      packageBuilds: [{ package_build_id: "build-1", status: "success" }],
+    })
+
+    expect(releasesHtml).toContain("2.0.0")
+    expect(releasesHtml).toContain("success")
+    expect(buildsHtml).toContain("build-1")
+  })
+})
+
+test("injectPackagePageContent replaces the empty SPA root", () => {
+  const html = injectPackagePageContent(
+    '<body><div id="root" class="loaderanimation"></div></body>',
+    "<main>Rendered package</main>",
+  )
+
+  expect(html).toContain(
+    '<div id="root" data-server-rendered="true"><main>Rendered package</main></div>',
+  )
+})
+
+test("serializeForInlineScript prevents closing the script element", () => {
+  const serialized = serializeForInlineScript({ value: "</script><script>" })
+  expect(serialized).not.toContain("</script>")
+  expect(serialized).toContain("\\u003c/script\\u003e")
+})

--- a/server/package-page-ssr.js
+++ b/server/package-page-ssr.js
@@ -1,0 +1,387 @@
+// Shared by the production request handler and the local Vite SSR middleware.
+const RESERVED_TOP_LEVEL_ROUTES = new Set([
+  "api",
+  "authorize",
+  "cli-login",
+  "dashboard",
+  "datasheets",
+  "dev-login",
+  "editor",
+  "landing",
+  "latest",
+  "legacy-editor",
+  "login",
+  "my-orders",
+  "orders",
+  "org-login",
+  "orgs",
+  "playground",
+  "quickstart",
+  "search",
+  "settings",
+  "trending",
+])
+
+const decodePathPart = (part) => {
+  try {
+    return decodeURIComponent(part)
+  } catch {
+    return part
+  }
+}
+
+export const escapeHtml = (value) =>
+  String(value ?? "")
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;")
+
+const encodePath = (path) =>
+  path.split("/").filter(Boolean).map(encodeURIComponent).join("/")
+
+export function parsePackagePageRoute(requestUrl) {
+  const url = new URL(requestUrl, "https://tscircuit.com")
+  const parts = url.pathname.split("/").filter(Boolean)
+  let isLegacyRoute = false
+
+  if (parts[0] === "view-package") {
+    parts.shift()
+    isLegacyRoute = true
+  }
+
+  if (parts.length < 2 || RESERVED_TOP_LEVEL_ROUTES.has(parts[0])) return null
+
+  const [author, packageName, ...rest] = parts.map(decodePathPart)
+  if (packageName === "settings") return null
+  const baseRoute = {
+    author,
+    packageName,
+    packageNameWithScope: `${author}/${packageName}`,
+    version: url.searchParams.get("version"),
+    isLegacyRoute,
+  }
+
+  if (rest.length === 0) return { ...baseRoute, kind: "package" }
+
+  if (rest[0] === "tree") {
+    return {
+      ...baseRoute,
+      kind: "directory",
+      filePath: rest.slice(1).join("/"),
+    }
+  }
+
+  if (rest[0] === "blob" && rest.length > 1) {
+    return {
+      ...baseRoute,
+      kind: "file",
+      filePath: rest.slice(1).join("/"),
+    }
+  }
+
+  if (rest[0] === "settings" && rest.length === 1) {
+    return { ...baseRoute, kind: "settings" }
+  }
+
+  if (rest[0] !== "releases") return null
+  if (rest.length === 1) return { ...baseRoute, kind: "releases" }
+
+  const releaseId = rest[1]
+  if (rest.length === 2) {
+    return { ...baseRoute, kind: "release", releaseId }
+  }
+  if (rest[2] === "preview" && rest.length === 3) {
+    return { ...baseRoute, kind: "preview", releaseId }
+  }
+  if (rest[2] === "builds" && rest.length === 3) {
+    return { ...baseRoute, kind: "builds", releaseId }
+  }
+  if (rest[2] === "builds" && rest.length === 4) {
+    return {
+      ...baseRoute,
+      kind: "build",
+      releaseId,
+      buildId: rest[3],
+    }
+  }
+
+  return null
+}
+
+const formatDate = (value) => {
+  if (!value) return null
+  const date = new Date(value)
+  return Number.isNaN(date.getTime()) ? String(value) : date.toISOString()
+}
+
+const getReleaseLabel = (release) =>
+  release?.version || release?.package_release_id || "Unknown release"
+
+const getStatus = (record) =>
+  record?.status ||
+  record?.build_status ||
+  record?.deployment_status ||
+  (record?.is_latest ? "latest" : null)
+
+const renderDefinitionList = (entries) => {
+  const visibleEntries = entries.filter(
+    ([, value]) => value != null && value !== "",
+  )
+  if (visibleEntries.length === 0) return ""
+
+  return `<dl>${visibleEntries
+    .map(
+      ([label, value]) =>
+        `<div><dt>${escapeHtml(label)}</dt><dd>${escapeHtml(value)}</dd></div>`,
+    )
+    .join("")}</dl>`
+}
+
+const getDirectoryEntries = (packageFiles, directoryPath) => {
+  const normalizedDirectory = directoryPath.replace(/^\/+|\/+$/g, "")
+  const prefix = normalizedDirectory ? `${normalizedDirectory}/` : ""
+  const entries = new Map()
+
+  for (const file of packageFiles || []) {
+    const normalizedPath = String(file.file_path || "").replace(/^\/+/, "")
+    if (
+      !normalizedPath.startsWith(prefix) ||
+      normalizedPath === normalizedDirectory
+    ) {
+      continue
+    }
+
+    const relativePath = normalizedPath.slice(prefix.length)
+    const [name, ...remainingParts] = relativePath.split("/")
+    if (!name) continue
+
+    const isDirectory = remainingParts.length > 0 || file.is_directory === true
+    if (!entries.has(name) || isDirectory) {
+      entries.set(name, {
+        name,
+        isDirectory,
+        path: `${prefix}${name}`,
+      })
+    }
+  }
+
+  return Array.from(entries.values()).sort((a, b) => {
+    if (a.isDirectory !== b.isDirectory) return a.isDirectory ? -1 : 1
+    return a.name.localeCompare(b.name)
+  })
+}
+
+const renderFileList = ({ route, packageFiles }) => {
+  const directoryPath = route.kind === "directory" ? route.filePath : ""
+  const entries = getDirectoryEntries(packageFiles, directoryPath)
+  const basePath = `/${encodeURIComponent(route.author)}/${encodeURIComponent(
+    route.packageName,
+  )}`
+  const versionSearch = route.version
+    ? `?version=${encodeURIComponent(route.version)}`
+    : ""
+
+  if (entries.length === 0) {
+    return "<p>No files were found in this directory.</p>"
+  }
+
+  return `<ul class="ssr-file-list">${entries
+    .map((entry) => {
+      const routeSegment = entry.isDirectory ? "tree" : "blob"
+      const href = `${basePath}/${routeSegment}/${encodePath(entry.path)}${versionSearch}`
+      return `<li><a href="${escapeHtml(href)}"><span aria-hidden="true">${
+        entry.isDirectory ? "📁" : "📄"
+      }</span> ${escapeHtml(entry.name)}</a></li>`
+    })
+    .join("")}</ul>`
+}
+
+const renderReleaseList = (route, packageReleases) => {
+  if (!packageReleases?.length) return "<p>No releases have been published.</p>"
+  const basePath = `/${encodeURIComponent(route.author)}/${encodeURIComponent(
+    route.packageName,
+  )}/releases`
+
+  return `<ol class="ssr-release-list">${packageReleases
+    .map((release) => {
+      const releaseId = release.package_release_id || release.version
+      return `<li><a href="${basePath}/${encodeURIComponent(
+        releaseId,
+      )}"><strong>${escapeHtml(getReleaseLabel(release))}</strong></a>${
+        getStatus(release)
+          ? ` <span>${escapeHtml(getStatus(release))}</span>`
+          : ""
+      }${
+        release.created_at
+          ? `<time datetime="${escapeHtml(formatDate(release.created_at))}">${escapeHtml(
+              formatDate(release.created_at),
+            )}</time>`
+          : ""
+      }</li>`
+    })
+    .join("")}</ol>`
+}
+
+const renderBuildList = (route, packageBuilds) => {
+  if (!packageBuilds?.length)
+    return "<p>No builds were found for this release.</p>"
+  const basePath = `/${encodeURIComponent(route.author)}/${encodeURIComponent(
+    route.packageName,
+  )}/releases/${encodeURIComponent(route.releaseId)}/builds`
+
+  return `<ol class="ssr-release-list">${packageBuilds
+    .map(
+      (build) =>
+        `<li><a href="${basePath}/${encodeURIComponent(
+          build.package_build_id,
+        )}"><strong>${escapeHtml(build.package_build_id)}</strong></a>${
+          getStatus(build)
+            ? ` <span>${escapeHtml(getStatus(build))}</span>`
+            : ""
+        }${
+          build.created_at
+            ? `<time datetime="${escapeHtml(formatDate(build.created_at))}">${escapeHtml(
+                formatDate(build.created_at),
+              )}</time>`
+            : ""
+        }</li>`,
+    )
+    .join("")}</ol>`
+}
+
+const renderRelease = (packageRelease) =>
+  renderDefinitionList([
+    ["Version", packageRelease?.version],
+    ["Release ID", packageRelease?.package_release_id],
+    ["Status", getStatus(packageRelease)],
+    ["Created", formatDate(packageRelease?.created_at)],
+    ["Latest build", packageRelease?.latest_package_build_id],
+  ])
+
+const renderBuild = (packageBuild) =>
+  renderDefinitionList([
+    ["Build ID", packageBuild?.package_build_id],
+    ["Status", getStatus(packageBuild)],
+    ["Created", formatDate(packageBuild?.created_at)],
+    ["Started", formatDate(packageBuild?.started_at)],
+    ["Completed", formatDate(packageBuild?.completed_at)],
+  ])
+
+const renderRouteContent = ({
+  route,
+  packageRelease,
+  packageFiles,
+  primaryFile,
+  packageReleases,
+  packageBuilds,
+  packageBuild,
+}) => {
+  if (route.kind === "file") {
+    return `<section><h2>${escapeHtml(route.filePath)}</h2>${
+      primaryFile?.content_text == null
+        ? "<p>A text preview is not available for this file.</p>"
+        : `<pre><code>${escapeHtml(primaryFile.content_text)}</code></pre>`
+    }</section>`
+  }
+
+  if (route.kind === "directory") {
+    return `<section><h2>Files in ${escapeHtml(
+      route.filePath ? `(root)/${route.filePath}` : "(root)",
+    )}</h2>${renderFileList({ route, packageFiles })}</section>`
+  }
+
+  if (route.kind === "releases") {
+    return `<section><h2>Releases</h2>${renderReleaseList(
+      route,
+      packageReleases,
+    )}</section>`
+  }
+
+  if (route.kind === "release" || route.kind === "preview") {
+    return `<section><h2>${
+      route.kind === "preview" ? "Release preview" : "Release"
+    } ${escapeHtml(getReleaseLabel(packageRelease))}</h2>${renderRelease(
+      packageRelease,
+    )}${
+      packageBuild ? `<h3>Latest build</h3>${renderBuild(packageBuild)}` : ""
+    }</section>`
+  }
+
+  if (route.kind === "builds") {
+    return `<section><h2>Builds for ${escapeHtml(
+      getReleaseLabel(packageRelease),
+    )}</h2>${renderRelease(packageRelease)}${renderBuildList(
+      route,
+      packageBuilds,
+    )}</section>`
+  }
+
+  if (route.kind === "build") {
+    return `<section><h2>Build ${escapeHtml(
+      packageBuild?.package_build_id || route.buildId,
+    )}</h2>${renderBuild(packageBuild)}</section>`
+  }
+
+  if (route.kind === "settings") {
+    return "<section><h2>Package settings</h2><p>Sign in to manage this package.</p></section>"
+  }
+
+  return `<section><h2>Files</h2>${renderFileList({
+    route,
+    packageFiles,
+  })}</section>${
+    primaryFile?.content_text
+      ? `<article><h2>${escapeHtml(
+          primaryFile.file_path || "README.md",
+        )}</h2><pre><code>${escapeHtml(primaryFile.content_text)}</code></pre></article>`
+      : ""
+  }`
+}
+
+export function renderPackagePageContent(data) {
+  const { route, packageInfo, packageRelease } = data
+  const packageDescription =
+    packageInfo.description ||
+    packageInfo.ai_description ||
+    `A tscircuit package created by ${route.author}.`
+  const packageUrl = `/${encodeURIComponent(route.author)}/${encodeURIComponent(
+    route.packageName,
+  )}`
+
+  return `<style>#loader{display:none}.ssr-package-page{max-width:75rem;margin:0 auto;padding:2rem 1rem;font-family:ui-sans-serif,system-ui,sans-serif;color:#111827}.ssr-package-page nav{font-size:.875rem;margin-bottom:1rem}.ssr-package-page header{border-bottom:1px solid #e5e7eb;padding-bottom:1.5rem;margin-bottom:1.5rem}.ssr-package-page h1{font-size:2rem;margin:.25rem 0}.ssr-package-page h2{font-size:1.25rem;margin:1.5rem 0 .75rem}.ssr-package-page p{line-height:1.6}.ssr-package-page ul,.ssr-package-page ol{padding-left:1.5rem}.ssr-package-page li{margin:.5rem 0}.ssr-package-page a{color:#2563eb;text-decoration:none}.ssr-package-page a:hover{text-decoration:underline}.ssr-package-page pre{overflow:auto;padding:1rem;border:1px solid #e5e7eb;border-radius:.375rem;background:#f9fafb;white-space:pre-wrap}.ssr-package-page dl>div{display:grid;grid-template-columns:minmax(8rem,12rem) 1fr;padding:.5rem 0;border-bottom:1px solid #e5e7eb}.ssr-package-page dt{font-weight:600}.ssr-release-list time{display:block;color:#6b7280;font-size:.875rem}</style><main class="ssr-package-page" data-ssr-package-page="${escapeHtml(
+    route.kind,
+  )}"><nav><a href="/">tscircuit</a> / <a href="/${encodeURIComponent(
+    route.author,
+  )}">${escapeHtml(route.author)}</a> / <a href="${packageUrl}">${escapeHtml(
+    route.packageName,
+  )}</a></nav><header><h1>${escapeHtml(packageInfo.name)}</h1><p>${escapeHtml(
+    packageDescription,
+  )}</p>${
+    packageInfo.ai_usage_instructions
+      ? `<p><strong>Usage:</strong> ${escapeHtml(packageInfo.ai_usage_instructions)}</p>`
+      : ""
+  }${renderDefinitionList([
+    ["Version", packageRelease?.version || packageInfo.latest_version],
+    ["License", packageInfo.license],
+    ["Stars", packageInfo.star_count],
+  ])}</header>${renderRouteContent(data)}</main>`
+}
+
+export function injectPackagePageContent(html, ssrContent) {
+  if (!ssrContent) return html
+  return html.replace(
+    /<div id="root"(?: class="[^"]*")?><\/div>/,
+    `<div id="root" data-server-rendered="true">${ssrContent}</div>`,
+  )
+}
+
+export function serializeForInlineScript(value) {
+  return JSON.stringify(value)
+    .replaceAll("<", "\\u003c")
+    .replaceAll(">", "\\u003e")
+    .replaceAll("&", "\\u0026")
+    .replaceAll("\u2028", "\\u2028")
+    .replaceAll("\u2029", "\\u2029")
+}

--- a/src/lib/populate-query-cache-with-ssr-data.ts
+++ b/src/lib/populate-query-cache-with-ssr-data.ts
@@ -11,43 +11,146 @@ export function populateQueryCacheWithSSRData(queryClient: QueryClient) {
   const ssrPackage = windowAny.SSR_PACKAGE
   const ssrPackageRelease = windowAny.SSR_PACKAGE_RELEASE
   const ssrPackageFiles = windowAny.SSR_PACKAGE_FILES
+  const ssrPackageFile = windowAny.SSR_PACKAGE_FILE
+  const ssrPackageReleases = windowAny.SSR_PACKAGE_RELEASES
+  const ssrPackageBuilds = windowAny.SSR_PACKAGE_BUILDS
+  const ssrPackageBuild = windowAny.SSR_PACKAGE_BUILD
+  const ssrPackageRoute = windowAny.SSR_PACKAGE_ROUTE
 
-  if (!ssrPackage || !ssrPackageRelease) return
+  if (!ssrPackage) return
 
   // Cache lookups by package name and id
   queryClient.setQueryData(["package", ssrPackage.name], ssrPackage)
   queryClient.setQueryData(["package", ssrPackage.package_id], ssrPackage)
   queryClient.setQueryData(["packages", ssrPackage.package_id], ssrPackage)
 
-  queryClient.setQueryData(
-    [
-      "packageRelease",
-      {
-        is_latest: true,
-        package_name: ssrPackage.name,
-        include_ai_review: true,
-      },
-    ],
-    ssrPackageRelease,
-  )
+  if (ssrPackageReleases) {
+    queryClient.setQueryData(
+      ["packageReleases", ssrPackage.package_id],
+      ssrPackageReleases,
+    )
+  }
 
-  queryClient.setQueryData(
-    ["packageRelease", { is_latest: true, package_id: ssrPackage.package_id }],
-    ssrPackageRelease,
-  )
+  if (ssrPackageRelease) {
+    queryClient.setQueryData(
+      [
+        "packageRelease",
+        {
+          is_latest: true,
+          package_name: ssrPackage.name,
+          include_ai_review: true,
+        },
+      ],
+      ssrPackageRelease,
+    )
 
-  queryClient.setQueryData(
-    [
-      "packageRelease",
-      { package_release_id: ssrPackageRelease.package_release_id },
-    ],
-    ssrPackageRelease,
-  )
+    queryClient.setQueryData(
+      [
+        "packageRelease",
+        { is_latest: true, package_id: ssrPackage.package_id },
+      ],
+      ssrPackageRelease,
+    )
 
-  if (ssrPackageFiles && ssrPackageRelease.package_release_id) {
+    queryClient.setQueryData(
+      [
+        "packageRelease",
+        { package_release_id: ssrPackageRelease.package_release_id },
+      ],
+      ssrPackageRelease,
+    )
+
+    queryClient.setQueryData(
+      [
+        "packageRelease",
+        {
+          package_release_id: ssrPackageRelease.package_release_id,
+          include_logs: true,
+        },
+      ],
+      ssrPackageRelease,
+    )
+
+    if (ssrPackageRoute?.releaseId) {
+      queryClient.setQueryData(
+        [
+          "packageRelease",
+          {
+            package_name_with_version: `${ssrPackage.name}@${ssrPackageRoute.releaseId}`,
+            include_logs: true,
+          },
+        ],
+        ssrPackageRelease,
+      )
+      queryClient.setQueryData(
+        [
+          "packageRelease",
+          {
+            package_name_with_version: `${ssrPackage.name}@${ssrPackageRoute.releaseId}`,
+          },
+        ],
+        ssrPackageRelease,
+      )
+    }
+
+    if (ssrPackageRoute?.version) {
+      queryClient.setQueryData(
+        [
+          "packageRelease",
+          {
+            package_name_with_version: `${ssrPackage.name}@${ssrPackageRoute.version}`,
+            include_ai_review: true,
+          },
+        ],
+        ssrPackageRelease,
+      )
+    }
+  }
+
+  if (ssrPackageFiles && ssrPackageRelease?.package_release_id) {
     queryClient.setQueryData(
       ["packageFiles", ssrPackageRelease.package_release_id],
       ssrPackageFiles,
+    )
+  }
+
+  if (
+    ssrPackageFile &&
+    ssrPackageRelease?.package_release_id &&
+    ssrPackageRoute?.filePath
+  ) {
+    queryClient.setQueryData(
+      [
+        "packageFile",
+        {
+          package_release_id: ssrPackageRelease.package_release_id,
+          file_path: ssrPackageRoute.filePath,
+        },
+      ],
+      ssrPackageFile,
+    )
+  }
+
+  if (ssrPackageBuilds && ssrPackageRoute?.releaseId) {
+    queryClient.setQueryData(
+      ["packageBuilds", { package_release_id: ssrPackageRoute.releaseId }],
+      ssrPackageBuilds,
+    )
+    if (ssrPackageRelease?.package_release_id !== ssrPackageRoute.releaseId) {
+      queryClient.setQueryData(
+        [
+          "packageBuilds",
+          { package_release_id: ssrPackageRelease?.package_release_id },
+        ],
+        ssrPackageBuilds,
+      )
+    }
+  }
+
+  if (ssrPackageBuild?.package_build_id) {
+    queryClient.setQueryData(
+      ["packageBuild", ssrPackageBuild.package_build_id, true],
+      ssrPackageBuild,
     )
   }
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,6 +9,7 @@ import { ViteImageOptimizer } from "vite-plugin-image-optimizer"
 import { getNodeHandler } from "winterspec/adapters/node"
 import vercel from "vite-plugin-vercel"
 import type { IncomingMessage, ServerResponse } from "http"
+import { parsePackagePageRoute } from "./server/package-page-ssr.js"
 
 // @ts-ignore
 import winterspecBundle from "./dist/bundle.js"
@@ -107,7 +108,9 @@ function vercelSsrDevPlugin(): Plugin {
           return next()
         }
 
-        if (extname(url)) {
+        const isPackagePage = Boolean(parsePackagePageRoute(url))
+
+        if (extname(url) && !isPackagePage) {
           return next()
         }
 


### PR DESCRIPTION
## Summary

- server-render semantic package content into the initial HTML response instead of returning only the SPA loader
- cover package roots, directory and file routes, releases, release previews, build lists/details, settings, and the legacy package URL
- include route-specific important content such as package metadata, directory listings, README/source text, release metadata, and build status
- preload the same package, release, file, and build records into React Query for the interactive client render
- safely escape rendered content and inline JSON to prevent package data from injecting markup or closing the preload script
- route package paths containing extensions and dotted versions through the local SSR middleware

## Why

Package routes previously injected API data and SEO tags but left the root element empty. Clients without JavaScript—including `curl`, link unfurlers, crawlers, and accessibility tooling—received a loading overlay rather than the actual package content. File URLs such as `blob/index.tsx` and dotted release versions were also mistaken for static assets by the local middleware.

## User and developer impact

Every public package page now returns meaningful semantic HTML on the first response. The browser still transitions into the existing interactive React application, while non-JavaScript consumers can read package metadata and the primary content for the requested route directly from the response body.

## Validation

- `bun test ./bun-tests/package-page-ssr.test.js` (17 tests)
- `bun run typecheck`
- `bun run lint`
- `bun run build`
- verified raw HTML with `curl` for package, directory, `.tsx` file, releases, dotted release version, preview, builds, and build-detail routes
- browser-tested a fresh server-rendered file route through the interactive client render, including the correct release content and hidden loader
