### PR TITLE
fix: load the corrected GLB exporter for 3D exports

### DIFF
--- a/src/lib/utils/load-internal-dynamic-modules.ts
+++ b/src/lib/utils/load-internal-dynamic-modules.ts
@@ -101,7 +101,7 @@ const loadCircuitJsonConverter = <T>(packageName: string): Promise<T> => {
 const ensureCircuitJsonToGltfLoaded =
   async (): Promise<CircuitJsonToGltfModule> => {
     return loadCircuitJsonConverter<CircuitJsonToGltfModule>(
-      "circuit-json-to-gltf",
+      "circuit-json-to-gltf@0.0.124",
     )
   }
 


### PR DESCRIPTION
Load `circuit-json-to-gltf@0.0.124` through the shared dynamic module loader, selecting the release containing the corrected silkscreen font for GLB, glTF, and 3D PNG export paths. Keep the existing unversioned module registration key.

The lowercase `v` in `74LVC1G08GW v1.0` appeared raised in 3D snapshots because the exporter embedded a stale font. The root fix is merged in https://github.com/tscircuit/circuit-json-to-gltf/pull/196 and published as `circuit-json-to-gltf@0.0.124`; it includes a pixel regression and reviewed snapshots.

Validation: Bundled the modified loader with `@tscircuit/internal-dynamic-import@0.0.15` and exercised it in headless Chrome using real CDN imports. Exported the `74LVC1G08GW v1.0` label circuit and verified GLB magic and a 10,160-byte output. Formatting and `git diff --check` passed. The full website suite was not run.