### PR TITLE
fix: avoid opening lockfiles by default in the editor

### DIFF
--- a/bun-tests/lib/findPriorityFilePath.test.ts
+++ b/bun-tests/lib/findPriorityFilePath.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, test } from "bun:test"
+import { findPriorityFilePath } from "@/lib/utils/findPriorityFilePath"
+import { findTargetFile } from "@/lib/utils/findTargetFile"
+
+const metadata = (...paths: string[]) =>
+  paths.map((file_path) => ({ file_path }))
+
+const packageFiles = (...paths: string[]) =>
+  paths.map((path) => ({ path, content: "" }))
+
+const lockfiles = [
+  "bun.lock",
+  "bun.lockb",
+  "package-lock.json",
+  "yarn.lock",
+  "pnpm-lock.yaml",
+]
+
+describe("findPriorityFilePath", () => {
+  test("opens the circuit entrypoint for the reported package file order", () => {
+    expect(
+      findPriorityFilePath(
+        metadata(
+          "bun.lock",
+          "dist/index.js",
+          "imports/AP2112K_3_3TRG1.tsx",
+          "index.circuit.tsx",
+          "package.json",
+          "tscircuit.config.json",
+          "tsconfig.json",
+        ),
+      ),
+    ).toBe("index.circuit.tsx")
+  })
+
+  test.each([
+    "index.tsx",
+    "index.ts",
+    "index.circuit.tsx",
+    "src/board.circuit.tsx",
+    "main.tsx",
+    "main.ts",
+    "Board.tsx",
+  ])("prefers %s over lockfiles and package metadata", (entrypoint) => {
+    expect(
+      findPriorityFilePath(metadata(...lockfiles, "package.json", entrypoint)),
+    ).toBe(entrypoint)
+  })
+
+  test("uses the same entrypoint precedence as the editor", () => {
+    const paths = [
+      "bun.lock",
+      "Board.tsx",
+      "main.ts",
+      "board.circuit.tsx",
+      "index.tsx",
+    ]
+
+    while (paths.length > 1) {
+      expect(findPriorityFilePath(metadata(...paths))).toBe(
+        findTargetFile({
+          files: packageFiles(...paths),
+          filePathFromUrl: null,
+        })?.path ?? null,
+      )
+      paths.pop()
+    }
+  })
+
+  test.each(lockfiles)("does not fall back to %s", (lockfile) => {
+    expect(findPriorityFilePath(metadata(lockfile, "README.md"))).toBe(
+      "README.md",
+    )
+  })
+
+  test("skips generated and hidden files, including nested lockfiles", () => {
+    expect(
+      findPriorityFilePath(
+        metadata(
+          "dist/index.tsx",
+          ".github/workflows/build.yml",
+          "nested/bun.lock",
+          "README.md",
+        ),
+      ),
+    ).toBe("README.md")
+  })
+
+  test.each([
+    { paths: [] },
+    { paths: lockfiles },
+    { paths: ["dist/index.tsx", "nested/bun.lock"] },
+  ])("returns null when no default file is eligible: %j", ({ paths }) => {
+    expect(findPriorityFilePath(metadata(...paths))).toBeNull()
+  })
+
+  test("keeps an explicitly requested lockfile accessible", () => {
+    expect(
+      findPriorityFilePath(
+        metadata("index.circuit.tsx", "bun.lock"),
+        "bun.lock",
+      ),
+    ).toBe("bun.lock")
+  })
+
+  test("preserves exact and partial URL file selection", () => {
+    const files = metadata("bun.lock", "index.tsx", "src/helper.ts")
+
+    expect(findPriorityFilePath(files, "src/helper.ts")).toBe("src/helper.ts")
+    expect(findPriorityFilePath(files, "helper.ts")).toBe("src/helper.ts")
+  })
+
+  test("uses a safe default when the requested file does not exist", () => {
+    expect(
+      findPriorityFilePath(
+        metadata("bun.lock", "index.circuit.tsx"),
+        "missing.tsx",
+      ),
+    ).toBe("index.circuit.tsx")
+  })
+})
+
+describe("findTargetFile default fallback", () => {
+  test("does not select a lockfile when the URL file is missing", () => {
+    expect(
+      findTargetFile({
+        files: packageFiles("bun.lock", "README.md"),
+        filePathFromUrl: "missing.tsx",
+      })?.path,
+    ).toBe("README.md")
+  })
+
+  test("returns null for a lockfile-only package with a missing URL file", () => {
+    expect(
+      findTargetFile({
+        files: packageFiles(...lockfiles),
+        filePathFromUrl: "missing.tsx",
+      }),
+    ).toBeNull()
+  })
+
+  test("allows opening a lockfile explicitly", () => {
+    expect(
+      findTargetFile({
+        files: packageFiles("bun.lock", "index.circuit.tsx"),
+        filePathFromUrl: "bun.lock",
+      })?.path,
+    ).toBe("bun.lock")
+  })
+
+  test("still honors a configured entrypoint when content is loaded", () => {
+    expect(
+      findTargetFile({
+        files: [
+          ...packageFiles("bun.lock", "index.tsx", "src/board.tsx"),
+          {
+            path: "tscircuit.config.json",
+            content: JSON.stringify({ mainEntrypoint: "./src/board.tsx" }),
+          },
+        ],
+        filePathFromUrl: null,
+      })?.path,
+    ).toBe("src/board.tsx")
+  })
+})

