### PR TITLE
Server-render build logs on release and build pages

### DIFF
--- a/bun-tests/package-page-ssr.test.js
+++ b/bun-tests/package-page-ssr.test.js
@@ -192,6 +192,110 @@ describe("renderPackagePageContent", () => {
     expect(releasesHtml).toContain("success")
     expect(buildsHtml).toContain("build-1")
   })
+
+  test.each(["release", "build"])(
+    "renders build logs in the %s page body without JavaScript",
+    (kind) => {
+      const html = renderPackagePageContent({
+        ...baseData,
+        route: {
+          ...baseData.route,
+          kind,
+          releaseId: "release-1",
+          buildId: "build-1",
+        },
+        packageBuild: {
+          package_build_id: "build-1",
+          user_code_job_started_at: "2026-09-03T14:15:35.301Z",
+          user_code_job_completed_at: "2026-09-03T14:16:35.301Z",
+          user_code_job_completed_logs: [
+            {
+              timestamp: "2026-09-03T14:15:41.583Z",
+              msg: "Starting execution",
+            },
+            {
+              timestamp: "2026-09-03T14:15:55.294Z",
+              stream: "stderr",
+              msg: 'Build <board />\n<script>alert("nope")</script> & done',
+            },
+            "Plain text log",
+            { action: "execution_complete", exitCode: 0 },
+          ],
+        },
+      })
+
+      expect(html).toContain("<h2>Build Logs</h2>")
+      expect(html).toContain("Status: Ready")
+      expect(html).toContain(
+        "<dt>Started</dt><dd>2026-09-03T14:15:35.301Z</dd>",
+      )
+      expect(html).toContain(
+        "<dt>Completed</dt><dd>2026-09-03T14:16:35.301Z</dd>",
+      )
+      expect(html).toContain(
+        "<pre><code>2026-09-03T14:15:41.583Z Starting execution\n2026-09-03T14:15:55.294Z Build &lt;board /&gt;\n&lt;script&gt;alert(&quot;nope&quot;)&lt;/script&gt; &amp; done\nPlain text log\n{&quot;action&quot;:&quot;execution_complete&quot;,&quot;exitCode&quot;:0}</code></pre>",
+      )
+      expect(html).not.toContain("<script>")
+    },
+  )
+
+  test.each([
+    "Build failed <details>",
+    { message: "Build failed <details>" },
+    { code: "BUILD_FAILED" },
+  ])("renders build errors even when logs are absent: %j", (error) => {
+    const html = renderPackagePageContent({
+      ...baseData,
+      route: { ...baseData.route, kind: "release", releaseId: "release-1" },
+      packageBuild: {
+        package_build_id: "build-1",
+        build_in_progress: true,
+        user_code_job_error: error,
+        user_code_job_completed_logs: null,
+      },
+    })
+
+    expect(html).toContain("Status: Failed")
+    expect(html).toContain("<strong>Error:</strong>")
+    expect(html).toContain(
+      typeof error === "string" || error.message
+        ? "Build failed &lt;details&gt;"
+        : "{&quot;code&quot;:&quot;BUILD_FAILED&quot;}",
+    )
+    expect(html).toContain("No logs available.")
+    expect(html).not.toContain("Build in progress.")
+  })
+
+  test("renders the available log snapshot for an active build", () => {
+    const html = renderPackagePageContent({
+      ...baseData,
+      route: { ...baseData.route, kind: "build", buildId: "build-1" },
+      packageBuild: {
+        package_build_id: "build-1",
+        user_code_job_started_at: "2026-09-03T14:15:35.301Z",
+        user_code_job_completed_logs: [{ msg: "Autorouting phase 2" }],
+      },
+    })
+
+    expect(html).toContain("Status: Building")
+    expect(html).toContain("<pre><code>Autorouting phase 2</code></pre>")
+    expect(html).toContain("Refresh this page for updated logs.")
+  })
+
+  test("renders queued builds and releases without builds", () => {
+    const data = {
+      ...baseData,
+      route: { ...baseData.route, kind: "release", releaseId: "release-1" },
+    }
+    const queuedHtml = renderPackagePageContent({
+      ...data,
+      packageBuild: { package_build_id: "build-1" },
+    })
+
+    expect(queuedHtml).toContain("Status: Queued")
+    expect(queuedHtml).toContain("No logs available.")
+    expect(renderPackagePageContent(data)).toContain("No build available.")
+  })
 })
 
 test("injectPackagePageContent replaces the empty SPA root", () => {
@@ -209,4 +313,22 @@ test("serializeForInlineScript prevents closing the script element", () => {
   const serialized = serializeForInlineScript({ value: "</script><script>" })
   expect(serialized).not.toContain("</script>")
   expect(serialized).toContain("\\u003c/script\\u003e")
+})
+
+test("injectPackagePageContent preserves dollar patterns in build logs", () => {
+  const content = renderPackagePageContent({
+    ...baseData,
+    route: { ...baseData.route, kind: "build", buildId: "build-1" },
+    packageBuild: {
+      package_build_id: "build-1",
+      user_code_job_completed_logs: [{ msg: "Patterns: $& $$ $` $'" }],
+    },
+  })
+  const html = injectPackagePageContent(
+    '<body><div id="root"></div></body>',
+    content,
+  )
+
+  expect(html).toContain("Patterns: $&amp; $$ $` $&#39;")
+  expect(html).toContain(content)
 })

--- a/server/package-page-ssr.js
+++ b/server/package-page-ssr.js
@@ -270,9 +270,59 @@ const renderBuild = (packageBuild) =>
     ["Build ID", packageBuild?.package_build_id],
     ["Status", getStatus(packageBuild)],
     ["Created", formatDate(packageBuild?.created_at)],
-    ["Started", formatDate(packageBuild?.started_at)],
-    ["Completed", formatDate(packageBuild?.completed_at)],
+    ["Started", formatDate(packageBuild?.user_code_job_started_at)],
+    ["Completed", formatDate(packageBuild?.user_code_job_completed_at)],
   ])
