### PR TITLE
Use shared Gerber file generation for fabrication downloads

### DIFF
--- a/bun-tests/download-fabrication-files.test.ts
+++ b/bun-tests/download-fabrication-files.test.ts
@@ -1,0 +1,48 @@
+import { expect, test } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import JSZip from "jszip"
+import { createFabricationFilesZip } from "@/lib/download-fns/download-fabrication-files"
+
+test("fabrication zip includes plated, blind, and non-plated drill layers", async () => {
+  const zipBlob = await createFabricationFilesZip({
+    circuitJson: [] as AnyCircuitElement[],
+    gerberConverter: {
+      convertSoupToGerberCommands: () => ({ frontCopper: [] }),
+      stringifyGerberCommandLayers: () => ({ F_Cu: "front copper" }),
+      convertSoupToExcellonDrillCommandLayers: () => ({
+        "drill-L1-L2.drl": ["blind plated"],
+        "drill-L1-L4.drl": ["through plated"],
+        "drill_npth.drl": ["non-plated"],
+      }),
+      stringifyExcellonDrill: (commands) => commands.join("\n"),
+    },
+    bomConverter: {
+      convertCircuitJsonToBomRows: () => [],
+      convertBomRowsToCsv: () => "bom",
+    },
+    pnpConverter: {
+      convertCircuitJsonToPickAndPlaceCsv: () => "pnp",
+    },
+  })
+
+  const zip = await JSZip.loadAsync(await zipBlob.arrayBuffer())
+
+  expect(Object.keys(zip.files).sort()).toEqual([
+    "bom.csv",
+    "gerber/",
+    "gerber/F_Cu.gbr",
+    "gerber/drill-L1-L2.drl",
+    "gerber/drill-L1-L4.drl",
+    "gerber/drill_npth.drl",
+    "pick_and_place.csv",
+  ])
+  expect(await zip.file("gerber/drill-L1-L2.drl")?.async("string")).toBe(
+    "blind plated",
+  )
+  expect(await zip.file("gerber/drill-L1-L4.drl")?.async("string")).toBe(
+    "through plated",
+  )
+  expect(await zip.file("gerber/drill_npth.drl")?.async("string")).toBe(
+    "non-plated",
+  )
+})

