### PR TITLE
Fix package social previews with built 3D image

### DIFF
--- a/api/generated-index.js
+++ b/api/generated-index.js
@@ -1,16 +1,17 @@
-// api/generated-index.js
-import ky from "ky"
 import { readFileSync } from "fs"
-import { join, dirname } from "path"
+import { dirname, join } from "path"
 import { fileURLToPath } from "url"
 import he from "he"
+// api/generated-index.js
+import ky from "ky"
+import { getPackageFileArtifactPaths } from "../server/package-file-artifacts.js"
+import { getPackagePageImageUrl } from "../server/package-page-seo.js"
 import {
   injectPackagePageContent,
   parsePackagePageRoute,
   renderPackagePageContent,
   serializeForInlineScript,
 } from "../server/package-page-ssr.js"
-import { getPackageFileArtifactPaths } from "../server/package-file-artifacts.js"
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
 
@@ -519,14 +520,13 @@ async function handlePackagePage(req, res, route) {
   const title = he.encode(
     getPackagePageTitle(route, packageInfo, data.packageRelease),
   )
-  const allowedViews = ["schematic", "pcb", "assembly", "3d"]
-  const defaultView = packageInfo.default_view || "3d"
-  const thumbnailView = allowedViews.includes(defaultView) ? defaultView : "3d"
-  const imageUrl = `${REGISTRY_URL}/packages/images/${encodeURIComponent(
-    route.author,
-  )}/${encodeURIComponent(route.packageName)}/${thumbnailView}.png?fs_sha=${encodeURIComponent(
-    packageInfo.latest_package_release_fs_sha || "",
-  )}`
+  const imageUrl = getPackagePageImageUrl({
+    registryUrl: REGISTRY_URL,
+    packageInfo,
+    packageRelease: data.packageRelease,
+    author: route.author,
+    packageName: route.packageName,
+  })
   const ssrContent = renderPackagePageContent(data)
   const html = getHtmlWithModifiedSeoTags({
     title,
@@ -643,14 +643,13 @@ async function handleCustomPackageHtml(req, res) {
   )
   const title = he.encode(`${packageInfo.name} - tscircuit`)
 
-  const allowedViews = ["schematic", "pcb", "assembly", "3d"]
-  const defaultView = packageInfo.default_view || "3d"
-  const thumbnailView = allowedViews.includes(defaultView) ? defaultView : "3d"
-  const imageUrl = `${REGISTRY_URL}/packages/images/${he.encode(
+  const imageUrl = getPackagePageImageUrl({
+    registryUrl: REGISTRY_URL,
+    packageInfo,
+    packageRelease,
     author,
-  )}/${he.encode(unscopedPackageName)}/${thumbnailView}.png?fs_sha=${
-    packageInfo.latest_package_release_fs_sha
-  }`
+    packageName: unscopedPackageName,
+  })
 
   const html = getHtmlWithModifiedSeoTags({
     title,

--- a/bun-tests/package-page-seo.test.js
+++ b/bun-tests/package-page-seo.test.js
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test"
+import { getPackagePageImageUrl } from "../server/package-page-seo.js"
+
+const registryUrl = "https://api.tscircuit.com"
+const baseOptions = {
+  registryUrl,
+  packageInfo: {
+    default_view: "3d",
+    latest_package_release_fs_sha: "md5-latest",
+  },
+  packageRelease: null,
+  author: "alice",
+  packageName: "board",
+}
+
+describe("getPackagePageImageUrl", () => {
+  test("uses the release's built dist 3D preview", () => {
+    const builtPreviewUrl =
+      "https://api.tscircuit.com/package_files/view?package_release_id=release-1&file_path=dist%2Findex%2F3d.png"
+
+    expect(
+      getPackagePageImageUrl({
+        ...baseOptions,
+        packageRelease: { cad_preview_image_url: builtPreviewUrl },
+      }),
+    ).toBe(builtPreviewUrl)
+  })
+
+  test("falls back to the package's latest built 3D preview", () => {
+    const builtPreviewPath =
+      "/package_files/view?package_release_id=release-1&file_path=dist%2Findex%2F3d.png"
+
+    expect(
+      getPackagePageImageUrl({
+        ...baseOptions,
+        packageInfo: {
+          ...baseOptions.packageInfo,
+          latest_cad_preview_image_url: builtPreviewPath,
+        },
+      }),
+    ).toBe(`${registryUrl}${builtPreviewPath}`)
+  })
+
+  test("uses the image renderer when no built 3D preview is available", () => {
+    expect(getPackagePageImageUrl(baseOptions)).toBe(
+      `${registryUrl}/packages/images/alice/board/3d.png?fs_sha=md5-latest`,
+    )
+  })
+
+  test("preserves the configured non-3D thumbnail renderer", () => {
+    expect(
+      getPackagePageImageUrl({
+        ...baseOptions,
+        packageInfo: { ...baseOptions.packageInfo, default_view: "pcb" },
+      }),
+    ).toBe(
+      `${registryUrl}/packages/images/alice/board/pcb.png?fs_sha=md5-latest`,
+    )
+  })
+})

--- a/server/package-page-seo.js
+++ b/server/package-page-seo.js
@@ -1,0 +1,38 @@
+const allowedThumbnailViews = new Set(["schematic", "pcb", "assembly", "3d"])
+
+const makeAbsoluteUrl = (url, baseUrl) => {
+  try {
+    return new URL(url, `${baseUrl.replace(/\/+$/, "")}/`).toString()
+  } catch {
+    return url
+  }
+}
+
+export const getPackagePageImageUrl = ({
+  registryUrl,
+  packageInfo,
+  packageRelease,
+  author,
+  packageName,
+}) => {
+  const defaultView = packageInfo.default_view || "3d"
+  const thumbnailView = allowedThumbnailViews.has(defaultView)
+    ? defaultView
+    : "3d"
+
+  if (thumbnailView === "3d") {
+    const builtCadPreviewUrl =
+      packageRelease?.cad_preview_image_url ??
+      packageInfo.latest_cad_preview_image_url
+
+    if (builtCadPreviewUrl) {
+      return makeAbsoluteUrl(builtCadPreviewUrl, registryUrl)
+    }
+  }
+
+  return `${registryUrl}/packages/images/${encodeURIComponent(
+    author,
+  )}/${encodeURIComponent(packageName)}/${thumbnailView}.png?fs_sha=${encodeURIComponent(
+    packageInfo.latest_package_release_fs_sha || "",
+  )}`
+}


### PR DESCRIPTION
## Summary

- use the release CAD preview URL for 3D package-page social metadata
- reference the already-built dist/index/3d.png artifact instead of rerendering Circuit JSON
- retain the packages/images renderer as a fallback when no built preview exists
- preserve the configured renderer for PCB, schematic, and assembly thumbnails

## Tests

- bun test bun-tests/package-page-seo.test.js bun-tests/package-page-ssr.test.js
- bun run typecheck
- Biome check on changed files