### PR TITLE
Add /door photo redirect

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -51,6 +51,11 @@
       "permanent": false
     },
     {
+      "source": "/door",
+      "destination": "https://photos.app.goo.gl/U2QuQWjZHKPZqND26",
+      "permanent": false
+    },
+    {
       "source": "/legal/terms-of-service",
       "destination": "https://registry.tscircuit.com/legal/terms-of-service.html",
       "permanent": false


### PR DESCRIPTION
## Summary

- add a Vercel redirect from `/door` to the supplied Google Photos album
- keep the redirect non-permanent, matching the repository's existing short-link redirects

## Why

Visitors to `tscircuit.com/door` should be sent directly to the shared photo album.

## Impact

Requests to `/door` will receive a temporary redirect to `https://photos.app.goo.gl/U2QuQWjZHKPZqND26`.

## Validation

- `jq` assertion for the exact redirect source, destination, and permanence
- `bunx @biomejs/biome@1.9.4 check vercel.json`
- `git diff --check`