--- a/playwright-tests/editor-default-file.spec.ts
+++ b/playwright-tests/editor-default-file.spec.ts
@@ -1,0 +1,162 @@
+import { expect, test, type Page } from "@playwright/test"
+import { gzipSync, strToU8 } from "fflate"
+
+const packageId = "ceec4b8f-865f-4e81-8937-74c8cfa57d89"
+const releaseId = "ff2cab7b-d3e3-46e2-9046-c1929999ffe6"
+const editorUrl = `http://127.0.0.1:5177/editor?package_id=${packageId}`
+
+const mockPackage = async (
+  page: Page,
+  files: Record<string, string>,
+  beforeFileResponse?: (path: string) => Promise<void>,
+) => {
+  await page.route("**/api/packages/get?**", async (route) => {
+    await route.fulfill({
+      json: {
+        package: {
+          package_id: packageId,
+          name: "testuser/default-file-regression",
+          unscoped_name: "default-file-regression",
+          owner_github_username: "testuser",
+          creator_account_id: "account-1234",
+          latest_package_release_id: releaseId,
+          is_private: false,
+          star_count: 0,
+        },
+      },
+    })
+  })
+
+  await page.route("**/api/package_releases/get**", async (route) => {
+    await route.fulfill({
+      json: {
+        package_release: {
+          package_release_id: releaseId,
+          package_id: packageId,
+          version: "1.0.0",
+        },
+      },
+    })
+  })
+
+  const packageFiles = Object.entries(files).map(
+    ([file_path, content_text]) => ({
+      package_file_id: file_path,
+      package_release_id: releaseId,
+      file_path,
+      content_text,
+      is_text: true,
+    }),
+  )
+
+  await page.route("**/api/package_files/list?**", async (route) => {
+    await route.fulfill({
+      json: {
+        package_files: packageFiles.map(({ content_text, ...file }) => file),
+      },
+    })
+  })
+
+  await page.route("**/api/package_files/get?**", async (route) => {
+    const fileId = new URL(route.request().url()).searchParams.get(
+      "package_file_id",
+    )
+    const file = packageFiles.find((file) => file.package_file_id === fileId)
+    if (!file) return route.fulfill({ status: 404, json: {} })
+
+    await beforeFileResponse?.(file.file_path)
+    await route.fulfill({ json: { package_file: file } })
+  })
+}
+
+test("opens the circuit entrypoint even when the lockfile loads first", async ({
+  page,
+}) => {
+  let releaseEntrypoint!: () => void
+  const entrypointGate = new Promise<void>((resolve) => {
+    releaseEntrypoint = resolve
+  })
+  await mockPackage(
+    page,
+    {
+      "bun.lock": '{"lockfileVersion": 1}',
+      "imports/part.tsx": "export const Part = () => <resistor />",
+      "index.circuit.tsx":
+        'export default () => <board width="10mm" height="10mm" />',
+      "package.json": "{}",
+    },
+    async (path) => {
+      if (path === "index.circuit.tsx") await entrypointGate
+    },
+  )
+
+  const lockfileLoaded = page.waitForResponse((response) =>
+    response.url().includes("package_file_id=bun.lock"),
+  )
+  await page.goto(editorUrl)
+  try {
+    await lockfileLoaded
+    await expect(page.getByText("Select a file to start editing")).toBeVisible()
+    await expect(
+      page.getByRole("navigation", { name: "breadcrumb" }),
+    ).toHaveCount(0)
+  } finally {
+    releaseEntrypoint()
+  }
+
+  await expect(
+    page.getByRole("navigation", { name: "breadcrumb" }),
+  ).toContainText("index.circuit.tsx")
+})
+
+test("still opens a lockfile explicitly requested in the URL", async ({
+  page,
+}) => {
+  await mockPackage(page, {
+    "bun.lock": '{"lockfileVersion": 1}',
+    "index.circuit.tsx": "export default () => <board />",
+  })
+
+  await page.goto(`${editorUrl}&file_path=bun.lock`)
+
+  await expect(page.getByRole("navigation", { name: "breadcrumb" })).toHaveText(
+    "bun.lock",
+  )
+})
+
+test("a lockfile-only package finishes loading without a default selection", async ({
+  page,
+}) => {
+  await mockPackage(page, { "bun.lock": '{"lockfileVersion": 1}' })
+  const lockfileLoaded = page.waitForResponse((response) =>
+    response.url().includes("package_file_id=bun.lock"),
+  )
+
+  await page.goto(editorUrl)
+  await lockfileLoaded
+
+  await expect(page.getByText("Select a file to start editing")).toBeVisible()
+  await expect(
+    page.getByText("Loading files...", { exact: true }),
+  ).not.toBeVisible()
+  await expect(
+    page.getByRole("navigation", { name: "breadcrumb" }),
+  ).toHaveCount(0)
+})
+
+test("a lockfile-only URL hash does not reopen the first file", async ({
+  page,
+}) => {
+  const encodedFiles = Buffer.from(
+    gzipSync(strToU8(JSON.stringify({ "bun.lock": '{"lockfileVersion": 1}' }))),
+  ).toString("base64")
+
+  await page.goto(
+    `http://127.0.0.1:5177/editor#data:application/gzip;base64,${encodedFiles}`,
+  )
+
+  await expect(page.getByText("Select a file to start editing")).toBeVisible()
+  await expect(
+    page.getByRole("navigation", { name: "breadcrumb" }),
+  ).toHaveCount(0)
+})

