### PR TITLE
fix: match production package list star filtering and timestamps

### DIFF
--- a/bun-tests/fake-snippets-api/routes/packages/list-starred.test.ts
+++ b/bun-tests/fake-snippets-api/routes/packages/list-starred.test.ts
@@ -1,0 +1,75 @@
+import { getTestServer } from "bun-tests/fake-snippets-api/fixtures/get-test-server"
+import { expect, test } from "bun:test"
+
+test("starred_by filters before limit and keeps viewer metadata", async () => {
+  const { axios, jane_axios, unauthenticatedAxios, db, seed } =
+    await getTestServer()
+  await axios.post("/api/packages/create", { name: "testuser/unstarred" })
+  const {
+    data: { package: pkg },
+  } = await axios.post("/api/packages/create", {
+    name: "testuser/starred",
+  })
+  await jane_axios.post("/api/packages/add_star", {
+    package_id: pkg.package_id,
+  })
+
+  const { data } = await axios.post("/api/packages/list", {
+    starred_by: "JANE",
+    limit: 1,
+  })
+  expect(data.packages.map((p: any) => p.package_id)).toEqual([pkg.package_id])
+  expect(data.packages[0].starred_at).toBeNull()
+
+  await axios.post("/api/packages/add_star", { package_id: pkg.package_id })
+  const viewerStar = db.accountPackages.find(
+    (ap) =>
+      ap.package_id === pkg.package_id &&
+      ap.account_id === seed.account.account_id,
+  )!
+  viewerStar.starred_at = "2024-01-01T00:00:00.000Z"
+  viewerStar.updated_at = "2025-01-01T00:00:00.000Z"
+  const listed = await axios.post("/api/packages/list", { starred_by: "jane" })
+  expect(listed.data.packages[0].starred_at).toBe(viewerStar.starred_at)
+
+  await axios.post("/api/packages/remove_star", { package_id: pkg.package_id })
+  const afterUnstar = await axios.post("/api/packages/list", {
+    starred_by: "jane",
+  })
+  expect(afterUnstar.data.packages[0].starred_at).toBe(viewerStar.starred_at)
+  const ownStars = await axios.post("/api/packages/list", {
+    starred_by: "testuser",
+  })
+  expect(ownStars.data.packages).toEqual([])
+
+  await axios.post("/api/packages/add_star", { package_id: pkg.package_id })
+  expect(viewerStar.starred_at).not.toBe("2024-01-01T00:00:00.000Z")
+
+  const anonymous = await unauthenticatedAxios.post("/api/packages/list", {
+    starred_by: "jane",
+    owner_tscircuit_handle: "testuser",
+  })
+  expect(anonymous.data.packages).toHaveLength(1)
+  expect(anonymous.data.packages[0].starred_at).toBeNull()
+  const unknown = await axios.post("/api/packages/list", {
+    starred_by: "unknown",
+  })
+  expect(unknown.data.packages).toEqual([])
+})
+
+test("anonymous starred_by alone is rejected like production", async () => {
+  const { unauthenticatedAxios } = await getTestServer()
+  for (const method of ["get", "post"] as const) {
+    try {
+      await unauthenticatedAxios[method](
+        "/api/packages/list",
+        method === "get"
+          ? { params: { starred_by: "testuser" } }
+          : { starred_by: "testuser" },
+      )
+      throw new Error("Expected the request to fail")
+    } catch (error: any) {
+      expect(error.status).toBe(400)
+    }
+  }
+})

--- a/fake-snippets-api/lib/db/schema.ts
+++ b/fake-snippets-api/lib/db/schema.ts
@@ -246,6 +246,7 @@ export const accountPackageSchema = z.object({
   account_id: z.string(),
   package_id: z.string(),
   is_starred: z.boolean(),
+  starred_at: z.string().nullable().optional(),
   created_at: z.string(),
   updated_at: z.string(),
 })

