### PR TITLE
Fix zero-height mobile containers preventing 3D preview and code editor rendering

### DIFF
--- a/src/components/package-port/CodeAndPreview.tsx
+++ b/src/components/package-port/CodeAndPreview.tsx
@@ -256,7 +256,7 @@ export function CodeAndPreview({ pkg, projectUrl, isPackageFetched }: Props) {
         <div
           className={cn(
             "hidden flex-col md:flex border-r border-gray-200 bg-gray-50",
-            state.showPreview ? "w-full md:w-1/2" : "w-full flex",
+            state.showPreview ? "w-full md:w-1/2" : "w-full flex flex-1",
           )}
         >
           <CodeEditor
@@ -289,7 +289,7 @@ export function CodeAndPreview({ pkg, projectUrl, isPackageFetched }: Props) {
         </div>
         <div
           className={cn(
-            "flex min-h-0 p-0 flex-col overflow-y-hidden",
+            "flex flex-1 min-h-0 p-0 flex-col overflow-y-hidden",
             state.fullScreen
               ? "fixed inset-0 z-50 bg-white p-4 overflow-hidden"
               : "w-full md:w-1/2",


### PR DESCRIPTION
Before: 

https://github.com/user-attachments/assets/936e68fd-8390-4b37-a64a-10bb6602907c


After: 

https://github.com/user-attachments/assets/63da030b-33dc-4447-b4de-fe65d012be13


### Motivation

The package editor’s 3D preview failed to render on mobile devices. When the responsive layout switched from a side-by-side row to a stacked column, the preview wrapper had no flexible height and collapsed to `0px`.

`SuspenseRunFrame` and its Three.js canvas depend on a non-zero parent height to calculate their rendering dimensions. As a result, the preview appeared completely blank even though the circuit loaded successfully.

The code editor was vulnerable to the same collapse when users switched to the Code view on mobile.

### Root cause

The mobile column layout relied on child containers expanding into the available vertical space, but the preview and code editor wrappers did not consistently use `flex-1`.

Their children used full-height layouts without receiving a defined height from their parents, causing the wrappers to collapse.

### User impact

Mobile users can now:

- Open a package and see its 3D preview.
- Switch between Preview and Code without either view collapsing.
- Continue using the existing desktop split layout without behavior changes.

### Reproduction

Before this fix:

1. Open a package editor on a mobile-width screen.
2. Switch to the 3D preview.
3. Observe that the preview area is blank because its wrapper has zero height.
4. Switch to the Code view and observe the same potential height collapse.

After this fix, both containers expand into the remaining vertical space and render normally.