--- a/bun-tests/download-fabrication-files.test.ts
+++ b/bun-tests/download-fabrication-files.test.ts
@@ -7,14 +7,12 @@ test("fabrication zip includes plated, blind, and non-plated drill layers", asyn
   const zipBlob = await createFabricationFilesZip({
     circuitJson: [] as AnyCircuitElement[],
     gerberConverter: {
-      convertSoupToGerberCommands: () => ({ frontCopper: [] }),
-      stringifyGerberCommandLayers: () => ({ F_Cu: "front copper" }),
-      convertSoupToExcellonDrillCommandLayers: () => ({
-        "drill-L1-L2.drl": ["blind plated"],
-        "drill-L1-L4.drl": ["through plated"],
-        "drill_npth.drl": ["non-plated"],
+      convertCircuitJsonToGerberFiles: () => ({
+        "F_Cu.gbr": "front copper",
+        "drill-L1-L2.drl": "blind plated",
+        "drill-L1-L4.drl": "through plated",
+        "drill_npth.drl": "non-plated",
       }),
-      stringifyExcellonDrill: (commands) => commands.join("\n"),
     },
     bomConverter: {
       convertCircuitJsonToBomRows: () => [],

--- a/src/lib/download-fns/download-fabrication-files.ts
+++ b/src/lib/download-fns/download-fabrication-files.ts
@@ -24,30 +24,17 @@ export const createFabricationFilesZip = async ({
   pnpConverter: PnpConverter
 }) => {
   const zip = new JSZip()
-  const {
-    convertSoupToGerberCommands,
-    stringifyGerberCommandLayers,
-    convertSoupToExcellonDrillCommandLayers,
-    stringifyExcellonDrill,
-  } = gerberConverter
   const { convertCircuitJsonToBomRows, convertBomRowsToCsv } = bomConverter
   const { convertCircuitJsonToPickAndPlaceCsv } = pnpConverter
 
-  const gerberLayerCmds = convertSoupToGerberCommands(circuitJson, {
-    flip_y_axis: false,
-  })
-  const gerberFileContents = stringifyGerberCommandLayers(gerberLayerCmds)
-
-  for (const [fileName, fileContents] of Object.entries(gerberFileContents)) {
-    zip.file(`gerber/${fileName}.gbr`, fileContents)
-  }
-
-  const drillCommandLayers = convertSoupToExcellonDrillCommandLayers({
+  const gerberFiles = gerberConverter.convertCircuitJsonToGerberFiles(
     circuitJson,
-    flip_y_axis: false,
-  })
-  for (const [fileName, drillCommands] of Object.entries(drillCommandLayers)) {
-    zip.file(`gerber/${fileName}`, stringifyExcellonDrill(drillCommands))
+    {
+      flip_y_axis: false,
+    },
+  )
+  for (const [fileName, fileContents] of Object.entries(gerberFiles)) {
+    zip.file(`gerber/${fileName}`, fileContents)
   }
 
   const bomRows = await convertCircuitJsonToBomRows({ circuitJson })

--- a/src/lib/download-fns/download-fabrication-files.ts
+++ b/src/lib/download-fns/download-fabrication-files.ts
@@ -8,6 +8,58 @@ import { saveAs } from "file-saver"
 import JSZip from "jszip"
 import { withDownloadToast } from "./download-toast"
 
+type GerberConverter = Awaited<ReturnType<typeof loadCircuitJsonToGerber>>
+type BomConverter = Awaited<ReturnType<typeof loadCircuitJsonToBomCsv>>
+type PnpConverter = Awaited<ReturnType<typeof loadCircuitJsonToPnpCsv>>
+
+export const createFabricationFilesZip = async ({
+  circuitJson,
+  gerberConverter,
+  bomConverter,
+  pnpConverter,
+}: {
+  circuitJson: AnyCircuitElement[]
+  gerberConverter: GerberConverter
+  bomConverter: BomConverter
+  pnpConverter: PnpConverter
+}) => {
+  const zip = new JSZip()
+  const {
+    convertSoupToGerberCommands,
+    stringifyGerberCommandLayers,
+    convertSoupToExcellonDrillCommandLayers,
+    stringifyExcellonDrill,
+  } = gerberConverter
+  const { convertCircuitJsonToBomRows, convertBomRowsToCsv } = bomConverter
+  const { convertCircuitJsonToPickAndPlaceCsv } = pnpConverter
+
+  const gerberLayerCmds = convertSoupToGerberCommands(circuitJson, {
+    flip_y_axis: false,
+  })
+  const gerberFileContents = stringifyGerberCommandLayers(gerberLayerCmds)
+
+  for (const [fileName, fileContents] of Object.entries(gerberFileContents)) {
+    zip.file(`gerber/${fileName}.gbr`, fileContents)
+  }
+
+  const drillCommandLayers = convertSoupToExcellonDrillCommandLayers({
+    circuitJson,
+    flip_y_axis: false,
+  })
+  for (const [fileName, drillCommands] of Object.entries(drillCommandLayers)) {
+    zip.file(`gerber/${fileName}`, stringifyExcellonDrill(drillCommands))
+  }
+
+  const bomRows = await convertCircuitJsonToBomRows({ circuitJson })
+  const bomCsv = await convertBomRowsToCsv(bomRows)
+  zip.file("bom.csv", bomCsv)
+
+  const pnpCsv = await convertCircuitJsonToPickAndPlaceCsv(circuitJson)
+  zip.file("pick_and_place.csv", pnpCsv)
+
+  return zip.generateAsync({ type: "blob" })
+}
+
 export const downloadFabricationFiles = async ({
   circuitJson,
   snippetUnscopedName,
@@ -18,50 +70,18 @@ export const downloadFabricationFiles = async ({
   const zipBlob = await withDownloadToast(
     "Preparing fabrication files...",
     async () => {
-      const zip = new JSZip()
+      const [gerberConverter, bomConverter, pnpConverter] = await Promise.all([
+        loadCircuitJsonToGerber(),
+        loadCircuitJsonToBomCsv(),
+        loadCircuitJsonToPnpCsv(),
+      ])
 
-      const {
-        convertSoupToGerberCommands,
-        stringifyGerberCommandLayers,
-        convertSoupToExcellonDrillCommands,
-        stringifyExcellonDrill,
-      } = await loadCircuitJsonToGerber()
-      const { convertCircuitJsonToBomRows, convertBomRowsToCsv } =
-        await loadCircuitJsonToBomCsv()
-      const { convertCircuitJsonToPickAndPlaceCsv } =
-        await loadCircuitJsonToPnpCsv()
-
-      // Generate Gerber files
-      const gerberLayerCmds = convertSoupToGerberCommands(circuitJson, {
-        flip_y_axis: false,
-      })
-      const gerberFileContents = stringifyGerberCommandLayers(gerberLayerCmds)
-
-      for (const [fileName, fileContents] of Object.entries(
-        gerberFileContents,
-      )) {
-        zip.file(`gerber/${fileName}.gbr`, fileContents)
-      }
-
-      // Generate Drill files
-      const drillCmds = convertSoupToExcellonDrillCommands({
+      return createFabricationFilesZip({
         circuitJson,
-        is_plated: true,
-        flip_y_axis: false,
+        gerberConverter,
+        bomConverter,
+        pnpConverter,
       })
-      const drillFileContents = stringifyExcellonDrill(drillCmds)
-      zip.file("gerber/drill.drl", drillFileContents)
-
-      // Generate BOM CSV
-      const bomRows = await convertCircuitJsonToBomRows({ circuitJson })
-      const bomCsv = await convertBomRowsToCsv(bomRows)
-      zip.file("bom.csv", bomCsv)
-
-      // Generate Pick and Place CSV
-      const pnpCsv = await convertCircuitJsonToPickAndPlaceCsv(circuitJson)
-      zip.file("pick_and_place.csv", pnpCsv)
-
-      return zip.generateAsync({ type: "blob" })
     },
   )
 

--- a/src/lib/utils/load-internal-dynamic-modules.ts
+++ b/src/lib/utils/load-internal-dynamic-modules.ts
@@ -16,18 +16,10 @@ type CircuitJsonToBomCsvModule = {
 }
 
 type CircuitJsonToGerberModule = {
-  convertSoupToGerberCommands: (
+  convertCircuitJsonToGerberFiles: (
     circuitJson: AnyCircuitElement[],
-    options?: any,
-  ) => any
-  stringifyGerberCommandLayers: (
-    gerberLayerCommands: any,
+    options?: { flip_y_axis?: boolean },
   ) => Record<string, string>
-  convertSoupToExcellonDrillCommandLayers: (params: {
-    circuitJson: AnyCircuitElement[]
-    flip_y_axis?: boolean
-  }) => Record<string, any[]>
-  stringifyExcellonDrill: (drillCommands: any) => string
 }
 
 type CircuitJsonToGltfModule = {

--- a/src/lib/utils/load-internal-dynamic-modules.ts
+++ b/src/lib/utils/load-internal-dynamic-modules.ts
@@ -23,7 +23,10 @@ type CircuitJsonToGerberModule = {
   stringifyGerberCommandLayers: (
     gerberLayerCommands: any,
   ) => Record<string, string>
-  convertSoupToExcellonDrillCommands: (params: any) => any
+  convertSoupToExcellonDrillCommandLayers: (params: {
+    circuitJson: AnyCircuitElement[]
+    flip_y_axis?: boolean
+  }) => Record<string, any[]>
   stringifyExcellonDrill: (drillCommands: any) => string
 }
 


### PR DESCRIPTION
## Summary
- consume convertCircuitJsonToGerberFiles from the dynamically loaded circuit-json-to-gerber package
- package the shared Gerber/Excellon file map with BOM and pick-and-place outputs
- include through-hole, blind/buried, and NPTH drill files
- add ZIP-content regression coverage

## Why
circuit-json-to-gerber@0.0.97 now owns complete Gerber and Excellon file generation. The site should package that authoritative file map rather than reproduce converter flags and drill-layer logic.

## Validation
- bun test bun-tests/download-fabrication-files.test.ts
- bun run typecheck
- Biome formatting
- git diff --check