### PR TITLE
feat: add related packages to package pages

### DIFF
--- a/api/generated-index.js
+++ b/api/generated-index.js
@@ -115,6 +115,7 @@ function getHtmlWithModifiedSeoTags({
       packageReleases,
       packageBuilds,
       packageBuild,
+      relatedPackages,
       route,
     } = ssrPackageData
 
@@ -152,6 +153,11 @@ function getHtmlWithModifiedSeoTags({
     if (packageBuild) {
       assignments.push(
         `window.SSR_PACKAGE_BUILD = ${serializeForInlineScript(packageBuild)};`,
+      )
+    }
+    if (relatedPackages?.length) {
+      assignments.push(
+        `window.SSR_RELATED_PACKAGES = ${serializeForInlineScript(relatedPackages)};`,
       )
     }
     if (route) {
@@ -264,6 +270,50 @@ async function fetchPackageRelease(route) {
     package_name: route.packageNameWithScope,
     is_latest: true,
   })
+}
+
+function startCachedRelatedPackagesLookup(packageInfo) {
+  const isPublicPackage =
+    packageInfo.is_public !== false &&
+    !packageInfo.is_private &&
+    !packageInfo.is_unlisted
+  if (!isPublicPackage) return null
+
+  const abortController = new AbortController()
+  let isSettled = false
+  let packages = []
+
+  void requestJsonOrNull(
+    ky.get(`${REGISTRY_URL}/packages/list_related_packages`, {
+      searchParams: {
+        package_id: packageInfo.package_id,
+        cached_only: true,
+      },
+      signal: abortController.signal,
+      timeout: 2_000,
+    }),
+  )
+    .then((response) => {
+      packages = response?.packages ?? []
+    })
+    .catch((error) => {
+      if (error?.name !== "AbortError") {
+        console.warn("Failed to fetch cached related packages for SSR:", error)
+      }
+    })
+    .finally(() => {
+      isSettled = true
+    })
+
+  return {
+    takeIfReady() {
+      if (!isSettled) {
+        abortController.abort()
+        return []
+      }
+      return packages
+    },
+  }
 }
 
 async function fetchPackagePageData(route, packageInfo) {
@@ -509,7 +559,9 @@ async function handlePackagePage(req, res, route) {
   }
 
   const packageInfo = packageDetails.package
+  const relatedPackagesLookup = startCachedRelatedPackagesLookup(packageInfo)
   const data = await fetchPackagePageData(route, packageInfo)
+  data.relatedPackages = relatedPackagesLookup?.takeIfReady() ?? []
   const description = he.encode(
     `${
       packageInfo.description ||
@@ -542,6 +594,7 @@ async function handlePackagePage(req, res, route) {
       packageReleases: data.packageReleases,
       packageBuilds: data.packageBuilds,
       packageBuild: data.packageBuild,
+      relatedPackages: data.relatedPackages,
       route,
     },
   })

--- a/bun-tests/package-page-ssr.test.js
+++ b/bun-tests/package-page-ssr.test.js
@@ -192,6 +192,29 @@ describe("renderPackagePageContent", () => {
     expect(releasesHtml).toContain("success")
     expect(buildsHtml).toContain("build-1")
   })
+
+  test("renders cached related packages at the bottom of the page", () => {
+    const html = renderPackagePageContent({
+      ...baseData,
+      relatedPackages: [
+        {
+          package_id: "related-1",
+          name: "bob/other-board",
+          description: "A related <board>",
+          related_type: "similar_ai_description",
+          thumbnail_url: "https://example.com/other-board.png",
+        },
+      ],
+    })
+
+    expect(html).toContain("Related Packages")
+    expect(html).toContain('href="/bob/other-board"')
+    expect(html).toContain('src="https://example.com/other-board.png"')
+    expect(html).toContain("A related &lt;board&gt;")
+    expect(html.indexOf("Related Packages")).toBeGreaterThan(
+      html.indexOf("# Board"),
+    )
+  })
 })
 
 test("injectPackagePageContent replaces the empty SPA root", () => {

--- a/fake-snippets-api/routes/api/packages/list_related_packages.ts
+++ b/fake-snippets-api/routes/api/packages/list_related_packages.ts
@@ -10,6 +10,13 @@ const relatedTypeSchema = z.enum([
   "random",
 ])
 
+type RelatedPackage = Package & {
+  related_type: z.infer<typeof relatedTypeSchema>
+  thumbnail_url: string
+}
+
+const relatedPackagesCache = new Map<string, RelatedPackage[]>()
+
 const getThumbnailUrl = (pkg: Package) =>
   pkg.latest_pcb_preview_image_url ??
   pkg.latest_sch_preview_image_url ??
@@ -19,7 +26,10 @@ const getThumbnailUrl = (pkg: Package) =>
 export default withRouteSpec({
   methods: ["GET"],
   auth: "none",
-  commonParams: z.object({ package_id: z.string() }),
+  commonParams: z.object({
+    package_id: z.string(),
+    cached_only: z.coerce.boolean().optional().default(false),
+  }),
   jsonResponse: z.object({
     ok: z.boolean(),
     packages: z.array(
@@ -28,6 +38,7 @@ export default withRouteSpec({
         thumbnail_url: z.string(),
       }),
     ),
+    cache_status: z.enum(["hit", "miss"]),
   }),
 })(async (req, ctx) => {
   const sourcePackage = ctx.db.getPackageById(req.commonParams.package_id)
@@ -39,6 +50,21 @@ export default withRouteSpec({
     })
   }
 
+  const cachedPackages = relatedPackagesCache.get(sourcePackage.package_id)
+  if (cachedPackages) {
+    return ctx
+      .json({ ok: true, packages: cachedPackages, cache_status: "hit" })
+      .headers({
+        "Cache-Control": `public, max-age=${CACHE_DURATION_SECONDS}, s-maxage=${CACHE_DURATION_SECONDS}`,
+      })
+  }
+
+  if (req.commonParams.cached_only) {
+    return ctx
+      .json({ ok: true, packages: [], cache_status: "miss" })
+      .headers({ "Cache-Control": "private, no-store" })
+  }
+
   const eligiblePackages = ctx.db.packages.filter(
     (pkg) =>
       pkg.package_id !== sourcePackage.package_id &&
@@ -48,12 +74,7 @@ export default withRouteSpec({
       Boolean(getThumbnailUrl(pkg)),
   )
   const selectedPackageIds = new Set<string>()
-  const packages: Array<
-    Package & {
-      related_type: z.infer<typeof relatedTypeSchema>
-      thumbnail_url: string
-    }
-  > = []
+  const packages: RelatedPackage[] = []
 
   const addPackage = (
     pkg: Package | undefined,
@@ -93,7 +114,9 @@ export default withRouteSpec({
     "random",
   )
 
-  return ctx.json({ ok: true, packages }).headers({
+  relatedPackagesCache.set(sourcePackage.package_id, packages)
+
+  return ctx.json({ ok: true, packages, cache_status: "miss" }).headers({
     "Cache-Control": `public, max-age=${CACHE_DURATION_SECONDS}, s-maxage=${CACHE_DURATION_SECONDS}`,
   })
 })

--- a/fake-snippets-api/routes/api/packages/list_related_packages.ts
+++ b/fake-snippets-api/routes/api/packages/list_related_packages.ts
@@ -1,0 +1,99 @@
+import { packageSchema, type Package } from "fake-snippets-api/lib/db/schema"
+import { withRouteSpec } from "fake-snippets-api/lib/middleware/with-winter-spec"
+import { z } from "zod"
+
+const CACHE_DURATION_SECONDS = 48 * 60 * 60
+
+const relatedTypeSchema = z.enum([
+  "same_author",
+  "similar_ai_description",
+  "random",
+])
+
+const getThumbnailUrl = (pkg: Package) =>
+  pkg.latest_pcb_preview_image_url ??
+  pkg.latest_sch_preview_image_url ??
+  pkg.latest_cad_preview_image_url ??
+  null
+
+export default withRouteSpec({
+  methods: ["GET"],
+  auth: "none",
+  commonParams: z.object({ package_id: z.string() }),
+  jsonResponse: z.object({
+    ok: z.boolean(),
+    packages: z.array(
+      packageSchema.extend({
+        related_type: relatedTypeSchema,
+        thumbnail_url: z.string(),
+      }),
+    ),
+  }),
+})(async (req, ctx) => {
+  const sourcePackage = ctx.db.getPackageById(req.commonParams.package_id)
+
+  if (!sourcePackage) {
+    return ctx.error(404, {
+      error_code: "package_not_found",
+      message: "Package not found",
+    })
+  }
+
+  const eligiblePackages = ctx.db.packages.filter(
+    (pkg) =>
+      pkg.package_id !== sourcePackage.package_id &&
+      pkg.is_public !== false &&
+      !pkg.is_private &&
+      !pkg.is_unlisted &&
+      Boolean(getThumbnailUrl(pkg)),
+  )
+  const selectedPackageIds = new Set<string>()
+  const packages: Array<
+    Package & {
+      related_type: z.infer<typeof relatedTypeSchema>
+      thumbnail_url: string
+    }
+  > = []
+
+  const addPackage = (
+    pkg: Package | undefined,
+    relatedType: z.infer<typeof relatedTypeSchema>,
+  ) => {
+    if (!pkg || selectedPackageIds.has(pkg.package_id)) return
+    const thumbnailUrl = getThumbnailUrl(pkg)
+    if (!thumbnailUrl) return
+    selectedPackageIds.add(pkg.package_id)
+    packages.push({
+      ...pkg,
+      related_type: relatedType,
+      thumbnail_url: thumbnailUrl,
+    })
+  }
+
+  addPackage(
+    eligiblePackages.find(
+      (pkg) => pkg.owner_org_id === sourcePackage.owner_org_id,
+    ),
+    "same_author",
+  )
+  addPackage(
+    eligiblePackages.find(
+      (pkg) =>
+        pkg.owner_org_id !== sourcePackage.owner_org_id &&
+        !selectedPackageIds.has(pkg.package_id),
+    ),
+    "similar_ai_description",
+  )
+  addPackage(
+    eligiblePackages.find(
+      (pkg) =>
+        pkg.owner_org_id !== sourcePackage.owner_org_id &&
+        !selectedPackageIds.has(pkg.package_id),
+    ),
+    "random",
+  )
+
+  return ctx.json({ ok: true, packages }).headers({
+    "Cache-Control": `public, max-age=${CACHE_DURATION_SECONDS}, s-maxage=${CACHE_DURATION_SECONDS}`,
+  })
+})

--- a/playwright-tests/related-packages.spec.ts
+++ b/playwright-tests/related-packages.spec.ts
@@ -1,9 +1,17 @@
 import { expect, test } from "@playwright/test"
 
-test("related packages load after the initial package render", async ({
+test("related packages render in SSR without a duplicate browser request", async ({
   page,
 }) => {
   await page.setViewportSize({ width: 1280, height: 400 })
+
+  const packageResponse = await page.request.get(
+    "http://127.0.0.1:5177/api/packages/get?name=testuser%2Fmy-test-board",
+  )
+  const { package: sourcePackage } = await packageResponse.json()
+  await page.request.get(
+    `http://127.0.0.1:5177/api/packages/list_related_packages?package_id=${sourcePackage.package_id}`,
+  )
 
   let relatedPackagesRequestCount = 0
   page.on("request", (request) => {
@@ -12,23 +20,22 @@ test("related packages load after the initial package render", async ({
     }
   })
 
-  await page.goto("http://127.0.0.1:5177/testuser/my-test-board", {
-    waitUntil: "domcontentloaded",
-  })
+  const navigationResponse = await page.goto(
+    "http://127.0.0.1:5177/testuser/my-test-board",
+    { waitUntil: "domcontentloaded" },
+  )
+  const responseHtml = await navigationResponse?.text()
+  expect(responseHtml).toContain("ssr-related-packages-heading")
+  expect(responseHtml).toContain("window.SSR_RELATED_PACKAGES")
 
   const boundary = page.getByTestId("related-packages-boundary")
   await expect(boundary).toBeAttached()
-  await page.waitForTimeout(250)
-  expect(relatedPackagesRequestCount).toBe(0)
-
   await boundary.scrollIntoViewIfNeeded()
-
-  await expect
-    .poll(() => relatedPackagesRequestCount, { timeout: 10_000 })
-    .toBe(1)
   await expect(
     page.getByRole("heading", { name: "Related Packages" }),
   ).toBeVisible()
+  await page.waitForTimeout(500)
+  expect(relatedPackagesRequestCount).toBe(0)
 
   const relatedPackageImages = boundary.locator("img")
   await expect(relatedPackageImages.first()).toHaveAttribute("loading", "lazy")

--- a/playwright-tests/related-packages.spec.ts
+++ b/playwright-tests/related-packages.spec.ts
@@ -1,0 +1,39 @@
+import { expect, test } from "@playwright/test"
+
+test("related packages load after the initial package render", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 1280, height: 400 })
+
+  let relatedPackagesRequestCount = 0
+  page.on("request", (request) => {
+    if (request.url().includes("/packages/list_related_packages")) {
+      relatedPackagesRequestCount += 1
+    }
+  })
+
+  await page.goto("http://127.0.0.1:5177/testuser/my-test-board", {
+    waitUntil: "domcontentloaded",
+  })
+
+  const boundary = page.getByTestId("related-packages-boundary")
+  await expect(boundary).toBeAttached()
+  await page.waitForTimeout(250)
+  expect(relatedPackagesRequestCount).toBe(0)
+
+  await boundary.scrollIntoViewIfNeeded()
+
+  await expect
+    .poll(() => relatedPackagesRequestCount, { timeout: 10_000 })
+    .toBe(1)
+  await expect(
+    page.getByRole("heading", { name: "Related Packages" }),
+  ).toBeVisible()
+
+  const relatedPackageImages = boundary.locator("img")
+  await expect(relatedPackageImages.first()).toHaveAttribute("loading", "lazy")
+  await expect(relatedPackageImages.first()).toHaveAttribute(
+    "fetchpriority",
+    "low",
+  )
+})

--- a/server/package-page-ssr.js
+++ b/server/package-page-ssr.js
@@ -435,6 +435,31 @@ const renderRouteContent = ({
   }`
 }
 
+const relatedPackageLabels = {
+  same_author: "More from this author",
+  similar_ai_description: "Similar package",
+  random: "Discover something new",
+}
+
+const renderRelatedPackages = (relatedPackages) => {
+  if (!relatedPackages?.length) return ""
+
+  return `<style>.ssr-related-packages{border-top:1px solid #e5e7eb;margin-top:2rem;padding-top:.5rem}.ssr-related-packages ul{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:1rem;padding:0;list-style:none}.ssr-related-packages li{margin:0;border:1px solid #e5e7eb;border-radius:.5rem;overflow:hidden}.ssr-related-packages a{display:block;color:#111827}.ssr-related-packages img{display:block;width:100%;aspect-ratio:16/9;object-fit:cover;background:#f9fafb}.ssr-related-packages a>span{display:grid;gap:.25rem;padding:1rem}.ssr-related-packages small{color:#6b7280;text-transform:uppercase}.ssr-related-packages strong{color:#2563eb}.ssr-related-packages strong+span{font-size:.875rem;color:#4b5563}@media(max-width:640px){.ssr-related-packages ul{grid-template-columns:1fr}}</style><section class="ssr-related-packages" aria-labelledby="ssr-related-packages-heading"><h2 id="ssr-related-packages-heading">Related Packages</h2><ul>${relatedPackages
+    .map(
+      (pkg) =>
+        `<li><a href="/${encodePath(pkg.name)}"><img src="${escapeHtml(
+          pkg.thumbnail_url,
+        )}" alt="${escapeHtml(
+          pkg.name,
+        )} preview" loading="lazy" decoding="async"><span><small>${escapeHtml(
+          relatedPackageLabels[pkg.related_type] || "Related package",
+        )}</small><strong>${escapeHtml(pkg.name)}</strong>${
+          pkg.description ? `<span>${escapeHtml(pkg.description)}</span>` : ""
+        }</span></a></li>`,
+    )
+    .join("")}</ul></section>`
+}
+
 export function renderPackagePageContent(data) {
   const { route, packageInfo, packageRelease } = data
   const packageDescription =
@@ -461,7 +486,9 @@ export function renderPackagePageContent(data) {
     ["Version", packageRelease?.version || packageInfo.latest_version],
     ["License", packageInfo.license],
     ["Stars", packageInfo.star_count],
-  ])}</header>${renderRouteContent(data)}</main>`
+  ])}</header>${renderRouteContent(data)}${renderRelatedPackages(
+    data.relatedPackages,
+  )}</main>`
 }
 
 export function injectPackagePageContent(html, ssrContent) {

--- a/src/components/ViewPackagePage/components/related-packages-section.tsx
+++ b/src/components/ViewPackagePage/components/related-packages-section.tsx
@@ -1,0 +1,116 @@
+import { useEffect, useState } from "react"
+import { Link } from "wouter"
+import { useInView } from "react-intersection-observer"
+import {
+  type RelatedPackage,
+  useRelatedPackages,
+} from "@/hooks/use-related-packages"
+
+const relationshipLabels: Record<RelatedPackage["related_type"], string> = {
+  same_author: "More from this author",
+  similar_ai_description: "Similar package",
+  random: "Discover something new",
+}
+
+const useBrowserIdle = () => {
+  const [isIdle, setIsIdle] = useState(false)
+
+  useEffect(() => {
+    if ("requestIdleCallback" in window) {
+      const idleCallback = window.requestIdleCallback(() => setIsIdle(true), {
+        timeout: 1_500,
+      })
+      return () => window.cancelIdleCallback(idleCallback)
+    }
+
+    const timeout = setTimeout(() => setIsIdle(true), 0)
+    return () => clearTimeout(timeout)
+  }, [])
+
+  return isIdle
+}
+
+const RelatedPackageCard = ({ pkg }: { pkg: RelatedPackage }) => (
+  <Link
+    href={`/${pkg.name}`}
+    className="group overflow-hidden rounded-lg border border-gray-200 bg-white transition-colors hover:border-gray-300 dark:border-[#30363d] dark:bg-[#0d1117] dark:hover:border-gray-500"
+  >
+    <div className="aspect-[16/9] overflow-hidden border-b border-gray-200 bg-gray-50 dark:border-[#30363d] dark:bg-[#161b22]">
+      <img
+        src={pkg.thumbnail_url}
+        alt={`${pkg.name} preview`}
+        loading="lazy"
+        decoding="async"
+        fetchPriority="low"
+        className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-[1.03]"
+      />
+    </div>
+    <div className="p-4">
+      <div className="mb-1 text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">
+        {relationshipLabels[pkg.related_type]}
+      </div>
+      <h3 className="truncate font-semibold text-blue-600 group-hover:text-blue-700 dark:text-[#58a6ff]">
+        {pkg.name}
+      </h3>
+      {pkg.description && (
+        <p className="mt-1 line-clamp-2 text-sm text-gray-600 dark:text-gray-400">
+          {pkg.description}
+        </p>
+      )}
+    </div>
+  </Link>
+)
+
+export const RelatedPackagesSection = ({
+  packageId,
+}: {
+  packageId: string | null
+}) => {
+  const { ref, inView } = useInView({
+    triggerOnce: true,
+    rootMargin: "100px 0px",
+  })
+  const isBrowserIdle = useBrowserIdle()
+  const { data: relatedPackages, isLoading } = useRelatedPackages(
+    packageId,
+    inView && isBrowserIdle,
+  )
+
+  return (
+    <div ref={ref} className="min-h-px" data-testid="related-packages-boundary">
+      {isLoading && inView ? (
+        <section
+          aria-label="Loading related packages"
+          className="mx-auto max-w-[1200px] border-t border-gray-200 px-4 py-8 dark:border-[#30363d]"
+        >
+          <div className="mb-5 h-7 w-44 animate-pulse rounded bg-gray-100 dark:bg-[#161b22]" />
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+            {[0, 1, 2].map((index) => (
+              <div
+                key={index}
+                className="aspect-[4/3] animate-pulse rounded-lg bg-gray-100 dark:bg-[#161b22]"
+              />
+            ))}
+          </div>
+        </section>
+      ) : relatedPackages?.length ? (
+        <section
+          aria-labelledby="related-packages-heading"
+          className="mx-auto max-w-[1200px] border-t border-gray-200 px-4 py-8 dark:border-[#30363d]"
+        >
+          <h2
+            id="related-packages-heading"
+            className="mb-5 text-xl font-semibold text-gray-900 dark:text-[#c9d1d9]"
+          >
+            Related Packages
+          </h2>
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+            {relatedPackages.map((pkg) => (
+              <RelatedPackageCard key={pkg.package_id} pkg={pkg} />
+            ))}
+          </div>
+        </section>
+      ) : null}
+    </div>
+  )
+}

--- a/src/components/ViewPackagePage/components/repo-page-content.tsx
+++ b/src/components/ViewPackagePage/components/repo-page-content.tsx
@@ -28,6 +28,7 @@ import type {
 } from "fake-snippets-api/lib/db/schema"
 import { useUpdateAiDescriptionMutation } from "@/hooks/use-update-ai-description-mutation"
 import SidebarReleasesSection from "./sidebar-releases-section"
+import { RelatedPackagesSection } from "./related-packages-section"
 
 interface PackageFile extends ApiPackageFile {
   file_content?: string
@@ -304,6 +305,15 @@ export default function RepoPageContent({
           </div>
         </div>
       </div>
+      <RelatedPackagesSection
+        packageId={
+          packageInfo?.is_public !== false &&
+          !packageInfo?.is_private &&
+          !packageInfo?.is_unlisted
+            ? (packageInfo?.package_id ?? null)
+            : null
+        }
+      />
       <Footer />
     </div>
   )

--- a/src/hooks/use-related-packages.ts
+++ b/src/hooks/use-related-packages.ts
@@ -1,0 +1,35 @@
+import { useQuery } from "react-query"
+import type { Package } from "fake-snippets-api/lib/db/schema"
+import { useAxios } from "@/hooks/use-axios"
+
+const RELATED_PACKAGES_CACHE_TIME = 48 * 60 * 60 * 1000
+
+export type RelatedPackage = Package & {
+  related_type: "same_author" | "similar_ai_description" | "random"
+  thumbnail_url: string
+}
+
+export const useRelatedPackages = (
+  packageId: string | null,
+  enabled: boolean,
+) => {
+  const axios = useAxios()
+
+  return useQuery<RelatedPackage[]>(
+    ["relatedPackages", packageId],
+    async () => {
+      const response = await axios.get("/packages/list_related_packages", {
+        params: { package_id: packageId },
+      })
+      return response.data.packages
+    },
+    {
+      enabled: Boolean(packageId) && enabled,
+      retry: false,
+      refetchOnReconnect: false,
+      refetchOnWindowFocus: false,
+      staleTime: RELATED_PACKAGES_CACHE_TIME,
+      cacheTime: RELATED_PACKAGES_CACHE_TIME,
+    },
+  )
+}

--- a/src/lib/populate-query-cache-with-ssr-data.ts
+++ b/src/lib/populate-query-cache-with-ssr-data.ts
@@ -15,6 +15,7 @@ export function populateQueryCacheWithSSRData(queryClient: QueryClient) {
   const ssrPackageReleases = windowAny.SSR_PACKAGE_RELEASES
   const ssrPackageBuilds = windowAny.SSR_PACKAGE_BUILDS
   const ssrPackageBuild = windowAny.SSR_PACKAGE_BUILD
+  const ssrRelatedPackages = windowAny.SSR_RELATED_PACKAGES
   const ssrPackageRoute = windowAny.SSR_PACKAGE_ROUTE
 
   if (!ssrPackage) return
@@ -23,6 +24,13 @@ export function populateQueryCacheWithSSRData(queryClient: QueryClient) {
   queryClient.setQueryData(["package", ssrPackage.name], ssrPackage)
   queryClient.setQueryData(["package", ssrPackage.package_id], ssrPackage)
   queryClient.setQueryData(["packages", ssrPackage.package_id], ssrPackage)
+
+  if (Array.isArray(ssrRelatedPackages) && ssrRelatedPackages.length > 0) {
+    queryClient.setQueryData(
+      ["relatedPackages", ssrPackage.package_id],
+      ssrRelatedPackages,
+    )
+  }
 
   if (ssrPackageReleases) {
     queryClient.setQueryData(


### PR DESCRIPTION
## Summary

- add a responsive Related Packages section to the bottom of public package pages
- use the merged `/packages/list_related_packages` endpoint and render its thumbnail data
- render warm cached recommendations directly into the package-page SSR HTML for search crawlers
- seed React Query from the SSR payload so hydration does not issue a duplicate request
- retain the deferred browser fetch as the cold-cache fallback, which also populates the API cache on demand
- add matching fake API cache behavior plus SSR and browser regression coverage

## Performance

- begin the SSR `cached_only=true` request in parallel with existing package data fetching
- never wait for that request: use it only if it has settled by the time core SSR data is ready, otherwise abort it
- avoid database or similarity work on SSR cache misses
- keep API/browser results fresh for 48 hours
- lazy-load thumbnails with asynchronous decoding and low fetch priority
- silently omit the non-critical section if no cached result is ready and let the viewport-deferred client path fill it later

This gives warm-cache pages crawlable related-package links without adding the endpoint to the SSR critical path.

## Validation

- `bun test` (338 pass, 5 skip)
- `bun run typecheck`
- `bun run lint`
- `bun run build`
- `bun run build:fake-api`
- `bunx playwright test playwright-tests/related-packages.spec.ts --reporter=line`
- `git diff --check`

API dependencies:
- https://github.com/tscircuit/api.tscircuit.com/pull/1158
- https://github.com/tscircuit/api.tscircuit.com/pull/1159
