### PR TITLE
fix: export all schematic sheets in image downloads

### DIFF
--- a/src/lib/download-fns/download-circuit-png.ts
+++ b/src/lib/download-fns/download-circuit-png.ts
@@ -4,7 +4,7 @@ import {
   convertCircuitJsonToAssemblySvg,
   convertCircuitJsonToPcbSvg,
   convertCircuitJsonToPinoutSvg,
-  convertCircuitJsonToSchematicSvg,
+  convertCircuitJsonToStackedSchematicSheetsSvg,
 } from "circuit-to-svg"
 import { saveAs } from "file-saver"
 import { withDownloadToast } from "./download-toast"
@@ -23,7 +23,7 @@ const SVG_RENDERERS: Record<
   string,
   (circuitJson: AnyCircuitElement[], options: any) => string
 > = {
-  schematic: convertCircuitJsonToSchematicSvg,
+  schematic: convertCircuitJsonToStackedSchematicSheetsSvg,
   pcb: convertCircuitJsonToPcbSvg,
   assembly: convertCircuitJsonToAssemblySvg,
   pinout: convertCircuitJsonToPinoutSvg,

--- a/src/lib/download-fns/download-schematic-svg.ts
+++ b/src/lib/download-fns/download-schematic-svg.ts
@@ -1,12 +1,12 @@
 import { AnyCircuitElement } from "circuit-json"
-import { convertCircuitJsonToSchematicSvg } from "circuit-to-svg"
+import { convertCircuitJsonToStackedSchematicSheetsSvg } from "circuit-to-svg"
 import { saveAs } from "file-saver"
 
 export const downloadSchematicSvg = (
   circuitJson: AnyCircuitElement[],
   fileName: string,
 ) => {
-  const svg = convertCircuitJsonToSchematicSvg(circuitJson)
-  const blob = new Blob([svg], { type: "image/svg" })
+  const svg = convertCircuitJsonToStackedSchematicSheetsSvg(circuitJson)
+  const blob = new Blob([svg], { type: "image/svg+xml" })
   saveAs(blob, fileName + ".svg")
 }


### PR DESCRIPTION
## Motivation

Projects can contain multiple `schematic_sheet` elements, but schematic PNG and SVG downloads used `convertCircuitJsonToSchematicSvg`. That renderer intentionally selects one sheet, so multi-sheet projects downloaded only their first/default sheet—for example, the `host` sheet in `mohan-bee/hub`.

`circuit-to-svg` already provides `convertCircuitJsonToStackedSchematicSheetsSvg`, which renders every sheet in `sheet_index` order and preserves the existing behavior for projects with zero or one sheet.

## Changes

- use `convertCircuitJsonToStackedSchematicSheetsSvg` directly for schematic SVG downloads
- use the same stacked renderer before rasterizing schematic PNG downloads
- use the standard `image/svg+xml` MIME type for SVG downloads

## Result

Schematic PNG and SVG downloads now contain every sheet in one vertically stacked image. Single-sheet projects continue to render normally. PCB, assembly, pinout, and 3D downloads are unchanged.

## Testing

- `bun run typecheck`
- Biome formatting check on both changed files

## Reference

### Before

https://github.com/user-attachments/assets/146e12e2-7694-46d5-9fd6-976c578cda0a

### After

https://github.com/user-attachments/assets/166b2962-147e-42c7-b056-ee5585cbfda4
