### PR TITLE
Refresh profile stars when star and unstar requests complete

### DIFF
--- a/playwright-tests/profile-stars-sync.spec.ts
+++ b/playwright-tests/profile-stars-sync.spec.ts
@@ -1,0 +1,73 @@
+import { expect, test, type Route } from "@playwright/test"
+
+for (const initiallyStarred of [false, true]) {
+  test(`profile updates when ${initiallyStarred ? "removing" : "adding"} a star finishes after navigation`, async ({
+    page,
+  }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem(
+        "session_store",
+        JSON.stringify({
+          state: {
+            session: {
+              token: "profile-stars-test",
+              account_id: "account-1234",
+              session_id: "session-1234",
+              github_username: "testuser",
+              tscircuit_handle: "testuser",
+            },
+          },
+          version: 0,
+        }),
+      )
+    })
+
+    let isStarred = initiallyStarred
+    let pendingStar: Route | undefined
+    await page.route("**/packages/get?**", async (route) => {
+      const response = await route.fetch()
+      const data = await response.json()
+      data.package.is_starred = isStarred
+      await route.fulfill({ json: data })
+    })
+    await page.route("**/packages/list", async (route) => {
+      if (!route.request().postDataJSON()?.starred_by) {
+        await route.continue()
+        return
+      }
+      const response = await page.request.get(
+        "http://127.0.0.1:5177/api/packages/get?name=testuser/my-test-board",
+      )
+      const { package: pkg } = await response.json()
+      await route.fulfill({
+        json: { ok: true, packages: isStarred ? [pkg] : [] },
+      })
+    })
+    await page.route(
+      `**/packages/${initiallyStarred ? "remove_star" : "add_star"}`,
+      (route) => {
+        pendingStar = route
+      },
+    )
+
+    await page.goto("http://127.0.0.1:5177/testuser/my-test-board#files")
+    await page
+      .getByRole("button", { name: initiallyStarred ? /^Starred/ : /^Star\b/ })
+      .click()
+    await expect.poll(() => Boolean(pendingStar)).toBe(true)
+    await page.getByRole("link", { name: "My Profile", exact: true }).click()
+    await page.getByRole("tab", { name: "Starred Packages" }).click()
+
+    const packageLink = page.locator('a[href="/testuser/my-test-board"]')
+    await expect(packageLink).toHaveCount(initiallyStarred ? 1 : 0)
+    if (!initiallyStarred) {
+      await expect(
+        page.getByText("No starred packages", { exact: true }),
+      ).toBeVisible()
+    }
+
+    isStarred = !initiallyStarred
+    await pendingStar!.fulfill({ json: { ok: true } })
+    await expect(packageLink).toHaveCount(initiallyStarred ? 0 : 1)
+  })
+}

--- a/src/hooks/use-package-stars.ts
+++ b/src/hooks/use-package-stars.ts
@@ -79,6 +79,7 @@ export const usePackageStarMutation = (query: PackageStarQuery) => {
           )
         }
       },
+      onSuccess: () => queryClient.invalidateQueries(["starredPackages"]),
     },
   )
 
@@ -116,6 +117,7 @@ export const usePackageStarMutation = (query: PackageStarQuery) => {
           )
         }
       },
+      onSuccess: () => queryClient.invalidateQueries(["starredPackages"]),
     },
   )
 


### PR DESCRIPTION
Returning to a profile before a star or unstar request finishes can leave **Starred Packages** showing the old list. The mutation updates the package cache, but the profile query is never refreshed when the request succeeds.

Invalidate `starredPackages` after both successful mutations. This uses the existing React Query behavior and adds just two production lines, with no new dependencies or changes to optimistic updates and error rollback.

The regression tests hold each mutation open, navigate to the profile, verify the previous list, then complete the request and verify the list updates without reloading. Both tests fail on the base commit and pass with this change.

 ## Before:
https://github.com/user-attachments/assets/e1fa0da3-e378-48d3-8a85-1f238721d947

## After
https://github.com/user-attachments/assets/173db540-95df-445a-b2d1-dd00185f387c



Validation:
- Profile star/unstar regression tests: 2 passed.
- `bun test`: 341 passed, 5 skipped.
- `bun run lint`: passed.
- `NODE_OPTIONS=--max-old-space-size=8192 bun run typecheck`: passed; the default Node heap was insufficient locally.

Remaining investigation: this fixes the reproduced frontend race, but does not establish the full cause of the original report. The public registry lookup for `gokul/acoustic-guitar-tuner` returned `star_count: 1`, while `/packages/list` with `owner_tscircuit_handle=gokul` and `starred_by=GokulPandi-M` returned an empty list (also with the lowercase GitHub username). These were unauthenticated, read-only requests. The authenticated production response still needs checking before treating the reported issue as fully resolved.
