### PR TITLE
fix: search AI descriptions and org handles on Latest and Trending

### DIFF
--- a/src/pages/latest.tsx
+++ b/src/pages/latest.tsx
@@ -50,7 +50,9 @@ const LatestPage: React.FC = () => {
       const searchableFields = [
         pkg.unscoped_name.toLowerCase(),
         pkg.owner_github_username?.toLowerCase() ?? "",
+        pkg.org_owner_tscircuit_handle?.toLowerCase() ?? "",
         (pkg.description || "").toLowerCase(),
+        (pkg.ai_description || "").toLowerCase(),
       ]
 
       return searchableFields.some((field) => {

--- a/src/pages/trending.tsx
+++ b/src/pages/trending.tsx
@@ -76,7 +76,9 @@ const TrendingPage: React.FC = () => {
       const searchableFields = [
         pkg.unscoped_name?.toLowerCase() || "",
         pkg.owner_github_username?.toLowerCase() || "",
+        pkg.org_owner_tscircuit_handle?.toLowerCase() || "",
         pkg.description?.toLowerCase() || "",
+        pkg.ai_description?.toLowerCase() || "",
       ].filter(Boolean)
 
       const queryWords = query.split(/\s+/).filter((word) => word.length > 0)


### PR DESCRIPTION
The Latest and Trending pages filter their loaded packages by name, GitHub owner, and manual description. This hides otherwise matching packages when the query appears only in an AI-generated description, or when users search for an organization handle and the package has no GitHub owner username.

Add `ai_description` and `org_owner_tscircuit_handle` as searchable fields on both pages. For example, searching for text found only in a package's AI description now keeps that package in the results, and searching an organization handle works even when `owner_github_username` is null. Both description fields are searched independently, so AI text is searchable even when a manual description exists. The added fields use the existing case-insensitive matching and safely handle null values.

Validation:
- Formatting checks passed for both changed files.
- `git diff --check` passed.
- `bun run typecheck` could not pass because of an unrelated missing `circuit-json-to-altium` module in `src/lib/download-fns/download-altium-files.ts`.
