### PR TITLE
Fix user settings to normalize tscircuit handles into valid lowercase slugs

### DIFF
--- a/src/pages/user-settings.tsx
+++ b/src/pages/user-settings.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react"
+import { useState, useEffect, useMemo } from "react"
 import { useForm } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { z } from "zod"
@@ -33,15 +33,22 @@ import { useApiBaseUrl } from "@/hooks/use-packages-base-api-url"
 import { useLogout } from "@/hooks/use-logout"
 import { useConfirmDeleteAccountDialog } from "@/components/dialogs/confirm-delete-account-dialog"
 import { cn } from "@/lib/utils"
+import { normalizeName } from "@/lib/utils/normalizeName"
+
+const normalizeTscircuitHandle = (handle: string) =>
+  normalizeName(handle).toLowerCase()
 
 const accountSettingsSchema = z.object({
   tscircuit_handle: z
     .string()
     .min(1, "Handle is required")
-    .max(40, "Handle must be 40 characters or less")
-    .regex(
-      /^[0-9A-Za-z_-]+$/,
-      "Handle may only contain letters, numbers, underscores, and hyphens",
+    .refine(
+      (handle) => normalizeTscircuitHandle(handle).length > 0,
+      "Handle is required",
+    )
+    .refine(
+      (handle) => normalizeTscircuitHandle(handle).length <= 40,
+      "Handle must be 40 characters or less after normalization",
     ),
 })
 
@@ -135,6 +142,11 @@ export default function UserSettingsPage() {
     },
   )
   const account = accountResponse?.account
+  const handleValue = form.watch("tscircuit_handle")
+  const normalizedHandle = useMemo(() => {
+    if (!handleValue.trim()) return ""
+    return normalizeTscircuitHandle(handleValue)
+  }, [handleValue])
 
   const { organization: personalOrg, refetch: refetchPersonalOrg } =
     useOrganization({
@@ -277,7 +289,7 @@ export default function UserSettingsPage() {
 
   const onSubmit = (data: AccountSettingsFormData) => {
     updateAccountMutation.mutate({
-      tscircuit_handle: data.tscircuit_handle,
+      tscircuit_handle: normalizeTscircuitHandle(data.tscircuit_handle),
     })
   }
 
@@ -393,7 +405,8 @@ export default function UserSettingsPage() {
                         onClick={form.handleSubmit(onSubmit)}
                         disabled={
                           updateAccountMutation.isLoading ||
-                          !form.formState.isDirty
+                          !form.formState.isDirty ||
+                          !normalizedHandle
                         }
                       >
                         {updateAccountMutation.isLoading && (
@@ -427,6 +440,13 @@ export default function UserSettingsPage() {
                             />
                           </FormControl>
                           <FormMessage className="mt-2" />
+                          {field.value.trim() &&
+                            normalizedHandle !== field.value.trim() &&
+                            normalizedHandle && (
+                              <p className="text-xs text-gray-500 mt-2">
+                                Will be normalized to: {normalizedHandle}
+                              </p>
+                            )}
                           {!account?.tscircuit_handle && (
                             <p className="text-xs text-blue-600 mt-1.5">
                               A handle is required to use your account.


### PR DESCRIPTION
Before: 

https://github.com/user-attachments/assets/49227c88-5b51-42a0-92d2-2200f7c0321b

After: 

https://github.com/user-attachments/assets/c518e3ef-b926-4a3b-a9ba-21c714317dcc

### Motivation

User settings submitted tscircuit handles without applying the same normalization behavior used by package settings. Handles containing uppercase letters, spaces, accents, or unsupported characters reached the API and failed with:

> `tscircuit_handle must be lowercase and may only contain lowercase letters, numbers, underscores, and hyphens`

This prevented users from saving otherwise valid handles that could be safely normalized.

For example, `My TSCircuit Handle` is previewed and submitted as `my-tscircuit-handle`.

### User impact

Users can enter natural handle text without encountering an avoidable API validation failure. The settings page now previews and submits a value that conforms to the backend handle requirements.

### Root cause

The user-settings form validated and submitted the raw input, while package settings already normalized names before saving. This caused inconsistent behavior between the two settings pages and allowed invalid uppercase values to reach the account update API.
