### PR TITLE
fix(editor): sync selected file with URL

### DIFF
--- a/playwright-tests/editor-default-file.spec.ts
+++ b/playwright-tests/editor-default-file.spec.ts
@@ -124,6 +124,25 @@ test("still opens a lockfile explicitly requested in the URL", async ({
   )
 })
 
+test("updates file_path in the URL when selecting a workspace file", async ({
+  page,
+}) => {
+  await mockPackage(page, {
+    "index.circuit.tsx": "export default () => <board />",
+    "imports/part.tsx": "export const Part = () => <resistor />",
+  })
+
+  await page.goto(editorUrl)
+  await page.getByText("imports", { exact: true }).click()
+  await expect(page.getByText("part.tsx", { exact: true })).toBeVisible()
+
+  await page.getByText("part.tsx", { exact: true }).click()
+
+  await expect(page).toHaveURL(
+    new RegExp(`file_path=${encodeURIComponent("imports/part.tsx")}`),
+  )
+})
+
 test("a lockfile-only package finishes loading without a default selection", async ({
   page,
 }) => {

--- a/src/components/package-port/CodeAndPreview.tsx
+++ b/src/components/package-port/CodeAndPreview.tsx
@@ -250,6 +250,22 @@ export function CodeAndPreview({ pkg, projectUrl, isPackageFetched }: Props) {
     [setLocalFiles],
   )
 
+  const handleFileSelect = useCallback(
+    (path: string, lineNumber?: number) => {
+      onFileSelect(path)
+
+      const url = new URL(window.location.href)
+      url.searchParams.set("file_path", path)
+      if (lineNumber) {
+        url.searchParams.set("line", lineNumber.toString())
+      } else {
+        url.searchParams.delete("line")
+      }
+      window.history.replaceState(null, "", url)
+    },
+    [onFileSelect],
+  )
+
   const { importComponentDialog, openImportDialog } = useEditorComponentImport({
     currentFile,
     files: fsMap,
@@ -401,7 +417,7 @@ export function CodeAndPreview({ pkg, projectUrl, isPackageFetched }: Props) {
               <WorkspaceCodeEditor
                 files={localFiles}
                 currentFile={currentFile}
-                onFileSelect={onFileSelect}
+                onFileSelect={handleFileSelect}
                 onFileContentChange={handleFileContentChange}
                 onCreateFile={handleCreateFile}
                 onDeleteFile={handleDeleteFile}


### PR DESCRIPTION
## Summary
- update the editor URL when a workspace file is selected
- preserve existing query parameters and clear stale line selections
- add a browser regression test for file selection URL sync

## Testing
- bun run typecheck
- bunx playwright test playwright-tests/editor-default-file.spec.ts