### PR TITLE
Match fake API preview paths to tsci output naming

### DIFF
--- a/bun-tests/fake-snippets-api/routes/package_releases/get_preview_circuit_json.test.ts
+++ b/bun-tests/fake-snippets-api/routes/package_releases/get_preview_circuit_json.test.ts
@@ -112,6 +112,53 @@ test("get_preview_circuit_json - mainEntrypoint from config", async () => {
   expect(body.circuit_json).toEqual(mainCircuitJson)
 })
 
+test("get_preview_circuit_json - tsci source suffixes", async () => {
+  const { axios } = await getTestServer()
+
+  const cases = [
+    {
+      packageName: "testuser/preview-circuit-tsx-entrypoint",
+      config: {
+        mainEntrypoint: "rp2040-connector-routed.circuit.tsx",
+      },
+      componentPath: "rp2040-connector-routed.circuit.tsx",
+      circuitJsonPath: "dist/rp2040-connector-routed/circuit.json",
+    },
+    {
+      packageName: "testuser/preview-board-tsx-component",
+      config: { previewComponentPath: "boards/controller.board.tsx" },
+      componentPath: "boards/controller.board.tsx",
+      circuitJsonPath: "dist/boards/controller/circuit.json",
+    },
+  ]
+
+  for (const testCase of cases) {
+    const circuitJson = [
+      { type: "source_component", name: testCase.packageName },
+    ]
+    const { package_release_id } = await createPackageWithFiles(
+      axios,
+      testCase.packageName,
+      {
+        "tscircuit.config.json": JSON.stringify(testCase.config),
+        [testCase.componentPath]: "export default () => null",
+        [testCase.circuitJsonPath]: JSON.stringify(circuitJson),
+      },
+    )
+
+    const res = await axios.post(
+      "/api/package_releases/get_preview_circuit_json",
+      { package_release_id },
+    )
+
+    expect(res.status).toBe(200)
+    const body = res.data.preview_circuit_json_response
+    expect(body.circuit_json_found).toBe(true)
+    expect(body.component_path).toBe(testCase.componentPath)
+    expect(body.circuit_json).toEqual(circuitJson)
+  }
+})
+
 test("get_preview_circuit_json - initialComponentPath discovery via src/index.tsx", async () => {
   const { axios } = await getTestServer()
 
@@ -280,7 +327,7 @@ test("get_preview_circuit_json - .board.tsx file discovery", async () => {
     "testuser/preview-board-file",
     {
       "my-circuit.board.tsx": "export default () => null",
-      "dist/my-circuit.board/circuit.json": JSON.stringify(boardCircuitJson),
+      "dist/my-circuit/circuit.json": JSON.stringify(boardCircuitJson),
     },
   )
 

--- a/fake-snippets-api/routes/api/package_releases/get_preview_circuit_json.ts
+++ b/fake-snippets-api/routes/api/package_releases/get_preview_circuit_json.ts
@@ -1,5 +1,6 @@
 import path from "node:path"
 import { withRouteSpec } from "fake-snippets-api/lib/with-winter-spec"
+import { getCircuitJsonBuildOutputPath } from "fake-snippets-api/utils/getCircuitJsonBuildOutputPath"
 import { normalizeProjectFilePath } from "fake-snippets-api/utils/normalizeProjectFilePath"
 import { z } from "zod"
 
@@ -162,13 +163,8 @@ export default withRouteSpec({
   const mainEntrypoint = tscircuitConfig?.mainEntrypoint
 
   const fetchCircuitJsonByComponentPath = (componentPath: string) => {
-    const isCircuitJsonPath = componentPath.endsWith("circuit.json")
-    const extension = path.posix.extname(componentPath)
-    const pathWithoutExt = componentPath.slice(0, -extension.length)
     const circuitJsonPath = normalizeProjectFilePath(
-      isCircuitJsonPath
-        ? `dist/${componentPath}`
-        : `dist/${pathWithoutExt}/circuit.json`,
+      getCircuitJsonBuildOutputPath(componentPath),
     )
     const circuitFile = getFileByNormalizedPath(circuitJsonPath)
     const circuitJson = parseCircuitJson(circuitFile?.content_text ?? null)

--- a/fake-snippets-api/utils/getCircuitJsonBuildOutputPath.ts
+++ b/fake-snippets-api/utils/getCircuitJsonBuildOutputPath.ts
@@ -1,0 +1,20 @@
+import path from "node:path"
+import { normalizeProjectFilePath } from "./normalizeProjectFilePath"
+
+export const getCircuitJsonBuildOutputPath = (sourcePath: string) => {
+  const normalizedSourcePath = normalizeProjectFilePath(sourcePath)
+    .replace(/^\/+/, "")
+    .replace(/^dist\//, "")
+
+  const outputDir =
+    normalizedSourcePath === "circuit.json" ||
+    normalizedSourcePath.endsWith("/circuit.json")
+      ? path.posix.dirname(normalizedSourcePath)
+      : normalizedSourcePath
+          .replace(/(\.board|\.circuit)?\.tsx$/, "")
+          .replace(/\.circuit\.json$/, "")
+
+  return outputDir && outputDir !== "."
+    ? `dist/${outputDir}/circuit.json`
+    : "dist/circuit.json"
+}


### PR DESCRIPTION
## Summary

- make the fake package preview endpoint strip .circuit.tsx and .board.tsx like tsci
- add regression coverage for the adm6-breakout mainEntrypoint shape and board preview paths
- update the existing board discovery fixture to use the real tsci output path

This mirrors the production fix in tscircuit/api.tscircuit.com#1157 so local frontend behavior stays aligned with the registry API.

## Validation

- 12 get_preview_circuit_json tests pass
- bun run typecheck
- bun run lint