### PR TITLE
fix: explain avatar upload failures

### DIFF
--- a/bun-tests/get-avatar-upload-error-message.test.ts
+++ b/bun-tests/get-avatar-upload-error-message.test.ts
@@ -1,0 +1,77 @@
+import { expect, test } from "bun:test"
+import { getAvatarUploadErrorMessage } from "@/lib/get-avatar-upload-error-message"
+
+test.each([
+  { data: { error: { message: "Avatar file is empty" } } },
+  { data: { message: "Avatar file is empty" } },
+  { response: { data: { error: { message: "Avatar file is empty" } } } },
+  { response: { data: { message: "Avatar file is empty" } } },
+])("preserves the API rejection reason: %j", (error) => {
+  expect(getAvatarUploadErrorMessage(error)).toBe("Avatar file is empty")
+})
+
+test("prefers the server's explanation to the HTTP fallback", () => {
+  expect(
+    getAvatarUploadErrorMessage({
+      status: 503,
+      data: { message: "Avatar uploads are temporarily unavailable" },
+    }),
+  ).toBe("Avatar uploads are temporarily unavailable")
+})
+
+test("ignores malformed and blank messages without hiding a useful reason", () => {
+  expect(
+    getAvatarUploadErrorMessage({
+      data: { error: { message: { detail: "invalid" } }, message: "  " },
+      response: { data: { message: "  The image could not be read.  " } },
+    }),
+  ).toBe("The image could not be read.")
+})
+
+test.each([
+  [401, "Please sign in again before uploading your avatar."],
+  [403, "You don't have permission to update this avatar."],
+  [
+    413,
+    "The image is too large to upload. Choose a smaller image (up to 5MB).",
+  ],
+  [415, "This image format isn't supported. Try a PNG, JPG, or GIF image."],
+  [429, "Too many upload attempts. Please wait a moment and try again."],
+  [500, "The server couldn't save your avatar. Please try again later."],
+  [503, "The server couldn't save your avatar. Please try again later."],
+])("explains HTTP %i when there is no API message", (status, message) => {
+  expect(getAvatarUploadErrorMessage({ status, data: "" })).toBe(message)
+  expect(
+    getAvatarUploadErrorMessage({
+      response: { status, data: "<html>Upload failed</html>" },
+      message: `Request failed with status code ${status}`,
+    }),
+  ).toBe(message)
+})
+
+test.each([
+  new TypeError("Failed to fetch"),
+  new TypeError("Load failed"),
+  new TypeError("NetworkError when attempting to fetch resource."),
+  { code: "ERR_NETWORK" },
+  { status: 0 },
+])("explains a network failure: %j", (error) => {
+  expect(getAvatarUploadErrorMessage(error)).toBe(
+    "Unable to reach the upload server. Check your internet connection and try again.",
+  )
+})
+
+test("preserves ordinary Error messages", () => {
+  expect(
+    getAvatarUploadErrorMessage(new Error("The image could not be read.")),
+  ).toBe("The image could not be read.")
+})
+
+test.each([null, undefined, {}, { data: "<html>Upload failed</html>" }])(
+  "provides a next step for an unknown failure: %j",
+  (error) => {
+    expect(getAvatarUploadErrorMessage(error)).toBe(
+      "We couldn't upload your avatar. Please try again. If it still fails, contact support.",
+    )
+  },
+)

--- a/playwright-tests/avatar-upload-errors.spec.ts
+++ b/playwright-tests/avatar-upload-errors.spec.ts
@@ -1,0 +1,101 @@
+import { expect, test } from "@playwright/test"
+
+const avatar = {
+  name: "avatar.png",
+  mimeType: "image/png",
+  buffer: Buffer.from(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/l9sAAAAASUVORK5CYII=",
+    "base64",
+  ),
+}
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    localStorage.setItem(
+      "session_store",
+      JSON.stringify({
+        state: {
+          session: {
+            token: "avatar-upload-test",
+            account_id: "account-1234",
+            session_id: "session-1234",
+            github_username: "testuser",
+            tscircuit_handle: "testuser",
+          },
+        },
+        version: 0,
+      }),
+    )
+  })
+
+  await Promise.all([
+    page.waitForResponse("**/orgs/get?org_id=org-1234"),
+    page.goto("http://127.0.0.1:5177/settings"),
+  ])
+  await page.getByRole("button", { name: "Update avatar" }).click()
+  const dialog = page.getByRole("dialog")
+  const fileChooserPromise = page.waitForEvent("filechooser")
+  await dialog.locator('input[type="file"]').click()
+  await (await fileChooserPromise).setFiles(avatar)
+  await expect(dialog.getByText(avatar.name)).toBeVisible()
+})
+
+for (const { name, status, body, message } of [
+  {
+    name: "a top-level API rejection reason",
+    status: 400,
+    body: JSON.stringify({ message: "The image could not be read." }),
+    message: "The image could not be read.",
+  },
+  {
+    name: "a nested API rejection reason",
+    status: 400,
+    body: JSON.stringify({ error: { message: "Avatar file is empty" } }),
+    message: "Avatar file is empty",
+  },
+  {
+    name: "an upload size rejection without JSON",
+    status: 413,
+    body: "Payload Too Large",
+    message:
+      "The image is too large to upload. Choose a smaller image (up to 5MB).",
+  },
+  {
+    name: "a server failure without a message",
+    status: 503,
+    body: "",
+    message: "The server couldn't save your avatar. Please try again later.",
+  },
+]) {
+  test(`shows ${name} in the dialog and toast`, async ({ page }) => {
+    await page.route("**/orgs/upload_avatar", (route) =>
+      route.fulfill({ status, body }),
+    )
+    const dialog = page.getByRole("dialog")
+    await dialog.getByRole("button", { name: "Save avatar" }).click()
+
+    await expect(dialog.getByRole("alert")).toHaveText(message)
+    await expect(page.getByText(message, { exact: true })).toHaveCount(2)
+    await expect(dialog.getByText(avatar.name)).toBeVisible()
+    await expect(
+      dialog.getByRole("button", { name: "Save avatar" }),
+    ).toBeEnabled()
+  })
+}
+
+test("explains a network failure and lets the user retry the selected image", async ({
+  page,
+}) => {
+  await page.route("**/orgs/upload_avatar", (route) => route.abort("failed"))
+  const dialog = page.getByRole("dialog")
+  await dialog.getByRole("button", { name: "Save avatar" }).click()
+
+  await expect(dialog.getByRole("alert")).toHaveText(
+    "Unable to reach the upload server. Check your internet connection and try again.",
+  )
+
+  await page.unroute("**/orgs/upload_avatar")
+  await dialog.getByRole("button", { name: "Save avatar" }).click()
+  await expect(page.getByText("Avatar updated", { exact: true })).toBeVisible()
+  await expect(dialog).not.toBeVisible()
+})

