### PR TITLE
feat: support active section selection via tab query param in settings pages

### DIFF
--- a/src/components/ViewPackagePage/components/mobile-sidebar.tsx
+++ b/src/components/ViewPackagePage/components/mobile-sidebar.tsx
@@ -222,7 +222,7 @@ const MobileSidebar = ({
           <>
             {canManageOrg && packageInfo && (
               <Link
-                href={`/${packageInfo.name}/settings`}
+                href={`/${packageInfo.name}/settings?tab=github`}
                 className="flex items-center hover:underline hover:underline-offset-2 cursor-pointer hover:decoration-gray-500"
                 title="Connect GitHub"
               >

--- a/src/components/ViewPackagePage/components/sidebar-about-section.tsx
+++ b/src/components/ViewPackagePage/components/sidebar-about-section.tsx
@@ -266,7 +266,7 @@ export default function SidebarAboutSection({
           <>
             {canManageOrg && packageInfo && (
               <Link
-                href={`/${packageInfo.name}/settings`}
+                href={`/${packageInfo.name}/settings?tab=github`}
                 className="flex items-center hover:underline hover:underline-offset-2 cursor-pointer hover:decoration-gray-500"
                 title="Connect GitHub"
               >

--- a/src/hooks/use-settings-section.ts
+++ b/src/hooks/use-settings-section.ts
@@ -1,0 +1,28 @@
+import { useEffect, useState } from "react"
+
+const getSettingsSectionFromQuery = <SettingsSection extends string>(
+  validSections: readonly SettingsSection[],
+  defaultSection: SettingsSection,
+): SettingsSection => {
+  if (typeof window === "undefined") return defaultSection
+
+  const tab = new URLSearchParams(window.location.search).get("tab")
+  return validSections.includes(tab as SettingsSection)
+    ? (tab as SettingsSection)
+    : defaultSection
+}
+
+export const useSettingsSection = <SettingsSection extends string>(
+  validSections: readonly SettingsSection[],
+  defaultSection: SettingsSection,
+) => {
+  const [activeSection, setActiveSection] = useState<SettingsSection>(() =>
+    getSettingsSectionFromQuery(validSections, defaultSection),
+  )
+
+  useEffect(() => {
+    setActiveSection(getSettingsSectionFromQuery(validSections, defaultSection))
+  }, [defaultSection, validSections])
+
+  return [activeSection, setActiveSection] as const
+}

--- a/src/pages/organization-settings.tsx
+++ b/src/pages/organization-settings.tsx
@@ -140,7 +140,24 @@ export default function OrganizationSettingsPage() {
   const { toast } = useToast()
   const session = useGlobalStore((s) => s.session)
 
-  const [activeSection, setActiveSection] = useState<SettingsSection>("general")
+  const [activeSection, setActiveSection] = useState<SettingsSection>(() => {
+    if (typeof window !== "undefined") {
+      const tab = new URLSearchParams(window.location.search).get("tab") as SettingsSection
+      if (tab && ["general", "members", "domains", "github", "danger"].includes(tab)) {
+        return tab
+      }
+    }
+    return "general"
+  })
+
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      const tab = new URLSearchParams(window.location.search).get("tab") as SettingsSection
+      if (tab && ["general", "members", "domains", "github", "danger"].includes(tab)) {
+        setActiveSection(tab)
+      }
+    }
+  }, [])
 
   const {
     organization,

--- a/src/pages/organization-settings.tsx
+++ b/src/pages/organization-settings.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from "react"
+import { useState, useMemo } from "react"
 import { useForm } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { z } from "zod"
@@ -60,6 +60,7 @@ import { useApiBaseUrl } from "@/hooks/use-packages-base-api-url"
 import { useAvatarUploadDialog } from "@/hooks/use-avatar-upload-dialog"
 import { cn } from "@/lib/utils"
 import { OrgDomainsList } from "@/components/org-settings/OrgDomainsList"
+import { useSettingsSection } from "@/hooks/use-settings-section"
 
 const organizationSettingsSchema = z.object({
   tscircuit_handle: z
@@ -77,6 +78,14 @@ const organizationSettingsSchema = z.object({
 type OrganizationSettingsFormData = z.infer<typeof organizationSettingsSchema>
 
 type SettingsSection = "general" | "members" | "domains" | "github" | "danger"
+
+const settingsSections = [
+  "general",
+  "members",
+  "domains",
+  "github",
+  "danger",
+] as const
 
 const navItems: { id: SettingsSection; label: string }[] = [
   { id: "general", label: "General" },
@@ -140,24 +149,10 @@ export default function OrganizationSettingsPage() {
   const { toast } = useToast()
   const session = useGlobalStore((s) => s.session)
 
-  const [activeSection, setActiveSection] = useState<SettingsSection>(() => {
-    if (typeof window !== "undefined") {
-      const tab = new URLSearchParams(window.location.search).get("tab") as SettingsSection
-      if (tab && ["general", "members", "domains", "github", "danger"].includes(tab)) {
-        return tab
-      }
-    }
-    return "general"
-  })
-
-  useEffect(() => {
-    if (typeof window !== "undefined") {
-      const tab = new URLSearchParams(window.location.search).get("tab") as SettingsSection
-      if (tab && ["general", "members", "domains", "github", "danger"].includes(tab)) {
-        setActiveSection(tab)
-      }
-    }
-  }, [])
+  const [activeSection, setActiveSection] = useSettingsSection(
+    settingsSections,
+    "general",
+  )
 
   const {
     organization,

--- a/src/pages/organization-settings.tsx
+++ b/src/pages/organization-settings.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from "react"
+import { useEffect, useMemo, useState } from "react"
 import { useForm } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { z } from "zod"

--- a/src/pages/package-settings.tsx
+++ b/src/pages/package-settings.tsx
@@ -130,7 +130,24 @@ export default function PackageSettingsPage() {
   const qc = useQueryClient()
   const session = useGlobalStore((s) => s.session)
 
-  const [activeSection, setActiveSection] = useState<SettingsSection>("general")
+  const [activeSection, setActiveSection] = useState<SettingsSection>(() => {
+    if (typeof window !== "undefined") {
+      const tab = new URLSearchParams(window.location.search).get("tab") as SettingsSection
+      if (tab && ["general", "domains", "github", "danger"].includes(tab)) {
+        return tab
+      }
+    }
+    return "general"
+  })
+
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      const tab = new URLSearchParams(window.location.search).get("tab") as SettingsSection
+      if (tab && ["general", "domains", "github", "danger"].includes(tab)) {
+        setActiveSection(tab)
+      }
+    }
+  }, [])
 
   const {
     packageInfo,

--- a/src/pages/package-settings.tsx
+++ b/src/pages/package-settings.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from "react"
+import { useEffect, useMemo, useState } from "react"
 import { useParams, useLocation, Redirect, Link } from "wouter"
 import { Helmet } from "react-helmet-async"
 import { useMutation, useQueryClient } from "react-query"

--- a/src/pages/package-settings.tsx
+++ b/src/pages/package-settings.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from "react"
+import { useState, useMemo } from "react"
 import { useParams, useLocation, Redirect, Link } from "wouter"
 import { Helmet } from "react-helmet-async"
 import { useMutation, useQueryClient } from "react-query"
@@ -49,8 +49,11 @@ import {
 } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { PackageDomainsList } from "@/components/package-settings/PackageDomainsList"
+import { useSettingsSection } from "@/hooks/use-settings-section"
 
 type SettingsSection = "general" | "domains" | "github" | "danger"
+
+const settingsSections = ["general", "domains", "github", "danger"] as const
 
 const navItems: { id: SettingsSection; label: string }[] = [
   { id: "general", label: "General" },
@@ -130,24 +133,10 @@ export default function PackageSettingsPage() {
   const qc = useQueryClient()
   const session = useGlobalStore((s) => s.session)
 
-  const [activeSection, setActiveSection] = useState<SettingsSection>(() => {
-    if (typeof window !== "undefined") {
-      const tab = new URLSearchParams(window.location.search).get("tab") as SettingsSection
-      if (tab && ["general", "domains", "github", "danger"].includes(tab)) {
-        return tab
-      }
-    }
-    return "general"
-  })
-
-  useEffect(() => {
-    if (typeof window !== "undefined") {
-      const tab = new URLSearchParams(window.location.search).get("tab") as SettingsSection
-      if (tab && ["general", "domains", "github", "danger"].includes(tab)) {
-        setActiveSection(tab)
-      }
-    }
-  }, [])
+  const [activeSection, setActiveSection] = useSettingsSection(
+    settingsSections,
+    "general",
+  )
 
   const {
     packageInfo,

--- a/src/pages/user-settings.tsx
+++ b/src/pages/user-settings.tsx
@@ -111,7 +111,24 @@ export default function UserSettingsPage() {
   const apiBaseUrl = useApiBaseUrl()
   const { handleLogout } = useLogout()
 
-  const [activeSection, setActiveSection] = useState<SettingsSection>("general")
+  const [activeSection, setActiveSection] = useState<SettingsSection>(() => {
+    if (typeof window !== "undefined") {
+      const tab = new URLSearchParams(window.location.search).get("tab") as SettingsSection
+      if (tab && ["general", "github", "danger"].includes(tab)) {
+        return tab
+      }
+    }
+    return "general"
+  })
+
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      const tab = new URLSearchParams(window.location.search).get("tab") as SettingsSection
+      if (tab && ["general", "github", "danger"].includes(tab)) {
+        setActiveSection(tab)
+      }
+    }
+  }, [])
 
   const { Dialog: DeleteAccountDialog, openDialog: openDeleteAccountDialog } =
     useConfirmDeleteAccountDialog()

--- a/src/pages/user-settings.tsx
+++ b/src/pages/user-settings.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react"
+import { useState } from "react"
 import { useForm } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { z } from "zod"
@@ -31,6 +31,7 @@ import { useOrganization } from "@/hooks/use-organization"
 import { useAvatarUploadDialog } from "@/hooks/use-avatar-upload-dialog"
 import { useApiBaseUrl } from "@/hooks/use-packages-base-api-url"
 import { useLogout } from "@/hooks/use-logout"
+import { useSettingsSection } from "@/hooks/use-settings-section"
 import { useConfirmDeleteAccountDialog } from "@/components/dialogs/confirm-delete-account-dialog"
 import { cn } from "@/lib/utils"
 
@@ -48,6 +49,8 @@ const accountSettingsSchema = z.object({
 type AccountSettingsFormData = z.infer<typeof accountSettingsSchema>
 
 type SettingsSection = "general" | "github" | "danger"
+
+const settingsSections = ["general", "github", "danger"] as const
 
 const navItems: { id: SettingsSection; label: string }[] = [
   { id: "general", label: "General" },
@@ -111,24 +114,10 @@ export default function UserSettingsPage() {
   const apiBaseUrl = useApiBaseUrl()
   const { handleLogout } = useLogout()
 
-  const [activeSection, setActiveSection] = useState<SettingsSection>(() => {
-    if (typeof window !== "undefined") {
-      const tab = new URLSearchParams(window.location.search).get("tab") as SettingsSection
-      if (tab && ["general", "github", "danger"].includes(tab)) {
-        return tab
-      }
-    }
-    return "general"
-  })
-
-  useEffect(() => {
-    if (typeof window !== "undefined") {
-      const tab = new URLSearchParams(window.location.search).get("tab") as SettingsSection
-      if (tab && ["general", "github", "danger"].includes(tab)) {
-        setActiveSection(tab)
-      }
-    }
-  }, [])
+  const [activeSection, setActiveSection] = useSettingsSection(
+    settingsSections,
+    "general",
+  )
 
   const { Dialog: DeleteAccountDialog, openDialog: openDeleteAccountDialog } =
     useConfirmDeleteAccountDialog()

--- a/src/pages/user-settings.tsx
+++ b/src/pages/user-settings.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react"
+import { useEffect, useState } from "react"
 import { useForm } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { z } from "zod"


### PR DESCRIPTION
Motivation: On clicking the connect github misleading to user to general settings which seems to a bad user experience 

Before:

https://github.com/user-attachments/assets/3e8e0fb4-38c2-4b52-97c9-15446d6a304d



After: 

https://github.com/user-attachments/assets/729fea13-50ce-43f8-88f4-08e9916c5a92


## Description
- Adds support for selecting active settings tab via ?tab= query parameter across user, organization, and package settings pages.
- Updates sidebar links to direct users directly to ?tab=github when opening package settings.