### PR TITLE
Route logged-out dashboard users through the login page

### DIFF
--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -10,7 +10,6 @@ import { useGlobalStore } from "@/hooks/use-global-store"
 import { Link } from "wouter"
 import { PackagesList } from "@/components/PackagesList"
 import { Helmet } from "react-helmet-async"
-import { useSignIn } from "@/hooks/use-sign-in"
 import { useConfirmDeletePackageDialog } from "@/components/dialogs/confirm-delete-package-dialog"
 import { PackageCardSkeleton } from "@/components/PackageCardSkeleton"
 import { PackageCard } from "@/components/PackageCard"
@@ -23,8 +22,6 @@ export const DashboardPage = () => {
 
   const currentUser = useGlobalStore((s) => s.session)
   const isLoggedIn = Boolean(currentUser)
-  const signIn = useSignIn()
-
   const [showAllTrending, setShowAllTrending] = useState(false)
   const [showAllLatest, setShowAllLatest] = useState(false)
   const [packageToDelete, setPackageToDelete] = useState<Package | null>(null)
@@ -114,9 +111,9 @@ export const DashboardPage = () => {
                 <p className="text-gray-600 mb-6 text-center max-w-md text-sm sm:text-base">
                   Log in to access your dashboard and manage your packages.
                 </p>
-                <Button onClick={() => signIn()} variant="default">
-                  Log In
-                </Button>
+                <Link href="/login">
+                  <Button variant="default">Log In</Button>
+                </Link>
               </div>
             ) : (
               <>


### PR DESCRIPTION
**Before:** 

https://github.com/user-attachments/assets/c57681e7-b64a-40cb-874d-b55f04b5b6e2


**After:** 

https://github.com/user-attachments/assets/ab31cb16-8aeb-4e1c-8dc7-ab738af5007b



### Motivation

When a logged-out user visits `/dashboard` and clicks **Log In**, the dashboard invokes the GitHub authentication flow directly. This bypasses `/login`, preventing the user from seeing and selecting the available authentication providers.

### Change

- Replace the dashboard’s direct GitHub sign-in action with an internal link to `/login`.
- Remove the now-unused `useSignIn` hook from the dashboard.
- Reuse the application’s existing login route and client-side navigation pattern.

### User impact

Logged-out dashboard users are now taken to the standard login page, where they can choose their preferred authentication method instead of being sent directly to GitHub.

### Tests

- Confirmed TypeScript compilation passes with `bun run typecheck`.
- Verified the dashboard login action targets `/login`.