--- a/src/hooks/useFileManagement.ts
+++ b/src/hooks/useFileManagement.ts
@@ -189,7 +189,7 @@ export function useFileManagement({
         })
         setLocalFiles(filesFromUrl)
         setInitialFiles([])
-        setCurrentFile(targetFile?.path || filesFromUrl[0]?.path || null)
+        setCurrentFile(targetFile?.path ?? null)
         return
       }
 

--- a/src/hooks/useOptimizedPackageFilesLoader.ts
+++ b/src/hooks/useOptimizedPackageFilesLoader.ts
@@ -4,6 +4,7 @@ import { useApiBaseUrl } from "@/hooks/use-packages-base-api-url"
 import type { Package } from "fake-snippets-api/lib/db/schema"
 import { useMemo, useState } from "react"
 import { isDownloadOnlyPackageFile } from "@/lib/is-download-only-package-file"
+import { findPriorityFilePath } from "@/lib/utils/findPriorityFilePath"
 import { useQueries, useQuery } from "react-query"
 import { useGlobalStore } from "./use-global-store"
 
@@ -47,26 +48,7 @@ export function useOptimizedPackageFilesLoader(
   const targetFilePath = useMemo(() => {
     if (!pkgFiles.data) return priorityFilePath
 
-    if (priorityFilePath) {
-      const exactMatch = pkgFiles.data.find(
-        (f) => f.file_path === priorityFilePath,
-      )
-      if (exactMatch) return exactMatch.file_path
-
-      const partialMatch = pkgFiles.data.find(
-        (f) =>
-          f.file_path.includes(priorityFilePath) ||
-          priorityFilePath.includes(f.file_path),
-      )
-      if (partialMatch) return partialMatch.file_path
-    }
-
-    // Check for index.tsx first
-    const indexFile = pkgFiles.data.find((f) => f.file_path === "index.tsx")
-    if (indexFile) return indexFile.file_path
-
-    // Fallback to first file
-    return pkgFiles.data[0]?.file_path || null
+    return findPriorityFilePath(pkgFiles.data, priorityFilePath)
   }, [pkgFiles.data, priorityFilePath])
 
   const priorityFileData = pkgFiles.data?.find(
@@ -214,17 +196,21 @@ export function useOptimizedPackageFilesLoader(
     priorityFileQuery.isLoading
   const error =
     priorityFileQuery.error || remainingFilesQueries.find((q) => q.error)?.error
+  // A package containing only hidden files has no automatic selection, so
+  // there is no priority request to wait for before showing the file browser.
+  const isPriorityFileFetched =
+    priorityFileQuery.isFetched || (pkgFiles.isFetched && !targetFilePath)
 
   return {
     priorityFile: priorityFileQuery.data || null,
-    priorityFileFetched: priorityFileQuery.isFetched,
+    priorityFileFetched: isPriorityFileFetched,
     allFiles,
-    isPriorityLoading: priorityFileQuery.isLoading,
+    isPriorityLoading: Boolean(priorityFileData) && priorityFileQuery.isLoading,
     areAllFilesLoading,
     error,
     isMetaLoading: pkgFiles.isLoading,
     totalFilesCount: pkgFiles.data?.length || 0,
     loadedFilesCount: allFiles.length,
-    isPriorityFileFetched: priorityFileQuery.isFetched,
+    isPriorityFileFetched,
   }
 }

--- a/src/lib/utils/findPriorityFilePath.ts
+++ b/src/lib/utils/findPriorityFilePath.ts
@@ -1,0 +1,27 @@
+import { findTargetFile } from "./findTargetFile"
+
+export const findPriorityFilePath = (
+  files: { file_path: string }[],
+  priorityFilePath?: string | null,
+): string | null => {
+  if (priorityFilePath) {
+    const exactMatch = files.find((f) => f.file_path === priorityFilePath)
+    if (exactMatch) return exactMatch.file_path
+
+    const partialMatch = files.find(
+      (f) =>
+        f.file_path.includes(priorityFilePath) ||
+        priorityFilePath.includes(f.file_path),
+    )
+    if (partialMatch) return partialMatch.file_path
+  }
+
+  // Only paths are available before file contents load. Reuse the editor's
+  // default selection rules instead of relying on the API's file order.
+  return (
+    findTargetFile({
+      files: files.map((file) => ({ path: file.file_path, content: "" })),
+      filePathFromUrl: null,
+    })?.path ?? null
+  )
+}

--- a/src/lib/utils/findTargetFile.ts
+++ b/src/lib/utils/findTargetFile.ts
@@ -64,10 +64,6 @@ export const findTargetFile = ({
   }
 
   let targetFile: PackageFile | undefined | null = null
-  if (!filePathFromUrl) {
-    files = files.filter((x) => !isHiddenFile(x.path))
-  }
-
   if (filePathFromUrl) {
     const file = files.find((file) => file.path === filePathFromUrl)?.path
     if (
@@ -86,6 +82,10 @@ export const findTargetFile = ({
       }
     }
   }
+
+  // Explicit selections may open hidden files, but automatic fallbacks must
+  // exclude them even when the URL points to a file that no longer exists.
+  files = files.filter((file) => !isHiddenFile(file.path))
 
   if (!targetFile) {
     targetFile =


### PR DESCRIPTION
## Summary

- Use the editor's existing default-file selection rules in the optimized package loader, recognizing `index.ts`, `*.circuit.tsx`, `main.ts(x)`, and other TSX files while excluding lockfiles and generated/hidden files.
- Preserve explicit file selection, including links that intentionally open a lockfile.
- Keep automatic fallbacks safe when a URL references a missing file or contains only lockfiles, and finish loading when there is no eligible default file.

## Root cause

The optimized loader checked only for `index.tsx`, then selected the first file returned by `/package_files/list`. It bypassed `findTargetFile`, which already recognizes circuit entrypoints and excludes lockfiles. Once the priority file was selected, `useFileManagement` retained that selection as the other files arrived.

For [ShiboSoftwareDev/msp430f5503-usb-c-dev-board](https://tscircuit.com/editor?package_id=ceec4b8f-865f-4e81-8937-74c8cfa57d89), the live API returns `bun.lock` first and the circuit entrypoint is `index.circuit.tsx`, so the loader opened `bun.lock`.

Also inspected the related API file-list endpoint and the installed Monaco editor implementation. File order is not an entrypoint contract, and Monaco receives its selected file from this application; no changes to those repositories are needed.

## Verification

- Reproduced the original `bun.lock` selection with a regression test before applying the fix.
- `bun test`: 314 passed, 5 skipped, 0 failed (includes 25 selection regression tests).
- `bunx tsc --noEmit`: passed.
- Biome formatting checks on all changed files: passed.
- `bunx playwright test playwright-tests/editor-default-file.spec.ts --workers=1 --retries=0 --reporter=line`: 4 passed.
  - Circuit entrypoint selected even when the lockfile loads first.
  - Explicit `file_path=bun.lock` remains supported.
  - Lockfile-only packages finish loading without a default selection.
  - Lockfile-only URL hashes do not reopen the first file.
