### PR TITLE
Fix expired session handling in JLCPCB import

### DIFF
--- a/bun-tests/fake-snippets-api/routes/sessions/list.test.ts
+++ b/bun-tests/fake-snippets-api/routes/sessions/list.test.ts
@@ -1,0 +1,11 @@
+import { expect, test } from "bun:test"
+import { getTestServer } from "bun-tests/fake-snippets-api/fixtures/get-test-server"
+
+test("POST /api/sessions/list validates an authenticated session", async () => {
+  const { axios } = await getTestServer()
+
+  const response = await axios.post("/api/sessions/list", {})
+
+  expect(response.status).toBe(200)
+  expect(response.data.sessions).toBeArray()
+})

--- a/fake-snippets-api/routes/api/sessions/list.ts
+++ b/fake-snippets-api/routes/api/sessions/list.ts
@@ -1,0 +1,30 @@
+import { withRouteSpec } from "fake-snippets-api/lib/middleware/with-winter-spec"
+import { z } from "zod"
+
+export default withRouteSpec({
+  auth: "session",
+  methods: ["GET", "POST"],
+  commonParams: z.object({
+    is_cli_session: z.boolean().optional(),
+  }),
+  jsonResponse: z.object({
+    sessions: z.array(
+      z.object({
+        session_id: z.string(),
+        expires_at: z.string(),
+      }),
+    ),
+  }),
+})(async (req, ctx) => {
+  const sessions = ctx.db.getSessions({
+    account_id: ctx.auth.account_id,
+    is_cli_session: req.commonParams.is_cli_session,
+  })
+
+  return ctx.json({
+    sessions: sessions.map(({ session_id, expires_at }) => ({
+      session_id,
+      expires_at,
+    })),
+  })
+})

--- a/playwright-tests/jlcpcb-import-session.spec.ts
+++ b/playwright-tests/jlcpcb-import-session.spec.ts
@@ -1,0 +1,45 @@
+import { expect, test } from "@playwright/test"
+
+test("shows sign-in guidance instead of the JLCPCB dialog for an expired session", async ({
+  page,
+}) => {
+  await page.addInitScript(() => {
+    window.localStorage.setItem(
+      "session_store",
+      JSON.stringify({
+        state: {
+          session: {
+            token: "stale-session-token",
+            account_id: "account-1234",
+            session_id: "expired-session",
+            github_username: "testuser",
+            tscircuit_handle: "testuser",
+          },
+        },
+        version: 0,
+      }),
+    )
+  })
+
+  await page.route("**/api/sessions/list", async (route) => {
+    await route.fulfill({
+      status: 401,
+      contentType: "application/json",
+      body: JSON.stringify({
+        error_code: "session_expired",
+        message: "Session expired",
+      }),
+    })
+  })
+
+  await page.goto("http://127.0.0.1:5177/quickstart")
+  await page.getByRole("button", { name: "Import JLCPCB" }).click()
+
+  await expect(page.getByText("Session Expired")).toBeVisible()
+  await expect(
+    page.getByText("Your session has expired. Click here to sign in again."),
+  ).toBeVisible()
+  await expect(
+    page.getByRole("dialog", { name: /Import JLCPCB Parts Component/i }),
+  ).not.toBeVisible()
+})

--- a/src/components/dialogs/import-component-dialog.tsx
+++ b/src/components/dialogs/import-component-dialog.tsx
@@ -1,12 +1,13 @@
-import { useEffect, useRef } from "react"
-import { useApiBaseUrl } from "@/hooks/use-packages-base-api-url"
-import { createUseDialog } from "./create-use-dialog"
-import {
-  ImportComponentDialog2 as RunframeImportComponentDialog,
-  type ImportComponentDialog2Props,
-} from "@tscircuit/runframe/runner"
+import { useAxios } from "@/hooks/use-axios"
 import { useGlobalStore } from "@/hooks/use-global-store"
+import { useApiBaseUrl } from "@/hooks/use-packages-base-api-url"
 import { useToast } from "@/hooks/use-toast"