--- a/fake-snippets-api/routes/api/packages/add_star.ts
+++ b/fake-snippets-api/routes/api/packages/add_star.ts
@@ -64,6 +64,7 @@ export default withRouteSpec({
     // If record exists but is_starred is false, update to is_starred=true
     existing.is_starred = true
     existing.updated_at = new Date().toISOString()
+    existing.starred_at = existing.updated_at
   } else {
     // Add star by creating a new account_package record
     const newTimestamp = new Date().toISOString()
@@ -72,6 +73,7 @@ export default withRouteSpec({
       account_id: ctx.auth.account_id,
       package_id: packageId,
       is_starred: true,
+      starred_at: newTimestamp,
       created_at: newTimestamp,
       updated_at: newTimestamp,
     }

--- a/fake-snippets-api/routes/api/packages/list.ts
+++ b/fake-snippets-api/routes/api/packages/list.ts
@@ -12,6 +12,7 @@ export default withRouteSpec({
     is_writable: z.boolean().optional(),
     owner_org_id: z.string().optional(),
     name: z.string().optional(),
+    starred_by: z.string().optional(),
     limit: z.number().int().min(1).optional(),
   }),
   jsonResponse: z.object({
@@ -36,6 +37,7 @@ export default withRouteSpec({
     is_writable,
     owner_org_id,
     limit,
+    starred_by,
   } = req.commonParams
 
   const auth = "auth" in ctx && ctx.auth ? ctx.auth : null
@@ -92,20 +94,33 @@ export default withRouteSpec({
   if (owner_org_id) {
     packages = packages.filter((p) => p.owner_org_id === owner_org_id)
   }
-  if (limit) {
-    packages = packages.slice(0, limit)
-  }
   if (is_writable && auth) {
     packages = packages.filter(canManagePackage)
   }
 
-  // Get star timestamps for authenticated user
+  // Match production: starred_by selects packages, not whose metadata is returned.
+  if (starred_by) {
+    const account = ctx.db.accounts.find(
+      (account) => account.github_username === starred_by.toLowerCase(),
+    )
+    const starredPackageIds = new Set(
+      ctx.db.accountPackages
+        .filter((ap) => ap.account_id === account?.account_id && ap.is_starred)
+        .map((ap) => ap.package_id),
+    )
+    packages = packages.filter((pkg) => starredPackageIds.has(pkg.package_id))
+  }
+  if (limit) {
+    packages = packages.slice(0, limit)
+  }
+
+  // Production returns the viewer's timestamp, including a retained unstar timestamp.
   const starTimestamps = new Map<string, string>()
   if (auth) {
     ctx.db.accountPackages
-      .filter((ap) => ap.account_id === auth.account_id && ap.is_starred)
+      .filter((ap) => ap.account_id === auth.account_id)
       .forEach((ap) => {
-        starTimestamps.set(ap.package_id, ap.updated_at)
+        if (ap.starred_at) starTimestamps.set(ap.package_id, ap.starred_at)
       })
   }
 


### PR DESCRIPTION
The fake `/packages/list` endpoint ignores `starred_by` and derives `starred_at` from relationship updates. Match the production star-list contract: filter by the requested GitHub username before applying `limit`, keep the existing 400 response for anonymous requests with only `starred_by`, and return the authenticated viewer's dedicated `starred_at` independently of the filter target.

Add optional relationship `starred_at` storage and populate it on star/re-star. Preserve it after unstar, as production does. Regression tests cover cross-user timestamps, anonymous requests, mixed-case and unknown usernames, filter-before-limit, and unstar/re-star behavior.

Based independently on main; this replaces the fake API star-list portion proposed in #4874. Existing unrelated list differences (permissions, visibility, UUID validation, and other filters) are outside this PR.

Production references:
- https://github.com/tscircuit/api.tscircuit.com/blob/main/routes/packages/list.ts
- https://github.com/tscircuit/api.tscircuit.com/blob/main/lib/package/get-packages-query.ts
- https://github.com/tscircuit/api.tscircuit.com/blob/main/routes/packages/add_star.ts

Validation:
- GitHub Actions at 9d3002ff: Bun tests, type-check, and format-check all passed.
- Local `tsc --noEmit`, Biome formatting, and `git diff --check` passed.
- Local API execution was blocked by dependency bundling/native-library restrictions; Linux CI passed the tests. No local dependency workarounds are included.