### PR TITLE
fix: show AI descriptions on package cards

### DIFF
--- a/src/components/PackageCard.tsx
+++ b/src/components/PackageCard.tsx
@@ -129,7 +129,9 @@ export const PackageCard: React.FC<PackageCardProps> = ({
               <p
                 className={`${compact ? "line-clamp-1" : "line-clamp-1 md:line-clamp-2 md:h-10 md:mb-2"} text-sm text-gray-600 overflow-hidden`}
               >
-                {pkg.description || "No description available"}
+                {pkg.description ||
+                  pkg.ai_description ||
+                  "No description available"}
               </p>
             </div>
 


### PR DESCRIPTION
## Summary

- fall back to ai_description when a package has no manually authored description
- retain the existing placeholder when neither description field is available
- make package cards consistent with the package detail sidebar

## Why

The registry stores manually authored and AI-generated descriptions in separate fields. For packages such as rushabhcodes/Attiny85-Arcade-Keychain, the API returns description as null while ai_description contains the generated summary.

The package detail page already falls back from description to ai_description, so it displays the summary correctly. PackageCard only checked description, causing the same package to show No description available on profile pages, dashboards, and search results even though usable description metadata was present.

Using the same fallback order in PackageCard removes this inconsistency without requiring a registry migration or backend change. Manually authored descriptions continue to take precedence.

## Validation

- bun run typecheck
- git diff --check