### PR TITLE
Update monaco-code-editor

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -58,7 +58,7 @@
         "@tscircuit/layout": "^0.0.29",
         "@tscircuit/math-utils": "^0.0.36",
         "@tscircuit/mm": "^0.0.8",
-        "@tscircuit/monaco-code-editor": "git+https://github.com/tscircuit/monaco-code-editor.git#0cbbad9",
+        "@tscircuit/monaco-code-editor": "git+https://github.com/tscircuit/monaco-code-editor.git#cb64d17",
         "@tscircuit/order-dialog": "git+https://github.com/tscircuit/order-dialog.git#55a2839",
         "@tscircuit/pcb-viewer": "1.11.376",
         "@tscircuit/prompt-benchmarks": "^0.0.28",
@@ -843,7 +843,7 @@
 
     "@tscircuit/mm": ["@tscircuit/mm@0.0.8", "", { "peerDependencies": { "typescript": "^5.0.0" } }, "sha512-nl7nxE7AhARbKuobflI0LUzoir7+wJyvwfPw6bzA/O0Q3YTcH3vBkU/Of+V/fp6ht+AofiCXj7YAH9E446138Q=="],
 
-    "@tscircuit/monaco-code-editor": ["@tscircuit/monaco-code-editor@github:tscircuit/monaco-code-editor#0cbbad9", { "dependencies": { "@fontsource-variable/geist": "^5.2.9", "@monaco-editor/react": "^4.7.0", "@radix-ui/react-slot": "^1.3.0", "@shikijs/monaco": "^4.3.0", "@shikijs/vscode-textmate": "^10.0.2", "@typescript/ata": "^0.9.8", "class-variance-authority": "^0.7.1", "clsx": "^2.1.1", "lucide-react": "^1.21.0", "monaco-editor": "^0.55.1", "radix-ui": "^1.6.0", "shiki": "^4.3.0", "tailwind-merge": "^3.6.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18", "typescript": ">=5.6.3 <7" } }, "tscircuit-monaco-code-editor-0cbbad9", "sha512-FUtFvaQ0K/xGwcKIIaoOTZX674Kos/JqjiMx84yIpcBET9ZxbeRRVfnM9X1F11zDnF2Gk0BMuoa3vfWbzBcMJg=="],
+    "@tscircuit/monaco-code-editor": ["@tscircuit/monaco-code-editor@github:tscircuit/monaco-code-editor#cb64d17", { "dependencies": { "@fontsource-variable/geist": "^5.2.9", "@monaco-editor/react": "^4.7.0", "@radix-ui/react-slot": "^1.3.0", "@shikijs/monaco": "^4.3.0", "@shikijs/vscode-textmate": "^10.0.2", "@typescript/ata": "^0.9.8", "class-variance-authority": "^0.7.1", "clsx": "^2.1.1", "lucide-react": "^1.21.0", "monaco-editor": "^0.55.1", "radix-ui": "^1.6.0", "shiki": "^4.3.0", "tailwind-merge": "^3.6.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18", "typescript": ">=5.6.3 <7" } }, "tscircuit-monaco-code-editor-cb64d17"],
 
     "@tscircuit/ngspice-spice-engine": ["@tscircuit/ngspice-spice-engine@0.0.20", "", { "peerDependencies": { "@tscircuit/props": "*", "circuit-json": "*", "spicets": "*", "typescript": "^5" } }, "sha512-dXjH51Wl95B6yEVkWCz65DpAHWTJRLHDyD/09eJUpGwLcYfd1F9m4E0XWbuiYZ8wKygYlACTozrSX9n3/LtfwA=="],
 

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "@tscircuit/layout": "^0.0.29",
     "@tscircuit/math-utils": "^0.0.36",
     "@tscircuit/mm": "^0.0.8",
-    "@tscircuit/monaco-code-editor": "git+https://github.com/tscircuit/monaco-code-editor.git#0cbbad9",
+    "@tscircuit/monaco-code-editor": "git+https://github.com/tscircuit/monaco-code-editor.git#cb64d17",
     "@tscircuit/order-dialog": "git+https://github.com/tscircuit/order-dialog.git#55a2839",
     "@tscircuit/pcb-viewer": "1.11.376",
     "@tscircuit/prompt-benchmarks": "^0.0.28",


### PR DESCRIPTION
## What changed

- Updated `@tscircuit/monaco-code-editor` from commit `0cbbad9` to `cb64d17`.
- Refreshed the Bun lockfile for the new Git revision.

## Why

This brings tscircuit.com onto the latest `main` revision of the Monaco code editor package.

## Impact

The application now consumes the latest editor implementation while retaining the existing dependency API and peer dependency set.

## Validation

- `bun run typecheck`
- `bun install --frozen-lockfile`
- `git diff --check`