+import {
+  type ImportComponentDialog2Props,
+  ImportComponentDialog2 as RunframeImportComponentDialog,
+} from "@tscircuit/runframe/runner"
+import { useEffect, useRef, useState } from "react"
+import { createUseDialog } from "./create-use-dialog"
 
 export type ImportComponentDialogProps = {
   open: boolean
@@ -26,19 +27,58 @@ export const ImportComponentDialog = ({
   ...rest
 }: ImportComponentDialogProps) => {
   const session = useGlobalStore((s) => s.session)
+  const axios = useAxios()
   const apiBaseUrl = useApiBaseUrl()
   const { toastLibrary } = useToast()
-  const prevOpenRef = useRef(false)
+  const sessionCheckStartedRef = useRef(false)
+  const [validatedSessionToken, setValidatedSessionToken] = useState<
+    string | null
+  >(null)
 
   useEffect(() => {
-    if (open && !prevOpenRef.current && !session) {
-      toastLibrary.error("You must be signed in to import from JLCPCB")
-      onOpenChange(false)
+    if (!open) {
+      sessionCheckStartedRef.current = false
+      setValidatedSessionToken(null)
+      return
     }
-    prevOpenRef.current = open
-  }, [open, session, onOpenChange])
 
-  if (!session) {
+    if (!session?.token) {
+      if (!sessionCheckStartedRef.current) {
+        toastLibrary.error("Please sign in to import from JLCPCB")
+      }
+      onOpenChange(false)
+      return
+    }
+
+    let cancelled = false
+    sessionCheckStartedRef.current = true
+    setValidatedSessionToken(null)
+
+    axios
+      .post("/sessions/list", {})
+      .then(() => {
+        if (!cancelled) {
+          setValidatedSessionToken(session.token)
+        }
+      })
+      .catch((error: any) => {
+        if (cancelled) return
+
+        const status = error?.response?.status ?? error?.status
+        if (status !== 401) {
+          toastLibrary.error(
+            "We couldn't verify your session. Please try again.",
+          )
+        }
+        onOpenChange(false)
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [axios, open, onOpenChange, session?.token, toastLibrary])
+
+  if (!session || validatedSessionToken !== session.token) {
     return null
   }
 

--- a/src/hooks/use-axios.tsx
+++ b/src/hooks/use-axios.tsx
@@ -1,10 +1,11 @@
-import axios from "redaxios"
+import { getAuthenticationErrorCopy } from "@/lib/auth/authentication-error-copy"
+import { getLoginPath } from "@/lib/utils/handle-redirect"
 import { useMemo } from "react"
+import axios from "redaxios"
+import { useLocation } from "wouter"
 import { useGlobalStore } from "./use-global-store"
 import { useApiBaseUrl } from "./use-packages-base-api-url"
 import { ToastContent, useToast } from "./use-toast"
-import { useLocation } from "wouter"
-import { getLoginPath } from "@/lib/utils/handle-redirect"
 
 export const useAxios = () => {
   const snippetsBaseApiUrl = useApiBaseUrl()
@@ -36,9 +37,8 @@ export const useAxios = () => {
       const errorCode =
         error?.data?.error_code || error?.data?.error?.error_code
       if (status === 401) {
-        const isSessionInvalid =
-          errorCode === "session_not_found" || errorCode === "session_expired"
-        if (isSessionInvalid) {
+        const authErrorCopy = getAuthenticationErrorCopy(errorCode)
+        if (authErrorCopy.shouldClearSession) {
           setSession(null)
         }
         toastLibrary.custom(
@@ -50,12 +50,8 @@ export const useAxios = () => {
               className="cursor-pointer"
             >
               <ToastContent
-                title={isSessionInvalid ? "Session Expired" : "Unauthorized"}
-                description={
-                  isSessionInvalid
-                    ? "Your session has expired. Click here to sign in again"
-                    : "You may need to sign in. Click here to sign in again"
-                }
+                title={authErrorCopy.title}
+                description={authErrorCopy.description}
                 variant={"destructive"}
                 t={t}
               />

--- a/src/lib/auth/authentication-error-copy.test.ts
+++ b/src/lib/auth/authentication-error-copy.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test"
+import { getAuthenticationErrorCopy } from "./authentication-error-copy"
+
+describe("getAuthenticationErrorCopy", () => {
+  test.each(["session_expired", "session_not_found"])(
+    "uses expired-session guidance for %s",
+    (errorCode) => {
+      expect(getAuthenticationErrorCopy(errorCode)).toEqual({
+        shouldClearSession: true,
+        title: "Session Expired",
+        description: "Your session has expired. Click here to sign in again.",
+      })
+    },
+  )
+
+  test.each(["no_token", "invalid_token"])(
+    "asks the user to sign in again for %s",
+    (errorCode) => {
+      expect(getAuthenticationErrorCopy(errorCode)).toEqual({
+        shouldClearSession: true,
+        title: "Sign In Required",
+        description: "Please sign in again to continue.",
+      })
+    },
+  )
+
+  test("does not clear local session state for an unknown 401", () => {
+    expect(getAuthenticationErrorCopy("unknown")).toEqual({
+      shouldClearSession: false,
+      title: "Sign In Required",
+      description: "Please sign in again to continue.",
+    })
+  })
+})

--- a/src/lib/auth/authentication-error-copy.ts
+++ b/src/lib/auth/authentication-error-copy.ts
@@ -1,0 +1,25 @@
+const INVALID_SESSION_ERROR_CODES = new Set([
+  "no_token",
+  "invalid_token",
+  "session_not_found",
+  "session_expired",
+])
+
+const EXPIRED_SESSION_ERROR_CODES = new Set([
+  "session_not_found",
+  "session_expired",
+])
+
+export const getAuthenticationErrorCopy = (errorCode?: string) => {
+  const isExpiredSession =
+    errorCode !== undefined && EXPIRED_SESSION_ERROR_CODES.has(errorCode)
+
+  return {
+    shouldClearSession:
+      errorCode !== undefined && INVALID_SESSION_ERROR_CODES.has(errorCode),
+    title: isExpiredSession ? "Session Expired" : "Sign In Required",
+    description: isExpiredSession
+      ? "Your session has expired. Click here to sign in again."
+      : "Please sign in again to continue.",
+  }
+}


### PR DESCRIPTION

<img width="1205" height="645" src="https://github.com/user-attachments/assets/92738da3-6ba8-442e-9d4e-cf11499be6fa" />


## Motivation

When a user is signed out or their session has expired, the JLCPCB import dialog displays a raw `HTTP 401` error. This technical message does not explain what went wrong or how the user can recover.

The import flow should clearly tell the user that authentication is required and provide an easy way to sign in again.

## Summary

- Validate the user session before opening the JLCPCB import dialog
- Prevent the dialog from displaying raw `HTTP 401` errors
- Show clear messages for missing, invalid, or expired sessions
- Clear invalid or expired sessions from local state
- Provide a clickable sign-in toast for session errors
- Add the session validation route to the fake API
- Add regression coverage for the expired-session flow

## Testing

- `bun run typecheck`
- Auth error-copy unit tests
- Session validation API test
- Playwright expired-session flow test
- Biome checks