### PR TITLE
Hide Order button

### DIFF
--- a/src/components/ViewPackagePage/components/package-header.tsx
+++ b/src/components/ViewPackagePage/components/package-header.tsx
@@ -386,7 +386,7 @@ export default function PackageHeader({
           </div>
 
           <div className="hidden md:flex items-center space-x-2">
-            <Button
+            {/* <Button
               variant="outline"
               size="sm"
               onClick={handleOrderClick}
@@ -396,7 +396,7 @@ export default function PackageHeader({
             >
               <Package className="w-4 h-4 mr-2" />
               Order
-            </Button>
+            </Button> */}
 
             <TooltipProvider>
               <Tooltip>
@@ -470,7 +470,7 @@ export default function PackageHeader({
 
           {/* Mobile buttons */}
           <div className="md:hidden flex items-center space-x-2 w-full justify-end pt-2">
-            <Button
+            {/* <Button
               variant="outline"
               size="sm"
               onClick={handleOrderClick}
@@ -480,7 +480,7 @@ export default function PackageHeader({
             >
               <Package className="w-4 h-4 mr-2" />
               Order
-            </Button>
+            </Button> */}
             <Button
               variant="outline"
               size="sm"


### PR DESCRIPTION
## Summary
- comment out the Order button in the desktop package header
- comment out the Order button in the mobile action row
- keep the order flow implementation in place for easy restoration

## Testing
- `bunx biome format src/components/ViewPackagePage/components/package-header.tsx`
- `bun run typecheck`
- `git diff --check`