### PR TITLE
Open the new build logs after GitHub sync

### DIFF
--- a/playwright-tests/github-sync-navigation.spec.ts
+++ b/playwright-tests/github-sync-navigation.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type Page } from "@playwright/test"
+import { type Page, expect, test } from "@playwright/test"
 
 const baseUrl = "http://127.0.0.1:5177"
 const packagePath = "/testuser/my-test-board"
@@ -34,7 +34,31 @@ for (const viewport of [
     await page.setViewportSize(viewport)
     await installSession(page)
 
+    let syncStarted = false
+    let postSyncBuildChecks = 0
+
+    await page.route("**/package_releases/list**", async (route) => {
+      if (syncStarted) postSyncBuildChecks += 1
+
+      if (!syncStarted || postSyncBuildChecks < 2) {
+        await route.continue()
+        return
+      }
+
+      await route.fulfill({
+        json: {
+          package_releases: [
+            {
+              latest_package_build_id: "new-build",
+              package_release_id: "new-release",
+            },
+          ],
+        },
+      })
+    })
+
     await page.route("**/packages/start_github_sync", async (route) => {
+      syncStarted = true
       await route.fulfill({
         json: {
           start_github_sync_result: {
@@ -49,7 +73,8 @@ for (const viewport of [
     await page.getByRole("button", { name: "Sync from GitHub" }).click()
 
     await expect(page).toHaveURL(
-      /\/testuser\/my-test-board\/releases\/package_release_\d+$/,
+      /\/testuser\/my-test-board\/releases\/new-release\/builds\/new-build$/,
     )
+    expect(postSyncBuildChecks).toBe(2)
   })
 }

--- a/playwright-tests/github-sync-navigation.spec.ts
+++ b/playwright-tests/github-sync-navigation.spec.ts
@@ -1,0 +1,55 @@
+import { expect, test, type Page } from "@playwright/test"
+
+const baseUrl = "http://127.0.0.1:5177"
+const packagePath = "/testuser/my-test-board"
+
+const installSession = async (page: Page) => {
+  await page.addInitScript(() => {
+    localStorage.setItem(
+      "session_store",
+      JSON.stringify({
+        state: {
+          session: {
+            token:
+              "eyJhbGciOiJIUzI1NiJ9.eyJhY2NvdW50X2lkIjoiYWNjb3VudC0xMjM0Iiwic2Vzc2lvbl9pZCI6InNlc3Npb24tdGVzdCJ9.signature",
+            account_id: "account-1234",
+            session_id: "session-test",
+            github_username: "testuser",
+            tscircuit_handle: "testuser",
+          },
+        },
+        version: 0,
+      }),
+    )
+  })
+}
+
+for (const viewport of [
+  { name: "desktop", width: 1280, height: 900 },
+  { name: "mobile", width: 390, height: 844 },
+]) {
+  test(`GitHub sync opens the build logs on ${viewport.name}`, async ({
+    page,
+  }) => {
+    await page.setViewportSize(viewport)
+    await installSession(page)
+
+    await page.route("**/packages/start_github_sync", async (route) => {
+      await route.fulfill({
+        json: {
+          start_github_sync_result: {
+            ok: true,
+            message: "GitHub sync job queued successfully",
+          },
+        },
+      })
+    })
+
+    await page.goto(`${baseUrl}${packagePath}`)
+    await page.getByRole("button", { name: "Sync from GitHub" }).click()
+
+    await expect(page).toHaveURL(
+      /\/testuser\/my-test-board\/releases\/package_release_\d+$/,
+    )
+  })
+}

--- a/src/components/ViewPackagePage/components/mobile-sidebar.tsx
+++ b/src/components/ViewPackagePage/components/mobile-sidebar.tsx
@@ -91,6 +91,9 @@ const MobileSidebar = ({
           title: "Sync started",
           description: response.data.start_github_sync_result.message,
         })
+        navigate(
+          `/${packageInfo.name}/releases/${packageInfo.latest_package_release_id}`,
+        )
       }
     } catch (error: any) {
       toast({
@@ -101,7 +104,7 @@ const MobileSidebar = ({
     } finally {
       setIsSyncing(false)
     }
-  }, [packageInfo?.package_id, axios, toast])
+  }, [packageInfo, axios, toast, navigate])
 
   const websiteUrl =
     packageInfo?.website || packageRelease?.package_release_website_url
@@ -204,6 +207,7 @@ const MobileSidebar = ({
                     <button
                       onClick={handleGitHubSync}
                       disabled={isSyncing}
+                      aria-label="Sync from GitHub"
                       className="p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-800 disabled:opacity-50"
                     >
                       <RefreshCw

--- a/src/components/ViewPackagePage/components/mobile-sidebar.tsx
+++ b/src/components/ViewPackagePage/components/mobile-sidebar.tsx
@@ -1,32 +1,31 @@
-import {
-  GitFork,
-  Star,
-  Tag,
-  Settings,
-  LinkIcon,
-  Github,
-  Plus,
-  RefreshCw,
-} from "lucide-react"
 import { Badge } from "@/components/ui/badge"
-import { Skeleton } from "@/components/ui/skeleton"
-import { useGlobalStore } from "@/hooks/use-global-store"
 import { Button } from "@/components/ui/button"
-import React, { useState, useEffect, useMemo, useCallback } from "react"
-import { useCurrentPackageInfo } from "@/hooks/use-current-package-info"
-import PreviewImageSquares from "./preview-image-squares"
-import { useOrganization } from "@/hooks/use-organization"
-import { useAxios } from "@/hooks/use-axios"
-import { useToast } from "@/hooks/use-toast"
-import { useGetOrgMember } from "@/hooks/use-get-org-member"
+import { Skeleton } from "@/components/ui/skeleton"
 import {
   Tooltip,
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip"
-import { Link, useLocation } from "wouter"
+import { useCurrentPackageInfo } from "@/hooks/use-current-package-info"
 import { useCurrentPackageRelease } from "@/hooks/use-current-package-release"
+import { useGetOrgMember } from "@/hooks/use-get-org-member"
+import { useGlobalStore } from "@/hooks/use-global-store"
+import { useManualGitHubSync } from "@/hooks/use-manual-github-sync"
+import { useOrganization } from "@/hooks/use-organization"
+import {
+  GitFork,
+  Github,
+  LinkIcon,
+  Plus,
+  RefreshCw,
+  Settings,
+  Star,
+  Tag,
+} from "lucide-react"
+import React, { useEffect, useMemo } from "react"
+import { Link, useLocation } from "wouter"
+import PreviewImageSquares from "./preview-image-squares"
 
 interface MobileSidebarProps {
   isLoading?: boolean
@@ -75,36 +74,7 @@ const MobileSidebar = ({
 
   const canManagePackage = isOwner || Boolean(orgMember)
 
-  const [isSyncing, setIsSyncing] = useState(false)
-  const axios = useAxios()
-  const { toast } = useToast()
-
-  const handleGitHubSync = useCallback(async () => {
-    if (!packageInfo?.package_id) return
-    setIsSyncing(true)
-    try {
-      const response = await axios.post("/packages/start_github_sync", {
-        package_id: packageInfo.package_id,
-      })
-      if (response.data?.start_github_sync_result?.ok) {
-        toast({
-          title: "Sync started",
-          description: response.data.start_github_sync_result.message,
-        })
-        navigate(
-          `/${packageInfo.name}/releases/${packageInfo.latest_package_release_id}`,
-        )
-      }
-    } catch (error: any) {
-      toast({
-        title: "Sync failed",
-        description: error?.data?.message || "Failed to start GitHub sync",
-        variant: "destructive",
-      })
-    } finally {
-      setIsSyncing(false)
-    }
-  }, [packageInfo, axios, toast, navigate])
+  const { handleGitHubSync, isSyncing } = useManualGitHubSync(packageInfo)
 
   const websiteUrl =
     packageInfo?.website || packageRelease?.package_release_website_url

--- a/src/components/ViewPackagePage/components/sidebar-about-section.tsx
+++ b/src/components/ViewPackagePage/components/sidebar-about-section.tsx
@@ -1,34 +1,33 @@
 import { Badge } from "@/components/ui/badge"
-import {
-  GitFork,
-  Star,
-  Settings,
-  Link as LinkIcon,
-  Github,
-  Plus,
-  RefreshCw,
-  Boxes,
-} from "lucide-react"
-import { Skeleton } from "@/components/ui/skeleton"
-import { useCurrentPackageInfo } from "@/hooks/use-current-package-info"
-import { useCurrentPackageRelease } from "@/hooks/use-current-package-release"
-import { useGlobalStore } from "@/hooks/use-global-store"
 import { Button } from "@/components/ui/button"
+import { Skeleton } from "@/components/ui/skeleton"
 import {
   Tooltip,
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip"
-import { useState, useEffect, useMemo } from "react"
+import { useCurrentPackageInfo } from "@/hooks/use-current-package-info"
+import { useCurrentPackageRelease } from "@/hooks/use-current-package-release"
+import { useGetOrgMember } from "@/hooks/use-get-org-member"
+import { useGlobalStore } from "@/hooks/use-global-store"
+import { useManualGitHubSync } from "@/hooks/use-manual-github-sync"
+import { useOrganization } from "@/hooks/use-organization"
+import { usePackageDomains } from "@/hooks/use-package-domains"
 import { usePackageFileById, usePackageFiles } from "@/hooks/use-package-files"
 import { getLicenseFromLicenseContent } from "@/lib/getLicenseFromLicenseContent"
 import { PackageInfo } from "@/lib/types"
-import { useOrganization } from "@/hooks/use-organization"
-import { useAxios } from "@/hooks/use-axios"
-import { useToast } from "@/hooks/use-toast"
-import { useGetOrgMember } from "@/hooks/use-get-org-member"
-import { usePackageDomains } from "@/hooks/use-package-domains"
+import {
+  Boxes,
+  GitFork,
+  Github,
+  Link as LinkIcon,
+  Plus,
+  RefreshCw,
+  Settings,
+  Star,
+} from "lucide-react"
+import { useEffect, useMemo } from "react"
 import { Link, useLocation } from "wouter"
 
 interface SidebarAboutSectionProps {
@@ -100,37 +99,7 @@ export default function SidebarAboutSection({
 
   const canManagePackage = isOwner || Boolean(orgMember)
 
-  const [isSyncing, setIsSyncing] = useState(false)
-
-  const axios = useAxios()
-  const { toast } = useToast()
-
-  const handleGitHubSync = async () => {
-    if (!packageInfo?.package_id) return
-    setIsSyncing(true)
-    try {
-      const response = await axios.post("/packages/start_github_sync", {
-        package_id: packageInfo.package_id,
-      })
-      if (response.data?.start_github_sync_result?.ok) {
-        toast({
-          title: "Sync started",
-          description: response.data.start_github_sync_result.message,
-        })
-        navigate(
-          `/${packageInfo.name}/releases/${packageInfo.latest_package_release_id}`,
-        )
-      }
-    } catch (error: any) {
-      toast({
-        title: "Sync failed",
-        description: error?.data?.message || "Failed to start GitHub sync",
-        variant: "destructive",
-      })
-    } finally {
-      setIsSyncing(false)
-    }
-  }
+  const { handleGitHubSync, isSyncing } = useManualGitHubSync(packageInfo)
 
   const websiteUrl =
     packageInfo?.website || packageRelease?.package_release_website_url

--- a/src/components/ViewPackagePage/components/sidebar-about-section.tsx
+++ b/src/components/ViewPackagePage/components/sidebar-about-section.tsx
@@ -117,6 +117,9 @@ export default function SidebarAboutSection({
           title: "Sync started",
           description: response.data.start_github_sync_result.message,
         })
+        navigate(
+          `/${packageInfo.name}/releases/${packageInfo.latest_package_release_id}`,
+        )
       }
     } catch (error: any) {
       toast({
@@ -248,6 +251,7 @@ export default function SidebarAboutSection({
                     <button
                       onClick={handleGitHubSync}
                       disabled={isSyncing}
+                      aria-label="Sync from GitHub"
                       className="p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-800 disabled:opacity-50"
                     >
                       <RefreshCw

--- a/src/hooks/use-manual-github-sync.ts
+++ b/src/hooks/use-manual-github-sync.ts
@@ -1,0 +1,98 @@
+import {
+  type PackageBuildReference,
+  waitForNewPackageBuild,
+} from "@/lib/wait-for-new-package-build"
+import { useCallback, useState } from "react"
+import { useLocation } from "wouter"
+import { useAxios } from "./use-axios"
+import { useToast } from "./use-toast"
+
+interface SyncablePackage {
+  name: string
+  package_id: string
+}
+
+export const useManualGitHubSync = (packageInfo?: SyncablePackage) => {
+  const [isSyncing, setIsSyncing] = useState(false)
+  const axios = useAxios()
+  const { toast } = useToast()
+  const [, navigate] = useLocation()
+
+  const handleGitHubSync = useCallback(async () => {
+    if (!packageInfo?.package_id || isSyncing) return
+
+    setIsSyncing(true)
+    let syncWasAccepted = false
+
+    const listBuilds = async () => {
+      const { data } = await axios.post<{
+        package_releases: Array<{
+          is_pr_preview?: boolean
+          latest_package_build_id?: string | null
+          package_release_id: string
+        }>
+      }>("/package_releases/list", {
+        package_id: packageInfo.package_id,
+      })
+
+      return (data.package_releases ?? []).flatMap<PackageBuildReference>(
+        (release) =>
+          !release.is_pr_preview && release.latest_package_build_id
+            ? [
+                {
+                  package_build_id: release.latest_package_build_id,
+                  package_release_id: release.package_release_id,
+                },
+              ]
+            : [],
+      )
+    }
+
+    try {
+      const existingBuildIds = new Set(
+        (await listBuilds()).map((build) => build.package_build_id),
+      )
+      const response = await axios.post("/packages/start_github_sync", {
+        package_id: packageInfo.package_id,
+      })
+      const result = response.data?.start_github_sync_result
+
+      if (!result?.ok) {
+        throw new Error(result?.message || "Failed to start GitHub sync")
+      }
+
+      syncWasAccepted = true
+      toast({
+        title: "Sync started",
+        description: "Waiting for the new build to be created...",
+      })
+
+      const newBuild = await waitForNewPackageBuild({
+        existingBuildIds,
+        listBuilds,
+      })
+
+      navigate(
+        `/${packageInfo.name}/releases/${newBuild.package_release_id}/builds/${newBuild.package_build_id}`,
+      )
+    } catch (error: any) {
+      if (syncWasAccepted) {
+        toast({
+          title: "Sync queued",
+          description:
+            "The sync was accepted, but the new build is not available yet. Check the releases page in a moment.",
+        })
+      } else {
+        toast({
+          title: "Sync failed",
+          description: error?.data?.message || error?.message,
+          variant: "destructive",
+        })
+      }
+    } finally {
+      setIsSyncing(false)
+    }
+  }, [axios, isSyncing, navigate, packageInfo, toast])
+
+  return { handleGitHubSync, isSyncing }
+}

--- a/src/lib/wait-for-new-package-build.test.ts
+++ b/src/lib/wait-for-new-package-build.test.ts
@@ -1,0 +1,51 @@
+import { expect, test } from "bun:test"
+import {
+  type PackageBuildReference,
+  waitForNewPackageBuild,
+} from "./wait-for-new-package-build"
+
+test("waits until a build that did not exist before the sync is available", async () => {
+  const existingBuild: PackageBuildReference = {
+    package_build_id: "existing-build",
+    package_release_id: "existing-release",
+  }
+  const newBuild: PackageBuildReference = {
+    package_build_id: "new-build",
+    package_release_id: "new-release",
+  }
+  const responses = [
+    [existingBuild],
+    [existingBuild],
+    [newBuild, existingBuild],
+  ]
+  let requestCount = 0
+
+  const result = await waitForNewPackageBuild({
+    existingBuildIds: new Set([existingBuild.package_build_id]),
+    listBuilds: async () => responses[requestCount++] ?? responses.at(-1)!,
+    pollIntervalMs: 0,
+    timeoutMs: 100,
+  })
+
+  expect(result).toEqual(newBuild)
+  expect(requestCount).toBe(3)
+})
+
+test("detects a new build when an existing release is rebuilt", async () => {
+  const result = await waitForNewPackageBuild({
+    existingBuildIds: new Set(["old-build"]),
+    listBuilds: async () => [
+      {
+        package_build_id: "new-build",
+        package_release_id: "same-release",
+      },
+    ],
+    pollIntervalMs: 0,
+    timeoutMs: 100,
+  })
+
+  expect(result).toEqual({
+    package_build_id: "new-build",
+    package_release_id: "same-release",
+  })
+})

--- a/src/lib/wait-for-new-package-build.ts
+++ b/src/lib/wait-for-new-package-build.ts
@@ -1,0 +1,36 @@
+export interface PackageBuildReference {
+  package_build_id: string
+  package_release_id: string
+}
+
+interface WaitForNewPackageBuildOptions {
+  existingBuildIds: ReadonlySet<string>
+  listBuilds: () => Promise<PackageBuildReference[]>
+  pollIntervalMs?: number
+  timeoutMs?: number
+}
+
+const delay = (durationMs: number) =>
+  new Promise<void>((resolve) => setTimeout(resolve, durationMs))
+
+export const waitForNewPackageBuild = async ({
+  existingBuildIds,
+  listBuilds,
+  pollIntervalMs = 2_000,
+  timeoutMs = 120_000,
+}: WaitForNewPackageBuildOptions): Promise<PackageBuildReference> => {
+  const deadline = Date.now() + timeoutMs
+
+  while (Date.now() < deadline) {
+    const builds = await listBuilds()
+    const newBuild = builds.find(
+      (build) => !existingBuildIds.has(build.package_build_id),
+    )
+
+    if (newBuild) return newBuild
+
+    await delay(Math.min(pollIntervalMs, Math.max(0, deadline - Date.now())))
+  }
+
+  throw new Error("Timed out waiting for the GitHub sync build")
+}


### PR DESCRIPTION
## Summary

- snapshot the package's existing non-PR build IDs before starting a manual GitHub sync
- poll the package releases API until it exposes a different latest build ID
- navigate to that exact release/build detail page, which displays the new build logs
- share the behavior between desktop and mobile package sidebars
- add unit coverage for both a new release and a same-release rebuild
- add a desktop/mobile Playwright regression test that proves navigation waits for the new build

## Why

The GitHub sync endpoint only queues asynchronous worker jobs. Navigating as soon as it returns can open the previous release and its stale logs.

The updated flow waits until the API exposes the new build. This works whether the worker creates a new package release or rebuilds an existing release with a new build ID. If no new build appears within two minutes, the user stays on the package page and sees a message that the sync is still queued.

## Validation

- `bun run typecheck`
- `bun test ./src/lib/wait-for-new-package-build.test.ts` (2 passed)
- `bunx playwright test playwright-tests/github-sync-navigation.spec.ts --retries=0` (2 passed)
- Biome formatting and `git diff --check`
