### PR TITLE
Patch RunFrame fullscreen z-index

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -166,6 +166,9 @@
   "trustedDependencies": [
     "@tscircuit/fake-stripe",
   ],
+  "patchedDependencies": {
+    "@tscircuit/runframe@0.0.2410": "patches/@tscircuit%2Frunframe@0.0.2410.patch",
+  },
   "packages": {
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
 

--- a/package.json
+++ b/package.json
@@ -196,5 +196,8 @@
     "zod": "^3.23.8",
     "zustand": "^4.5.5",
     "zustand-hoist": "^2.0.1"
+  },
+  "patchedDependencies": {
+    "@tscircuit/runframe@0.0.2410": "patches/@tscircuit%2Frunframe@0.0.2410.patch"
   }
 }

--- a/patches/@tscircuit%2Frunframe@0.0.2410.patch
+++ b/patches/@tscircuit%2Frunframe@0.0.2410.patch
@@ -1,0 +1,19 @@
+diff --git a/dist/chunk-GAZKWG2C.js b/dist/chunk-GAZKWG2C.js
+index a484647604bfad96d0370625f6aa6ee5546c36d1..53ca06578c2c685f4db0d96cddd158c287b86f13 100644
+--- a/dist/chunk-GAZKWG2C.js
++++ b/dist/chunk-GAZKWG2C.js
+@@ -3335,5 +3335,6 @@
+ // lib/utils/z-index-map.ts
+ var zIndexMap = {
++  circuitJsonPreviewFullScreen: 60,
+   importComponentDialog: 101,
+   importComponentDetailsDialog: 102
+ };
+@@ -6432,6 +6433,7 @@ var CircuitJsonPreview = ({
+             "rf-md:sticky rf-md:top-2 rf-h-full",
+             isFullScreen && "rf-fixed rf-top-0 rf-left-0 rf-w-full rf-h-full rf-bg-white rf-overflow-hidden"
+           ),
++          style: isFullScreen ? { zIndex: zIndexMap.circuitJsonPreviewFullScreen } : void 0,
+           children: /* @__PURE__ */ jsxs30(
+             Tabs,
+             {


### PR DESCRIPTION

## Summary

- Add a Bun dependency patch for `@tscircuit/runframe@0.0.2410`.
- Give the fullscreen `CircuitJsonPreview` a `z-index` of `60` through RunFrame's `zIndexMap`.
- Register the patch in `package.json` and `bun.lock`.

## Why

In production, Monaco's fixed overflow widgets could render above the fullscreen PCB viewer because the RunFrame fullscreen layer had no z-index. This keeps the fix in the RunFrame implementation without adding a global CSS workaround to `tscircuit.com`, while the upstream RunFrame release is pending.

## Validation

- `bun install --frozen-lockfile`
- `bun run typecheck`
- `bun run build`

The production build completed successfully with the repository's existing Vite warnings.