--- a/src/hooks/use-avatar-upload-dialog.tsx
+++ b/src/hooks/use-avatar-upload-dialog.tsx
@@ -14,6 +14,7 @@ import {
 import { Loader2 } from "lucide-react"
 import { useToast } from "@/hooks/use-toast"
 import { useUploadOrgAvatarMutation } from "@/hooks/use-upload-org-avatar-mutation"
+import { getAvatarUploadErrorMessage } from "@/lib/get-avatar-upload-error-message"
 
 interface UseAvatarUploadDialogProps {
   orgId: string | null | undefined
@@ -59,11 +60,8 @@ export const useAvatarUploadDialog = ({
       setIsOpen(false)
       onSuccess?.()
     },
-    onError: (err: any) => {
-      const errorMessage =
-        err?.data?.error?.message ||
-        err?.response?.data?.error?.message ||
-        "Failed to upload avatar"
+    onError: (err: unknown) => {
+      const errorMessage = getAvatarUploadErrorMessage(err)
       setError(errorMessage)
       toast({
         title: "Failed to upload avatar",
@@ -164,7 +162,11 @@ export const useAvatarUploadDialog = ({
               onChange={handleFileChange}
               disabled={uploadMutation.isLoading}
             />
-            {error && <p className="text-sm text-red-600">{error}</p>}
+            {error && (
+              <p role="alert" className="text-sm text-red-600">
+                {error}
+              </p>
+            )}
             <p className="text-xs text-gray-500">
               Supported formats: PNG, JPG, GIF. Max size 5MB.
             </p>

--- a/src/lib/get-avatar-upload-error-message.ts
+++ b/src/lib/get-avatar-upload-error-message.ts
@@ -1,0 +1,65 @@
+type UploadErrorResponse = {
+  status?: number
+  data?: {
+    error?: { message?: unknown }
+    message?: unknown
+  }
+}
+
+type UploadError = UploadErrorResponse & {
+  response?: UploadErrorResponse
+  message?: unknown
+  code?: string
+}
+
+export const getAvatarUploadErrorMessage = (error: unknown): string => {
+  const uploadError = error as UploadError | null | undefined
+
+  // Redaxios rejects with the response itself; Axios wraps it in `response`.
+  const messages = [
+    uploadError?.data?.error?.message,
+    uploadError?.data?.message,
+    uploadError?.response?.data?.error?.message,
+    uploadError?.response?.data?.message,
+  ]
+  for (const message of messages) {
+    if (typeof message === "string" && message.trim()) {
+      return message.trim()
+    }
+  }
+
+  const status = uploadError?.response?.status ?? uploadError?.status
+  switch (status) {
+    case 401:
+      return "Please sign in again before uploading your avatar."
+    case 403:
+      return "You don't have permission to update this avatar."
+    case 413:
+      return "The image is too large to upload. Choose a smaller image (up to 5MB)."
+    case 415:
+      return "This image format isn't supported. Try a PNG, JPG, or GIF image."
+    case 429:
+      return "Too many upload attempts. Please wait a moment and try again."
+  }
+
+  if (status && status >= 500) {
+    return "The server couldn't save your avatar. Please try again later."
+  }
+
+  const message =
+    typeof uploadError?.message === "string" ? uploadError.message.trim() : ""
+  if (
+    status === 0 ||
+    uploadError?.code === "ERR_NETWORK" ||
+    /^(failed to fetch|fetch failed|network ?error|networkerror when attempting to fetch resource\.?|load failed)$/i.test(
+      message,
+    )
+  ) {
+    return "Unable to reach the upload server. Check your internet connection and try again."
+  }
+
+  return (
+    message ||
+    "We couldn't upload your avatar. Please try again. If it still fails, contact support."
+  )
+}


### PR DESCRIPTION
Avatar uploads currently collapse top-level API messages, network failures, and non-JSON error responses into "Failed to upload avatar," leaving users without an explanation or next step.

Show the server's rejection reason in both the dialog and toast, supporting nested and top-level messages from Redaxios and Axios responses. When no reason is available, explain size or format rejection, authentication or permission failures, rate limiting, server errors, and connectivity failures. Mark the inline error as an alert for screen readers and keep the selected image available for retry.

Validation:

- 23 error-message unit tests and the existing avatar upload API test pass.
- 5 Playwright tests cover inline/toast messages and a successful retry after a network failure.
- TypeScript and formatting checks pass.
