### PR TITLE
Update LED and switch connections in template

### DIFF
--- a/src/lib/templates/usb-c-led-flashlight-template.ts
+++ b/src/lib/templates/usb-c-led-flashlight-template.ts
@@ -19,10 +19,10 @@ export default () => {
       <trace from="USBC.VBUS1" to="net.VBUS" />
       <trace from="USBC.VBUS2" to="net.VBUS" />
       
-      <trace from="LED.neg" to="net.GND" />
-      <trace from=".R1 > .neg" to="LED.pos" />
+      <trace from="LED.pin2" to="net.GND" />
+      <trace from=".R1 > .pin2" to="LED.pin1" />
       
-      <trace from="SW1.pin2" to="R1.pos" />
+      <trace from="SW1.pin2" to="R1.pin1" />
       <trace from="SW1.pin3" to="net.VBUS" />
     </board>
   )


### PR DESCRIPTION
Motivation: Quickstart usb-c-led-flashlight having led wrong led pin label, leaving user bad experience.

Before: 
<img width="684" height="402" alt="image" src="https://github.com/user-attachments/assets/0e580d13-dac3-4181-bf42-fd6c06019c8c" />

After: 

<img width="624" height="452" alt="image" src="https://github.com/user-attachments/assets/5910f2b6-595d-4992-b8a2-c4576b1f8d6e" />
