### PR TITLE
Prevent premature circuit runs while editor files initialize

### DIFF
--- a/src/components/package-port/CodeAndPreview.tsx
+++ b/src/components/package-port/CodeAndPreview.tsx
@@ -140,6 +140,13 @@ export function CodeAndPreview({ pkg, projectUrl, isPackageFetched }: Props) {
     releaseId: releaseIdForVersion,
   })
 
+  // Keep RunFrame's controls disabled until the file-management state has
+  // settled. `isFullyLoaded` can become true one render before the selected
+  // file is written, which otherwise makes a fast click start a run with an
+  // incomplete file map.
+  const isRunFrameLoading =
+    isLoading || !isFullyLoaded || localFiles.length === 0 || !currentFile
+
   const hasUnsavedChanges = useMemo(
     () =>
       (!isSaving &&
@@ -451,7 +458,7 @@ export function CodeAndPreview({ pkg, projectUrl, isPackageFetched }: Props) {
                 showFileMenu={false}
                 showRunButton
                 forceLatestEvalVersion
-                isLoadingFiles={isLoading || !isFullyLoaded}
+                isLoadingFiles={isRunFrameLoading}
                 onRenderStarted={() => {
                   sessionTokenAtRenderStartRef.current = sessionToken
                   setState((prev) => ({

--- a/src/components/package-port/CodeAndPreview.tsx
+++ b/src/components/package-port/CodeAndPreview.tsx
@@ -145,7 +145,11 @@ export function CodeAndPreview({ pkg, projectUrl, isPackageFetched }: Props) {
   // file is written, which otherwise makes a fast click start a run with an
   // incomplete file map.
   const isRunFrameLoading =
-    isLoading || !isFullyLoaded || localFiles.length === 0 || !currentFile
+    isLoading ||
+    !isFullyLoaded ||
+    localFiles.length === 0 ||
+    !currentFile ||
+    (totalFilesCount > 0 && loadedFilesCount < totalFilesCount)
 
   const hasUnsavedChanges = useMemo(
     () =>


### PR DESCRIPTION
## What changed

Prevents the RunFrame preview from becoming interactive before the editor's file state is ready.

## Why

Rapid clicks during initialization could start a run with an incomplete file map or no selected file, causing a loading/setup error. The preview now remains gated until files are fully loaded, the file map is populated, and a current file is selected.

## Impact

This improves web editor reliability and prevents an intermittent race condition during startup.

## Validation

- `bun run typecheck`
- Biome formatting check
- `git diff --check`