### PR TITLE
Add /discord redirect

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -46,6 +46,11 @@
       "permanent": false
     },
     {
+      "source": "/discord",
+      "destination": "https://discord.gg/V7FGE5ZCbA",
+      "permanent": false
+    },
+    {
       "source": "/legal/terms-of-service",
       "destination": "https://registry.tscircuit.com/legal/terms-of-service.html",
       "permanent": false


### PR DESCRIPTION
## What changed

- Added a temporary redirect from `/discord` to the same Discord invite used by `/join`.

## Why

This gives visitors a memorable `tscircuit.com/discord` URL while keeping the Discord destination consistent with the existing join route.

## Impact

Requests to `https://tscircuit.com/discord` will redirect to the current tscircuit Discord invite.

## Validation

- Parsed `vercel.json` successfully.
- Verified `/discord` and `/join` have identical destinations and redirect modes.
- Ran `git diff --check`.