+
+const renderBuildLogs = (packageBuild) => {
+  if (!packageBuild) {
+    return "<section><h2>Build Logs</h2><p>No build available.</p></section>"
+  }
+
+  const error = packageBuild.user_code_job_error
+  const errorMessage =
+    typeof error === "string"
+      ? error
+      : error?.message || (error ? JSON.stringify(error) : null)
+  const isBuilding =
+    !error &&
+    (packageBuild.build_in_progress ||
+      (packageBuild.user_code_job_started_at &&
+        !packageBuild.user_code_job_completed_at))
+  const status = error
+    ? "Failed"
+    : isBuilding
+      ? "Building"
+      : packageBuild.user_code_job_completed_at
+        ? "Ready"
+        : "Queued"
+  const logs = packageBuild.user_code_job_completed_logs ?? []
+  const logText = logs
+    .map((log) => {
+      const message =
+        typeof log === "string"
+          ? log
+          : typeof log?.msg === "string"
+            ? log.msg
+            : JSON.stringify(log)
+      return [log?.timestamp, message].filter((part) => part != null).join(" ")
+    })
+    .join("\n")
+
+  return `<section><h2>Build Logs</h2><p>Status: ${status}</p>${
+    errorMessage
+      ? `<p><strong>Error:</strong></p><pre><code>${escapeHtml(errorMessage)}</code></pre>`
+      : ""
+  }${
+    logs.length > 0
+      ? `<pre><code>${escapeHtml(logText)}</code></pre>`
+      : "<p>No logs available.</p>"
+  }${
+    isBuilding
+      ? "<p>Build in progress. Refresh this page for updated logs.</p>"
+      : ""
+  }</section>`
+}
 
 const convertCircuitJsonForPreview = (contentText, converter) => {
   if (!contentText) return null
@@ -401,7 +451,7 @@ const renderRouteContent = ({
       packageRelease,
     )}${
       packageBuild ? `<h3>Latest build</h3>${renderBuild(packageBuild)}` : ""
-    }</section>`
+    }</section>${route.kind === "release" ? renderBuildLogs(packageBuild) : ""}`
   }
 
   if (route.kind === "builds") {
@@ -416,7 +466,7 @@ const renderRouteContent = ({
   if (route.kind === "build") {
     return `<section><h2>Build ${escapeHtml(
       packageBuild?.package_build_id || route.buildId,
-    )}</h2>${renderBuild(packageBuild)}</section>`
+    )}</h2>${renderBuild(packageBuild)}</section>${renderBuildLogs(packageBuild)}`
   }
 
   if (route.kind === "settings") {
@@ -468,7 +518,7 @@ export function injectPackagePageContent(html, ssrContent) {
   if (!ssrContent) return html
   return html.replace(
     /<div id="root"(?: class="[^"]*")?><\/div>/,
-    `<div id="root" data-server-rendered="true">${ssrContent}</div>`,
+    () => `<div id="root" data-server-rendered="true">${ssrContent}</div>`,
   )
 }
 


### PR DESCRIPTION
Release and individual build pages already fetch logs during SSR, but only render build metadata in the HTML body. Include timestamped build logs, errors, status, and job start/completion times so `curl` and clients without JavaScript can read them.

Render the available log snapshot for active builds with a refresh hint, and provide empty states for queued builds and releases without builds. Escape log/error content and preserve literal dollar patterns when inserting the rendered HTML.

Validation:

- `bun test`: 345 passed, 5 skipped, 0 failed; includes regression coverage for both page types, active/queued builds, errors, escaping, and HTML insertion.
- `bun run typecheck` and `bun run lint`: passed.
- Plain `curl` against the local production request handler with the live registry verified logs in the HTML body for [the example release](https://tscircuit.com/seveibar/adm6-breakout/releases/65f0a6dd-aa34-490b-8f26-526a3db9442c) and its individual build URL.
