### PR TITLE
Fix editor import regression introduced by Monaco migration

### DIFF
--- a/src/components/package-port/CodeAndPreview.tsx
+++ b/src/components/package-port/CodeAndPreview.tsx
@@ -20,6 +20,7 @@ import { useGlobalStore } from "@/hooks/use-global-store"
 import { usePackageReleasesByPackageId } from "@/hooks/use-package-release"
 import { useApiBaseUrl } from "@/hooks/use-packages-base-api-url"
 import { getEasyEdaProxyAuthToast } from "./get-easyeda-proxy-auth-toast"
+import { useEditorComponentImport } from "@/hooks/use-editor-component-import"
 
 interface Props {
   pkg?: Package
@@ -237,6 +238,13 @@ export function CodeAndPreview({ pkg, projectUrl, isPackageFetched }: Props) {
     [setLocalFiles],
   )
 
+  const { importComponentDialog, openImportDialog } = useEditorComponentImport({
+    currentFile,
+    files: fsMap,
+    updateFileContent: handleFileContentChange,
+    createFile,
+  })
+
   useWarnUserOnPageChange({
     hasUnsavedChanges: Boolean(hasUnsavedChanges),
     isPackageThere: Boolean(pkg),
@@ -302,6 +310,7 @@ export function CodeAndPreview({ pkg, projectUrl, isPackageFetched }: Props) {
         isViewingOlderVersion={isViewingOlderVersion}
         viewingVersion={versionFromUrl}
         latestVersion={latestVersion}
+        onImportComponent={openImportDialog}
       />
       <div
         className={`flex flex-1 min-h-0 ${
@@ -383,6 +392,7 @@ export function CodeAndPreview({ pkg, projectUrl, isPackageFetched }: Props) {
       </div>
       <NewPackageSaveDialog initialIsPrivate={false} onSave={savePackage} />
       <DiscardChangesDialog onConfirm={handleDiscardChanges} />
+      {importComponentDialog}
     </div>
   )
 }

--- a/src/components/package-port/CodeEditorHeader.tsx
+++ b/src/components/package-port/CodeEditorHeader.tsx
@@ -1,8 +1,8 @@
-import React, { useState, useCallback, useMemo } from "react"
+import React, { useState, useCallback } from "react"
 import { Button } from "@/components/ui/button"
 import { handleManualEditsImportWithSupportForMultipleFiles } from "@/lib/handleManualEditsImportWithSupportForMultipleFiles"
-import { useImportComponentDialog } from "@/components/dialogs/import-component-dialog"
 import { useToast } from "@/hooks/use-toast"
+import { useEditorComponentImport } from "@/hooks/use-editor-component-import"
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -32,14 +32,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip"
-import {
-  JlcpcbComponentTsxLoadedPayload,
-  KicadStringSelectedPayload,
-  TscircuitPackageSelectedPayload,
-} from "@tscircuit/runframe/runner"
 import { ICreateFileProps, ICreateFileResult } from "@/hooks/useFileManagement"
-import { useGlobalStore } from "@/hooks/use-global-store"
-import { openJlcpcbImportIssue } from "@/hooks/use-jlcpcb-component-import"
 export type FileName = string
 
 interface CodeEditorHeaderProps {
@@ -66,19 +59,15 @@ export const CodeEditorHeader: React.FC<CodeEditorHeaderProps> = ({
   createFile,
   aiAutocompleteState,
 }) => {
-  const { Dialog: ImportComponentDialog, openDialog: openImportDialog } =
-    useImportComponentDialog()
+  const { importComponentDialog, openImportDialog } = useEditorComponentImport({
+    currentFile,
+    files,
+    updateFileContent,
+    createFile,
+  })
   const { toast } = useToast()
   const [sidebarOpen, setSidebarOpen] = fileSidebarState
   const [aiAutocompleteEnabled, setAiAutocompleteEnabled] = aiAutocompleteState
-  const session = useGlobalStore((s) => s.session)
-
-  const jlcpcbProxyRequestHeaders = useMemo(() => {
-    if (!session?.token) return undefined
-    return {
-      Authorization: `Bearer ${session.token}`,
-    }
-  }, [session?.token])
 
   const handleFormatFile = useCallback(() => {
     if (!window.prettier || !window.prettierPlugins) return
@@ -168,116 +157,6 @@ export const CodeEditorHeader: React.FC<CodeEditorHeaderProps> = ({
       }
     }
   }, [currentFile, files, toast, updateFileContent])
-
-  const handleTscircuitPackageSelected = useCallback(
-    async ({ fullPackageName }: TscircuitPackageSelectedPayload) => {
-      if (!currentFile) {
-        const message = "Select a file before importing a component."
-        toast({
-          title: "No file selected",
-          description: message,
-          variant: "destructive",
-        })
-        throw new Error(message)
-      }
-
-      const existingContent = files[currentFile] ?? ""
-      const newContent = `import {} from "${fullPackageName}"\n${existingContent}`
-      updateFileContent(currentFile, newContent)
-      toast({
-        title: "Component imported",
-        description: `Added ${fullPackageName} to ${currentFile}.`,
-      })
-    },
-    [currentFile, files, toast, updateFileContent],
-  )
-
-  const handleJlcpcbComponentTsxLoaded = useCallback(
-    async ({ result, tsx }: JlcpcbComponentTsxLoadedPayload) => {
-      console.log(232, result, tsx)
-      const partNumber = result.component.partNumber || "component"
-
-      try {
-        const sanitizedBaseName = partNumber
-          .toLowerCase()
-          .replace(/[^a-z0-9_-]/gi, "-")
-        let componentPath = `imports/${sanitizedBaseName}.tsx`
-        let suffix = 1
-        while (files[componentPath] || files[`./${componentPath}`]) {
-          componentPath = `imports/${sanitizedBaseName}-${suffix}.tsx`
-          suffix += 1
-        }
-
-        const createFileResult = createFile({
-          newFileName: componentPath,
-          content: tsx,
-          onError: (error) => {
-            throw error
-          },
-        })
-
-        if (!createFileResult.newFileCreated) {
-          throw new Error("Failed to create component file")
-        }
-
-        toast({
-          title: "Component imported",
-          description: `${partNumber} saved to ${componentPath}.`,
-        })
-      } catch (error) {
-        const message =
-          error instanceof Error
-            ? error.message
-            : "Failed to import component from JLCPCB"
-
-        toast({
-          title: "JLCPCB import failed",
-          description: (
-            <div className="space-y-2">
-              <p>{message}</p>
-              <button
-                className="text-sm text-blue-500 hover:underline"
-                onClick={(event) => {
-                  event.preventDefault()
-                  openJlcpcbImportIssue(partNumber, message)
-                }}
-              >
-                File issue on GitHub
-              </button>
-            </div>
-          ),
-          variant: "destructive",
-        })
-
-        throw new Error(message)
-      }
-    },
-    [createFile, files, toast],
-  )
-
-  const handleKicadStringSelected = useCallback(
-    async ({ footprint, result }: KicadStringSelectedPayload) => {
-      try {
-        await navigator.clipboard.writeText(footprint)
-        toast({
-          title: "KiCad footprint copied",
-          description: `${result.footprint.qualifiedName} copied to clipboard.`,
-        })
-      } catch (error) {
-        const message =
-          error instanceof Error
-            ? error.message
-            : "Failed to copy KiCad footprint to clipboard"
-        toast({
-          title: "KiCad import failed",
-          description: message,
-          variant: "destructive",
-        })
-        throw new Error(message)
-      }
-    },
-    [toast],
-  )
 
   return (
     <>
@@ -481,12 +360,7 @@ export const CodeEditorHeader: React.FC<CodeEditorHeaderProps> = ({
             </DropdownMenu>
           </div>
         </div>
-        <ImportComponentDialog
-          onTscircuitPackageSelected={handleTscircuitPackageSelected}
-          onJlcpcbComponentTsxLoaded={handleJlcpcbComponentTsxLoaded}
-          onKicadStringSelected={handleKicadStringSelected}
-          jlcpcbProxyRequestHeaders={jlcpcbProxyRequestHeaders}
-        />
+        {importComponentDialog}
       </div>
     </>
   )

--- a/src/components/package-port/EditorNav.tsx
+++ b/src/components/package-port/EditorNav.tsx
@@ -24,6 +24,7 @@ import {
   File,
   FilePenLine,
   MoreVertical,
+  PackagePlus,
   Pencil,
   Save,
   Share,
@@ -73,6 +74,7 @@ export default function EditorNav({
   isViewingOlderVersion,
   viewingVersion,
   latestVersion,
+  onImportComponent,
 }: {
   pkg?: Package | null
   isPackageFetched?: boolean
@@ -96,6 +98,7 @@ export default function EditorNav({
   isViewingOlderVersion?: boolean
   viewingVersion?: string
   latestVersion?: string | null
+  onImportComponent: () => void
 }) {
   const [location, navigate] = useLocation()
   const isLoggedIn = useGlobalStore((s) => Boolean(s.session))
@@ -476,6 +479,17 @@ export default function EditorNav({
             <Sparkles className="mr-1 h-3 w-3" />
             Edit with AI
           </Button> */}
+          <Button
+            variant="outline"
+            size="sm"
+            className="px-2 text-xs"
+            aria-label="Import"
+            disabled={isViewingOlderVersion}
+            onClick={onImportComponent}
+          >
+            <PackagePlus className="h-3 w-3 sm:mr-1" />
+            <span className="hidden sm:inline">Import</span>
+          </Button>
           <DownloadButtonAndMenu
             offerMultipleImageFormats
             unscopedName={pkg?.unscoped_name}

--- a/src/hooks/use-editor-component-import.tsx
+++ b/src/hooks/use-editor-component-import.tsx
@@ -1,0 +1,163 @@
+import { useImportComponentDialog } from "@/components/dialogs/import-component-dialog"
+import { useGlobalStore } from "@/hooks/use-global-store"
+import { openJlcpcbImportIssue } from "@/hooks/use-jlcpcb-component-import"
+import { useToast } from "@/hooks/use-toast"
+import type {
+  ICreateFileProps,
+  ICreateFileResult,
+} from "@/hooks/useFileManagement"
+import type {
+  JlcpcbComponentTsxLoadedPayload,
+  KicadStringSelectedPayload,
+  TscircuitPackageSelectedPayload,
+} from "@tscircuit/runframe/runner"
+import { useCallback, useMemo } from "react"
+
+export function useEditorComponentImport({
+  currentFile,
+  files,
+  updateFileContent,
+  createFile,
+}: {
+  currentFile: string | null
+  files: Record<string, string>
+  updateFileContent: (path: string, content: string) => void
+  createFile: (props: ICreateFileProps) => ICreateFileResult
+}) {
+  const { Dialog: ImportComponentDialog, openDialog: openImportDialog } =
+    useImportComponentDialog()
+  const { toast } = useToast()
+  const sessionToken = useGlobalStore((state) => state.session?.token)
+
+  const jlcpcbProxyRequestHeaders = useMemo(
+    () =>
+      sessionToken
+        ? {
+            Authorization: `Bearer ${sessionToken}`,
+          }
+        : undefined,
+    [sessionToken],
+  )
+
+  const handleTscircuitPackageSelected = useCallback(
+    async ({ fullPackageName }: TscircuitPackageSelectedPayload) => {
+      if (!currentFile) {
+        const message = "Select a file before importing a component."
+        toast({
+          title: "No file selected",
+          description: message,
+          variant: "destructive",
+        })
+        throw new Error(message)
+      }
+
+      const existingContent = files[currentFile] ?? ""
+      updateFileContent(
+        currentFile,
+        `import {} from "${fullPackageName}"\n${existingContent}`,
+      )
+      toast({
+        title: "Component imported",
+        description: `Added ${fullPackageName} to ${currentFile}.`,
+      })
+    },
+    [currentFile, files, toast, updateFileContent],
+  )
+
+  const handleJlcpcbComponentTsxLoaded = useCallback(
+    async ({ result, tsx }: JlcpcbComponentTsxLoadedPayload) => {
+      const partNumber = result.component.partNumber || "component"
+
+      try {
+        const sanitizedBaseName = partNumber
+          .toLowerCase()
+          .replace(/[^a-z0-9_-]/gi, "-")
+        let componentPath = `imports/${sanitizedBaseName}.tsx`
+        let suffix = 1
+        while (componentPath in files || `./${componentPath}` in files) {
+          componentPath = `imports/${sanitizedBaseName}-${suffix}.tsx`
+          suffix += 1
+        }
+
+        const createFileResult = createFile({
+          newFileName: componentPath,
+          content: tsx,
+          onError: (error) => {
+            throw error
+          },
+        })
+
+        if (!createFileResult.newFileCreated) {
+          throw new Error("Failed to create component file")
+        }
+
+        toast({
+          title: "Component imported",
+          description: `${partNumber} saved to ${componentPath}.`,
+        })
+      } catch (error) {
+        const message =
+          error instanceof Error
+            ? error.message
+            : "Failed to import component from JLCPCB"
+
+        toast({
+          title: "JLCPCB import failed",
+          description: (
+            <div className="space-y-2">
+              <p>{message}</p>
+              <button
+                className="text-sm text-blue-500 hover:underline"
+                onClick={(event) => {
+                  event.preventDefault()
+                  openJlcpcbImportIssue(partNumber, message)
+                }}
+              >
+                File issue on GitHub
+              </button>
+            </div>
+          ),
+          variant: "destructive",
+        })
+
+        throw new Error(message)
+      }
+    },
+    [createFile, files, toast],
+  )
+
+  const handleKicadStringSelected = useCallback(
+    async ({ footprint, result }: KicadStringSelectedPayload) => {
+      try {
+        await navigator.clipboard.writeText(footprint)
+        toast({
+          title: "KiCad footprint copied",
+          description: `${result.footprint.qualifiedName} copied to clipboard.`,
+        })
+      } catch (error) {
+        const message =
+          error instanceof Error
+            ? error.message
+            : "Failed to copy KiCad footprint to clipboard"
+        toast({
+          title: "KiCad import failed",
+          description: message,
+          variant: "destructive",
+        })
+        throw new Error(message)
+      }
+    },
+    [toast],
+  )
+
+  const importComponentDialog = (
+    <ImportComponentDialog
+      onTscircuitPackageSelected={handleTscircuitPackageSelected}
+      onJlcpcbComponentTsxLoaded={handleJlcpcbComponentTsxLoaded}
+      onKicadStringSelected={handleKicadStringSelected}
+      jlcpcbProxyRequestHeaders={jlcpcbProxyRequestHeaders}
+    />
+  )
+
+  return { importComponentDialog, openImportDialog }
+}


### PR DESCRIPTION
## Summary

Restores the component import workflow that became inaccessible after the editor migrated to Monaco.

## Problem

The Monaco migration removed the Import button and its supporting dialog integration from the editor. Users could no longer import tscircuit packages, JLCPCB components, or KiCad footprints from the editor navigation.

## Fix

- Restored the Import button beside Download
- Reconnected the component import dialog to the Monaco editor
- Restored package, JLCPCB, and KiCad import handlers
- Reused the editor's existing file map as the import source of truth
- Added collision-safe JLCPCB filenames, including when an existing file is empty
- Preserved authentication and error handling
- Prevented imports while viewing read-only historical versions
- Preserved responsive behavior by showing an icon-only button on smaller screens

## User impact

This restores a key editor workflow and removes the need for users to manually recreate imported components or edit import files outside the editor.

## Validation

- Confirmed the Import button appears beside Download
- Confirmed activating it reaches the existing import flow
- Confirmed signed-out users receive the existing authentication message
- Confirmed the project passes `bun run typecheck`
