### PR TITLE
patch: download representable 3d img size

### DIFF
--- a/src/lib/download-fns/download-circuit-png.ts
+++ b/src/lib/download-fns/download-circuit-png.ts
@@ -83,6 +83,9 @@ const renderCircuitToPng = async (
   const pngBytes = await renderCircuitJsonTo3dPng(circuitJson, {
     cameraPreset: "top-left-corner",
     boardTextureResolution: 2048,
+    width: 1920,
+    height: 1440,
+    supersampling: 2,
   })
   // Copy into a fresh ArrayBuffer: a Uint8Array view isn't assignable to BlobPart.
   const pngBuffer = new ArrayBuffer(pngBytes.byteLength)


### PR DESCRIPTION
# before
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/58ca23b4-fda3-40c1-ade1-4155af3dc7d4" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/20faa41c-3ba9-4c10-b448-e65bfb24e2b0" />

# after

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/27002670-8f54-4420-92f9-44bf0094024c" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/5149e6be-aa74-4c3c-a411-947d08fa9a33" />
