### PR TITLE
Show no-installable-release warning when a release has no transpiled artifact

### DIFF
--- a/src/components/ViewPackagePage/components/main-content-header.tsx
+++ b/src/components/ViewPackagePage/components/main-content-header.tsx
@@ -10,6 +10,7 @@ import {
   DownloadIcon,
   Package2,
   GitPullRequest,
+  AlertTriangle,
 } from "lucide-react"
 import {
   Tooltip,
@@ -38,6 +39,7 @@ import { useToast } from "@/hooks/use-toast"
 import ReleaseVersionSelector from "./release-version-selector"
 import { usePackageReleasesByPackageId } from "@/hooks/use-package-release"
 import { isVersionOlderByTime } from "@/lib/utils/isVersionOlderByTime"
+import { isReleaseInstallable } from "@/lib/utils/isReleaseInstallable"
 
 interface MainContentHeaderProps {
   packageFiles: PackageFile[]
@@ -286,6 +288,22 @@ export default function MainContentHeader({
             <span className="underline">Switch to latest</span>
           </button>
         ) : null)}
+      {packageRelease && !isReleaseInstallable(packageRelease) && (
+        <div
+          role="alert"
+          data-testid="not-installable-warning"
+          className="self-start flex items-start gap-1.5 px-2 py-1 text-xs bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded text-amber-700 dark:text-amber-400"
+        >
+          <AlertTriangle className="h-3.5 w-3.5 mt-px flex-shrink-0" />
+          <span>
+            No installable release
+            {packageRelease.version ? ` (v${packageRelease.version})` : ""} —
+            this version has no transpiled artifact, so{" "}
+            <code className="font-mono">tsci add</code> / npm install will fail.
+            Trigger a rebuild or try another version.
+          </span>
+        </div>
+      )}
     </div>
   )
 }

--- a/src/lib/__tests__/isReleaseInstallable.test.ts
+++ b/src/lib/__tests__/isReleaseInstallable.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test"
+import { isReleaseInstallable } from "../utils/isReleaseInstallable"
+
+describe("isReleaseInstallable", () => {
+  test("returns true when the release has a transpiled artifact", () => {
+    expect(isReleaseInstallable({ has_transpiled: true })).toBe(true)
+  })
+
+  test("returns false when transpilation never completed", () => {
+    expect(isReleaseInstallable({ has_transpiled: false })).toBe(false)
+  })
+
+  test("returns false when has_transpiled is null (e.g. release created before the field existed)", () => {
+    expect(isReleaseInstallable({ has_transpiled: null })).toBe(false)
+  })
+
+  test("returns false when has_transpiled is missing", () => {
+    expect(isReleaseInstallable({})).toBe(false)
+  })
+
+  test("returns false for nullish releases (still loading / none selected)", () => {
+    expect(isReleaseInstallable(null)).toBe(false)
+    expect(isReleaseInstallable(undefined)).toBe(false)
+  })
+})

--- a/src/lib/utils/isReleaseInstallable.ts
+++ b/src/lib/utils/isReleaseInstallable.ts
@@ -1,0 +1,16 @@
+import type { PublicPackageRelease } from "fake-snippets-api/lib/db/schema"
+
+/**
+ * A package release is installable via `tsci add` / npm only once it has a
+ * transpiled artifact. Releases whose build never completed (has_transpiled
+ * is false, null, or undefined) still show up in search and on the package
+ * page, but installing them fails with an undebuggable "tag not found, but
+ * package exists" error. The package page should surface an explicit
+ * "no installable release" state for these instead.
+ * See https://github.com/tscircuit/tscircuit.com/issues/4204
+ */
+export function isReleaseInstallable(
+  release?: Pick<PublicPackageRelease, "has_transpiled"> | null,
+): boolean {
+  return release?.has_transpiled === true
+}


### PR DESCRIPTION
## Problem
Releases whose build never completed (has_transpiled false/null, e.g. x4132/SHT40_AD1B_R2 v0.1.0) are still discoverable in search and render a normal package page, but tsci add / npm install fails with an undebuggable tag-not-found error. Related to #4204 (package-page half of that issue; the npm proxy itself lives outside this repo).

## Change
- New isReleaseInstallable() util (src/lib/utils/isReleaseInstallable.ts)
- Package page header now renders an amber role=alert banner (data-testid=not-installable-warning) when the selected release has no transpiled artifact, telling the user to trigger a rebuild or try another version instead of hitting a dead install.
- Banner only renders for non-installable releases, so existing pages/snapshots are unaffected.

## Verification
- bun test ./src/lib/__tests__/isReleaseInstallable.test.ts : 5 pass, 0 fail
- bun run typecheck (tsc --noEmit) : clean
- biome format on changed files : clean

Happy to adjust scope/copy if maintainers prefer a different treatment.