### PR TITLE
Open RunFrame accessory dialog from downloads

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -54,7 +54,7 @@
         "@tscircuit/create-snippet-url": "^0.0.14",
         "@tscircuit/eval": "^0.0.1185",
         "@tscircuit/fake-stripe": "git+https://github.com/tscircuit/fake-stripe.git#f1a5b40",
-        "@tscircuit/internal-dynamic-import": "^0.0.13",
+        "@tscircuit/internal-dynamic-import": "^0.0.15",
         "@tscircuit/layout": "^0.0.29",
         "@tscircuit/math-utils": "^0.0.36",
         "@tscircuit/mm": "^0.0.8",
@@ -831,7 +831,7 @@
 
     "@tscircuit/infgrid-ijump-astar": ["@tscircuit/infgrid-ijump-astar@0.0.35", "", {}, "sha512-PZx3GyD7mDNEhLJn8+7n8NjrieOvrX03g7Gx1cvwXv9mmgSC4M+yTA0WC4DgOvcRdTnarf0R8xvwtDeJ4tMK9Q=="],
 
-    "@tscircuit/internal-dynamic-import": ["@tscircuit/internal-dynamic-import@0.0.13", "", {}, "sha512-ji4NIF22ehRjR7G2Kv42epv/Uj2mjcYmpMi+L7Rlf2u8h2IaALjnh6vaL+Wy++a+TkDd/Wlo0/W4cpmG0XPmEQ=="],
+    "@tscircuit/internal-dynamic-import": ["@tscircuit/internal-dynamic-import@0.0.15", "", {}, "sha512-88yoEXJeesTHmdas7JHUyCwGpVtLAtVc3G8Y5VFP6cSKkhcHkqyVAykP8n00iBXVrKF8ga3GFIwlJGB8KUjaSQ=="],
 
     "@tscircuit/krt-wasm": ["@tscircuit/krt-wasm@0.1.8", "", { "peerDependencies": { "tscircuit": "*" } }, "sha512-ivC3RYpyqlpOLVrhLq7IjyzLd6xHHrB8VM8WW4YWQlgsOLE8bZ89RBlmiku04whwFs3Xi1oFF7jxQDhggZ9Gmw=="],
 

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "@tscircuit/create-snippet-url": "^0.0.14",
     "@tscircuit/eval": "^0.0.1185",
     "@tscircuit/fake-stripe": "git+https://github.com/tscircuit/fake-stripe.git#f1a5b40",
-    "@tscircuit/internal-dynamic-import": "^0.0.13",
+    "@tscircuit/internal-dynamic-import": "^0.0.15",
     "@tscircuit/layout": "^0.0.29",
     "@tscircuit/math-utils": "^0.0.36",
     "@tscircuit/mm": "^0.0.8",

--- a/src/components/DownloadButtonAndMenu.tsx
+++ b/src/components/DownloadButtonAndMenu.tsx
@@ -27,8 +27,9 @@ import { downloadSimpleRouteJson } from "@/lib/download-fns/download-simple-rout
 import { downloadSpiceFile } from "@/lib/download-fns/download-spice-file"
 import { downloadStepFile } from "@/lib/download-fns/download-step"
 import { CubeIcon } from "@radix-ui/react-icons"
+import { ExportAccessoryDialog } from "@tscircuit/runframe"
 import { AnyCircuitElement } from "circuit-json"
-import { ChevronDown, Download, Hammer, ImageIcon } from "lucide-react"
+import { ChevronDown, Download, Hammer, ImageIcon, Wrench } from "lucide-react"
 import { useState } from "react"
 
 interface DownloadButtonAndMenuProps {
@@ -59,6 +60,10 @@ export function DownloadButtonAndMenu({
     AnyCircuitElement[] | null
   >(null)
   const [isFetchingCircuitJson, setIsFetchingCircuitJson] = useState(false)
+  const [isAccessoryDialogOpen, setIsAccessoryDialogOpen] = useState(false)
+  const [accessoryCircuitJson, setAccessoryCircuitJson] = useState<
+    AnyCircuitElement[] | null
+  >(null)
 
   const canDownload = Boolean(
     hasCircuitJson || (circuitJson && circuitJson.length),
@@ -337,6 +342,25 @@ export function DownloadButtonAndMenu({
 
           <DropdownMenuItem
             className="text-xs"
+            disabled={isFetchingCircuitJson}
+            onSelect={async () => {
+              try {
+                const cj = await getCircuitJson()
+                setAccessoryCircuitJson(cj)
+                setIsAccessoryDialogOpen(true)
+              } catch {
+                // getCircuitJson displays the download error toast.
+              }
+            }}
+          >
+            <Wrench className="mr-1 h-3 w-3" />
+            <span className="flex-grow mr-6">
+              {isFetchingCircuitJson ? "Loading Accessories…" : "Accessory…"}
+            </span>
+          </DropdownMenuItem>
+
+          <DropdownMenuItem
+            className="text-xs"
             onClick={async () => {
               const cj = await getCircuitJson()
               await downloadFabricationFiles({
@@ -436,6 +460,14 @@ export function DownloadButtonAndMenu({
         circuitJson={fetchedCircuitJson || circuitJson || []}
         fileName={unscopedName || "circuit"}
       />
+      {accessoryCircuitJson && (
+        <ExportAccessoryDialog
+          open={isAccessoryDialogOpen}
+          onOpenChange={setIsAccessoryDialogOpen}
+          circuitJson={accessoryCircuitJson}
+          projectName={unscopedName || "circuit"}
+        />
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary

- add an **Accessory…** item to the project download menu
- fetch the current Circuit JSON on demand and open RunFrame's shared `ExportAccessoryDialog`
- preserve RunFrame's lazy loading behavior so the component-box converter is loaded only after the user selects that accessory

## User impact

Users can open the same accessory picker and preview used by RunFrame directly from tscircuit.com, then generate and download a component-box 3MF without leaving the project page.

## Validation

- `bun test` — 284 passed, 5 skipped
- `bun run build`
- `bun run typecheck`
- `bun run lint`
- `git diff --check`
