### PR TITLE
fix: show AI descriptions for related packages

### DIFF
--- a/bun-tests/package-page-ssr.test.js
+++ b/bun-tests/package-page-ssr.test.js
@@ -201,8 +201,17 @@ describe("renderPackagePageContent", () => {
           package_id: "related-1",
           name: "bob/other-board",
           description: "A related <board>",
+          ai_description: "This should not replace the manual description",
           related_type: "similar_ai_description",
           thumbnail_url: "https://example.com/other-board.png",
+        },
+        {
+          package_id: "related-2",
+          name: "carol/ai-described-board",
+          description: null,
+          ai_description: "An AI-described <board>",
+          related_type: "random",
+          thumbnail_url: "https://example.com/ai-described-board.png",
         },
       ],
     })
@@ -211,6 +220,8 @@ describe("renderPackagePageContent", () => {
     expect(html).toContain('href="/bob/other-board"')
     expect(html).toContain('src="https://example.com/other-board.png"')
     expect(html).toContain("A related &lt;board&gt;")
+    expect(html).toContain("An AI-described &lt;board&gt;")
+    expect(html).not.toContain("This should not replace the manual description")
     expect(html.indexOf("Related Packages")).toBeGreaterThan(
       html.indexOf("# Board"),
     )

--- a/server/package-page-ssr.js
+++ b/server/package-page-ssr.js
@@ -454,7 +454,9 @@ const renderRelatedPackages = (relatedPackages) => {
         )} preview" loading="lazy" decoding="async"><span><small>${escapeHtml(
           relatedPackageLabels[pkg.related_type] || "Related package",
         )}</small><strong>${escapeHtml(pkg.name)}</strong>${
-          pkg.description ? `<span>${escapeHtml(pkg.description)}</span>` : ""
+          pkg.description || pkg.ai_description
+            ? `<span>${escapeHtml(pkg.description || pkg.ai_description)}</span>`
+            : ""
         }</span></a></li>`,
     )
     .join("")}</ul></section>`

--- a/src/components/ViewPackagePage/components/related-packages-section.tsx
+++ b/src/components/ViewPackagePage/components/related-packages-section.tsx
@@ -52,9 +52,9 @@ const RelatedPackageCard = ({ pkg }: { pkg: RelatedPackage }) => (
       <h3 className="truncate font-semibold text-blue-600 group-hover:text-blue-700 dark:text-[#58a6ff]">
         {pkg.name}
       </h3>
-      {pkg.description && (
+      {(pkg.description || pkg.ai_description) && (
         <p className="mt-1 line-clamp-2 text-sm text-gray-600 dark:text-gray-400">
-          {pkg.description}
+          {pkg.description || pkg.ai_description}
         </p>
       )}
     </div>


### PR DESCRIPTION
## Summary

- fall back to ai_description in hydrated related-package cards when no manual description exists
- apply the same fallback in the server-rendered related-package markup
- add regression coverage for AI-only descriptions, manual-description precedence, and HTML escaping

## Why

The registry stores manually authored descriptions and generated descriptions in separate description and ai_description fields. A large number of packages have no manual description but do have a useful AI-generated description, and the related-packages endpoint returns both fields.

The main package About section already displays description first and falls back to ai_description. Related-package cards did not follow that behavior: both the React component and the independent SSR renderer only checked description. As a result, AI-described packages appeared without any explanatory text in the Related Packages section, even though the API response contained a description and the same package showed it on its own page.

Both render paths need to be updated because related packages are emitted in the initial server-rendered HTML and then hydrated by React. Fixing only one path would leave inconsistent output before and after hydration and could cause visible content changes.

The fallback preserves the intended precedence: a manually authored description is shown when present, ai_description is used only when it is absent, and no description block is rendered when both are empty.

## Validation

- bun test bun-tests/package-page-ssr.test.js (20 passed)
- bun run typecheck
- Biome formatting check
- git diff --check